### PR TITLE
Add management approval gate to PRC referral workflow

### DIFF
--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -29,7 +29,7 @@ module Corvid
 
     aasm column: :status, whiny_transitions: false do
       state :draft, initial: true
-      state :submitted, :eligibility_review, :alternate_resource_review
+      state :submitted, :eligibility_review, :management_approval, :alternate_resource_review
       state :priority_assignment, :committee_review, :exception_review
       state :authorized, :denied, :deferred, :cancelled
 
@@ -41,8 +41,14 @@ module Corvid
         transitions from: :submitted, to: :eligibility_review
       end
 
-      event :verify_eligibility do
-        transitions from: :eligibility_review, to: :alternate_resource_review
+      event :request_management_approval do
+        transitions from: :eligibility_review, to: :management_approval,
+                    guard: :checklist_items_except_approval_complete?
+      end
+
+      event :approve_management do
+        transitions from: :management_approval, to: :alternate_resource_review,
+                    after: :record_management_approval
       end
 
       event :verify_alternate_resources do
@@ -90,7 +96,25 @@ module Corvid
       Corvid.adapter.get_site_params&.dig(:committee_threshold)&.to_d || 50_000
     end
 
+    # Transient attribute for the manager who approved. Set before
+    # firing approve_management, read by the after callback.
+    attr_accessor :pending_approval_by
+
+    def checklist_items_except_approval_complete?
+      eligibility_checklist&.items_except_approval_complete? || false
+    end
+
     private
+
+    def record_management_approval
+      return unless eligibility_checklist
+
+      eligibility_checklist.verify_item!(
+        :management_approved,
+        source: "management_review",
+        by: @pending_approval_by
+      )
+    end
 
     def sync_status_to_ehr
       return unless referral_identifier.present?

--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -111,7 +111,6 @@ module Corvid
 
       eligibility_checklist.verify_item!(
         :management_approved,
-        source: "management_review",
         by: @pending_approval_by
       )
     end

--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -98,7 +98,16 @@ module Corvid
 
     # Transient attribute for the manager who approved. Set before
     # firing approve_management, read by the after callback.
-    attr_accessor :pending_approval_by
+    attr_writer :pending_approval_by
+
+    def pending_approval_by
+      @pending_approval_by
+    end
+
+    def pending_approval_by!
+      @pending_approval_by or raise ArgumentError,
+        "pending_approval_by must be set before approve_management!"
+    end
 
     def checklist_items_except_approval_complete?
       eligibility_checklist&.items_except_approval_complete? || false
@@ -111,7 +120,7 @@ module Corvid
 
       eligibility_checklist.verify_item!(
         :management_approved,
-        by: @pending_approval_by
+        by: pending_approval_by!
       )
     end
 

--- a/db/migrate/20260415000002_add_management_approval_to_prc_referral_statuses.rb
+++ b/db/migrate/20260415000002_add_management_approval_to_prc_referral_statuses.rb
@@ -16,6 +16,13 @@ class AddManagementApprovalToPrcReferralStatuses < ActiveRecord::Migration[8.1]
 
   def down
     old_statuses = PRC_STATUSES - %w[management_approval]
+    # Move any rows in management_approval back to eligibility_review
+    # so the old CHECK constraint can be applied safely.
+    execute <<~SQL
+      UPDATE corvid_prc_referrals
+      SET status = 'eligibility_review'
+      WHERE status = 'management_approval'
+    SQL
     remove_check_constraint :corvid_prc_referrals, name: "corvid_prc_referrals_status_check"
     add_check_constraint :corvid_prc_referrals,
                          "status IN (#{old_statuses.map { |s| "'#{s}'" }.join(',')})",

--- a/db/migrate/20260415000002_add_management_approval_to_prc_referral_statuses.rb
+++ b/db/migrate/20260415000002_add_management_approval_to_prc_referral_statuses.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddManagementApprovalToPrcReferralStatuses < ActiveRecord::Migration[8.1]
+  PRC_STATUSES = %w[
+    draft submitted eligibility_review management_approval alternate_resource_review
+    priority_assignment committee_review exception_review
+    authorized denied deferred cancelled
+  ].freeze
+
+  def up
+    remove_check_constraint :corvid_prc_referrals, name: "corvid_prc_referrals_status_check"
+    add_check_constraint :corvid_prc_referrals,
+                         "status IN (#{PRC_STATUSES.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_prc_referrals_status_check"
+  end
+
+  def down
+    old_statuses = PRC_STATUSES - %w[management_approval]
+    remove_check_constraint :corvid_prc_referrals, name: "corvid_prc_referrals_status_check"
+    add_check_constraint :corvid_prc_referrals,
+                         "status IN (#{old_statuses.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_prc_referrals_status_check"
+  end
+end

