### PR TITLE
Add enrollment, identity, and residency verification to adapter interface

### DIFF
--- a/features/prc/enrollment_verification.feature
+++ b/features/prc/enrollment_verification.feature
@@ -1,0 +1,36 @@
+Feature: Enrollment verification via adapter
+  As a PRC eligibility reviewer
+  I need the system to verify tribal enrollment, identity, and residency via the adapter
+  So that eligibility documentation is auto-populated instead of manually collected
+
+  Background:
+    Given a tenant "tnt_yakama" with facility "fac_toppenish"
+
+  Scenario: Verify tribal enrollment for an enrolled patient
+    Given a patient "pt_enrolled_001" registered in the adapter as enrolled
+    When I verify tribal enrollment for "pt_enrolled_001"
+    Then the enrollment result should show enrolled as true
+    And the enrollment result should include a membership number
+    And the enrollment result should include a tribe name
+
+  Scenario: Verify tribal enrollment for a non-enrolled patient
+    Given a patient "pt_nonenrolled_001" registered in the adapter as not enrolled
+    When I verify tribal enrollment for "pt_nonenrolled_001"
+    Then the enrollment result should show enrolled as false
+
+  Scenario: Verify identity documents for a patient with full records
+    Given a patient "pt_enrolled_001" registered in the adapter as enrolled
+    When I verify identity documents for "pt_enrolled_001"
+    Then the identity result should show ssn_present as true
+    And the identity result should show dob_present as true
+
+  Scenario: Verify residency for an on-reservation patient
+    Given a patient "pt_enrolled_001" registered in the adapter with an on-reservation address
+    When I verify residency for "pt_enrolled_001"
+    Then the residency result should show on_reservation as true
+    And the residency result should include an address
+
+  Scenario: Verify residency for an off-reservation patient
+    Given a patient "pt_off_res_001" registered in the adapter with an off-reservation address
+    When I verify residency for "pt_off_res_001"
+    Then the residency result should show on_reservation as false

--- a/features/step_definitions/enrollment_verification_steps.rb
+++ b/features/step_definitions/enrollment_verification_steps.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+Given("a patient {string} registered in the adapter as enrolled") do |patient_id|
+  Corvid.adapter.add_patient(patient_id,
+    display_name: "TEST,ENROLLED MEMBER",
+    dob: Date.new(1985, 6, 15),
+    sex: "F",
+    ssn_last4: "1234"
+  )
+  Corvid.adapter.add_enrollment(patient_id,
+    enrolled: true,
+    membership_number: "YN-12345",
+    tribe_name: "Test Tribe",
+    blood_quantum: "1/4",
+    member_status: "enrolled"
+  )
+  Corvid.adapter.add_residency(patient_id,
+    on_reservation: true,
+    address: "123 Main St, Toppenish, WA 98948",
+    service_area: "yakama"
+  )
+end
+
+Given("a patient {string} registered in the adapter as not enrolled") do |patient_id|
+  Corvid.adapter.add_patient(patient_id,
+    display_name: "TEST,NON ENROLLED",
+    dob: Date.new(1990, 3, 1),
+    sex: "M",
+    ssn_last4: nil
+  )
+  Corvid.adapter.add_enrollment(patient_id,
+    enrolled: false,
+    membership_number: nil,
+    tribe_name: nil,
+    member_status: "denied"
+  )
+end
+
+Given("a patient {string} registered in the adapter with an on-reservation address") do |patient_id|
+  # Patient data may already exist from a previous step; just ensure residency is set
+  Corvid.adapter.add_residency(patient_id,
+    on_reservation: true,
+    address: "456 Elm St, Toppenish, WA 98948",
+    service_area: "yakama"
+  )
+end
+
+Given("a patient {string} registered in the adapter with an off-reservation address") do |patient_id|
+  Corvid.adapter.add_patient(patient_id,
+    display_name: "TEST,OFF RESERVATION",
+    dob: Date.new(1988, 11, 20),
+    sex: "F",
+    ssn_last4: "5678"
+  )
+  Corvid.adapter.add_residency(patient_id,
+    on_reservation: false,
+    address: "789 Oak Ave, Seattle, WA 98101",
+    service_area: "seattle"
+  )
+end
+
+When("I verify tribal enrollment for {string}") do |patient_id|
+  @enrollment_result = Corvid.adapter.verify_tribal_enrollment(patient_id)
+end
+
+When("I verify identity documents for {string}") do |patient_id|
+  @identity_result = Corvid.adapter.verify_identity_documents(patient_id)
+end
+
+When("I verify residency for {string}") do |patient_id|
+  @residency_result = Corvid.adapter.verify_residency(patient_id)
+end
+
+Then("the enrollment result should show enrolled as true") do
+  assert @enrollment_result[:enrolled], "Expected enrolled to be true"
+end
+
+Then("the enrollment result should show enrolled as false") do
+  refute @enrollment_result[:enrolled], "Expected enrolled to be false"
+end
+
+Then("the enrollment result should include a membership number") do
+  refute_nil @enrollment_result[:membership_number]
+end
+
+Then("the enrollment result should include a tribe name") do
+  refute_nil @enrollment_result[:tribe_name]
+end
+
+Then("the identity result should show ssn_present as true") do
+  assert @identity_result[:ssn_present], "Expected ssn_present to be true"
+end
+
+Then("the identity result should show dob_present as true") do
+  assert @identity_result[:dob_present], "Expected dob_present to be true"
+end
+
+Then("the residency result should show on_reservation as true") do
+  assert @residency_result[:on_reservation], "Expected on_reservation to be true"
+end
+
+Then("the residency result should show on_reservation as false") do
+  refute @residency_result[:on_reservation], "Expected on_reservation to be false"
+end
+
+Then("the residency result should include an address") do
+  refute_nil @residency_result[:address]
+end