--- a/features/prc/management_approval_gate.feature
+++ b/features/prc/management_approval_gate.feature
@@ -1,0 +1,42 @@
+Feature: PRC management approval gate
+  As a tribal health officer
+  I need every PRC referral to require management approval before advancing
+  So that the 53/60 "no management approval" audit finding is eliminated
+
+  Background:
+    Given a tenant "tnt_yakama" with facility "fac_toppenish"
+    And a patient "pt_001" with a PRC case
+    And a PRC referral "rf_001" for that case
+
+  Scenario: Referral cannot skip management approval
+    Given the referral is in "eligibility_review" status
+    And an eligibility checklist with all non-approval items complete
+    When I try to advance directly to alternate resource review
+    Then the referral should remain in "eligibility_review" status
+
+  Scenario: Referral advances to management approval when 6/7 items complete
+    Given the referral is in "eligibility_review" status
+    And an eligibility checklist with all non-approval items complete
+    When I request management approval
+    Then the referral should be in "management_approval" status
+
+  Scenario: Referral cannot request management approval with incomplete checklist
+    Given the referral is in "eligibility_review" status
+    And an eligibility checklist with only 3 items complete
+    When I request management approval
+    Then the referral should remain in "eligibility_review" status
+
+  Scenario: Manager approves and referral advances
+    Given the referral is in "management_approval" status
+    And an eligibility checklist with all non-approval items complete
+    When manager "pr_mgr_cookie" approves the referral
+    Then the referral should be in "alternate_resource_review" status
+    And the eligibility checklist should have management approval by "pr_mgr_cookie"
+
+  Scenario: Full workflow from eligibility review through management approval
+    Given the referral is in "eligibility_review" status
+    And an eligibility checklist with all non-approval items complete
+    When I request management approval
+    And manager "pr_mgr_cookie" approves the referral
+    Then the referral should be in "alternate_resource_review" status
+    And the eligibility checklist should be complete

--- a/features/step_definitions/management_approval_steps.rb
+++ b/features/step_definitions/management_approval_steps.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+Given("the referral is in {string} status") do |status|
+  # Advance through states to reach the desired status
+  case status
+  when "eligibility_review"
+    @referral.submit!
+    @referral.begin_eligibility_review!
+  when "management_approval"
+    @referral.submit!
+    @referral.begin_eligibility_review!
+    # Need checklist with 6/7 items to advance
+    @checklist ||= Corvid::EligibilityChecklist.create!(
+      prc_referral: @referral,
+      facility_identifier: @facility,
+      application_complete: true,
+      identity_verified: true,
+      insurance_verified: true,
+      residency_verified: true,
+      enrollment_verified: true,
+      clinical_necessity_documented: true,
+      management_approved: false
+    )
+    @referral.request_management_approval!
+  end
+  assert_equal status, @referral.status
+end
+
+Given("an eligibility checklist with all non-approval items complete") do
+  @checklist = Corvid::EligibilityChecklist.find_or_create_by!(prc_referral: @referral) do |c|
+    c.facility_identifier = @facility
+  end
+  @checklist.update!(
+    application_complete: true,
+    identity_verified: true,
+    insurance_verified: true,
+    residency_verified: true,
+    enrollment_verified: true,
+    clinical_necessity_documented: true,
+    management_approved: false
+  )
+end
+
+Given("an eligibility checklist with only {int} items complete") do |count|
+  @checklist = Corvid::EligibilityChecklist.create!(
+    prc_referral: @referral,
+    facility_identifier: @facility,
+    application_complete: count >= 1,
+    identity_verified: count >= 2,
+    insurance_verified: count >= 3,
+    residency_verified: false,
+    enrollment_verified: false,
+    clinical_necessity_documented: false,
+    management_approved: false
+  )
+end
+
+When("I try to advance directly to alternate resource review") do
+  # verify_eligibility event no longer exists — confirm there's no direct path
+  refute @referral.respond_to?(:may_verify_eligibility?),
+         "Expected verify_eligibility event to not exist"
+end
+
+When("I request management approval") do
+  @referral.request_management_approval! if @referral.may_request_management_approval?
+end
+
+When("manager {string} approves the referral") do |manager_id|
+  @referral.pending_approval_by = manager_id
+  @referral.approve_management!
+end
+
+Then("the referral should be in {string} status") do |status|
+  assert_equal status, @referral.status
+end
+
+Then("the referral should remain in {string} status") do |status|
+  assert_equal status, @referral.status
+end
+
+Then("the eligibility checklist should have management approval by {string}") do |manager_id|
+  @checklist.reload
+  assert @checklist.management_approved
+  assert_equal manager_id, @checklist.management_approved_by
+end
+
+Then("the eligibility checklist should be complete") do
+  @checklist.reload
+  assert @checklist.complete?, "Expected checklist to be complete but missing: #{@checklist.missing_items}"
+end

--- a/features/step_definitions/management_approval_steps.rb
+++ b/features/step_definitions/management_approval_steps.rb
@@ -56,9 +56,16 @@ Given("an eligibility checklist with only {int} items complete") do |count|
 end
 
 When("I try to advance directly to alternate resource review") do
-  # verify_eligibility event no longer exists — confirm there's no direct path
-  refute @referral.respond_to?(:may_verify_eligibility?),
-         "Expected verify_eligibility event to not exist"
+  # Assert no AASM event from eligibility_review leads directly to
+  # alternate_resource_review, regardless of event name.
+  direct_events = @referral.class.aasm.events.select do |event|
+    event.transitions.any? do |t|
+      Array(t.from).include?(:eligibility_review) &&
+        t.to == :alternate_resource_review
+    end
+  end
+  assert_empty direct_events.map(&:name),
+    "Expected no direct path from eligibility_review to alternate_resource_review"
 end
 
 When("I request management approval") do

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -205,7 +205,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- New `management_approval` state in PrcReferral AASM between `eligibility_review` and `alternate_resource_review`
- Guard: 6/7 checklist items must be complete before management can be asked to approve
- Removes direct `verify_eligibility` path — cannot skip management approval
- After callback records approver identity and timestamp on EligibilityChecklist
- Updated CHECK constraint via migration

Closes #2

## Test plan

- [x] BDD: `bundle exec cucumber features/prc/management_approval_gate.feature` — 5 scenarios, 38 steps passing
- [x] Full suite: 39 unit tests + 13 BDD scenarios (103 steps), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)