--- a/lib/corvid/adapters/base.rb
+++ b/lib/corvid/adapters/base.rb
@@ -157,6 +157,28 @@ module Corvid
       def verify_eligibility(patient_identifier, resource_type)
         raise NotImplementedError, "#{self.class}#verify_eligibility not implemented"
       end
+
+      # ----------------------------------------------------------------------
+      # Enrollment verification (for PRC eligibility checklist)
+      # ----------------------------------------------------------------------
+
+      # Returns { enrolled: bool, membership_number: str|nil,
+      #           tribe_name: str|nil, verified_at: datetime }
+      def verify_tribal_enrollment(patient_identifier)
+        raise NotImplementedError, "#{self.class}#verify_tribal_enrollment not implemented"
+      end
+
+      # Returns { ssn_present: bool, dob_present: bool,
+      #           birthplace_present: bool, verified_at: datetime }
+      def verify_identity_documents(patient_identifier)
+        raise NotImplementedError, "#{self.class}#verify_identity_documents not implemented"
+      end
+
+      # Returns { on_reservation: bool, address: str|nil,
+      #           service_area: str|nil, verified_at: datetime }
+      def verify_residency(patient_identifier)
+        raise NotImplementedError, "#{self.class}#verify_residency not implemented"
+      end
     end
   end
 end

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -227,6 +227,48 @@ module Corvid
       end
 
       # ----------------------------------------------------------------------
+      # Enrollment verification
+      # ----------------------------------------------------------------------
+
+      def verify_tribal_enrollment(patient_identifier)
+        enrollment = @enrollments[patient_identifier.to_s]
+        return { enrolled: false, membership_number: nil, tribe_name: nil, verified_at: Time.current } unless enrollment
+
+        {
+          enrolled: enrollment[:enrolled],
+          membership_number: enrollment[:membership_number],
+          tribe_name: enrollment[:tribe_name],
+          blood_quantum: enrollment[:blood_quantum],
+          member_status: enrollment[:member_status],
+          verified_at: Time.current
+        }
+      end
+
+      def verify_identity_documents(patient_identifier)
+        patient = @patients[patient_identifier.to_s]
+        return { ssn_present: false, dob_present: false, birthplace_present: false, verified_at: Time.current } unless patient
+
+        {
+          ssn_present: patient[:ssn_last4].present?,
+          dob_present: patient[:dob].present?,
+          birthplace_present: patient[:birthplace].present?,
+          verified_at: Time.current
+        }
+      end
+
+      def verify_residency(patient_identifier)
+        residency = @residencies[patient_identifier.to_s]
+        return { on_reservation: false, address: nil, service_area: nil, verified_at: Time.current } unless residency
+
+        {
+          on_reservation: residency[:on_reservation],
+          address: residency[:address],
+          service_area: residency[:service_area],
+          verified_at: Time.current
+        }
+      end
+
+      # ----------------------------------------------------------------------
       # Test helpers
       # ----------------------------------------------------------------------
 
@@ -246,12 +288,22 @@ module Corvid
         @care_teams[patient_identifier.to_s] = members
       end
 
+      def add_enrollment(patient_identifier, attrs)
+        @enrollments[patient_identifier.to_s] = attrs
+      end
+
+      def add_residency(patient_identifier, attrs)
+        @residencies[patient_identifier.to_s] = attrs
+      end
+
       def reset!
         @patients = {}
         @practitioners = {}
         @referrals = {}
         @care_teams = {}
         @text_store = {}
+        @enrollments = {}
+        @residencies = {}
       end
 
       private


### PR DESCRIPTION
## Summary

- Extends `Corvid::Adapters::Base` with `verify_tribal_enrollment`, `verify_identity_documents`, `verify_residency`
- `MockAdapter` implements all 3 with test helpers (`add_enrollment`, `add_residency`)
- BDD feature with 5 scenarios covering enrolled/non-enrolled, identity docs, on/off reservation

Closes #3

## Test plan

- [x] BDD: `bundle exec cucumber features/prc/enrollment_verification.feature` — 5 scenarios, 24 steps passing
- [x] Full suite: 42 unit tests + 18 BDD scenarios (127 steps), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)