### PR TITLE
Add PrcAuditReportService for compliance summary and sample audit

### DIFF
--- a/app/services/corvid/prc_audit_report_service.rb
+++ b/app/services/corvid/prc_audit_report_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Generates PRC audit compliance reports matching the FY23 finding
+  # categories. Operates on EligibilityChecklist records within tenant scope.
+  class PrcAuditReportService
+    class << self
+      # Aggregate compliance stats per checklist item.
+      # Returns { total_referrals: N, item: { complete: N, total: N, percentage: F }, ... }
+      def compliance_summary(tenant:, date_range: nil)
+        checklists = scoped_checklists(tenant, date_range)
+        total = checklists.count
+
+        summary = { total_referrals: total }
+        Corvid::EligibilityChecklist::ITEMS.each do |item|
+          complete = checklists.where(item => true).count
+          summary[item] = {
+            complete: complete,
+            total: total,
+            percentage: total > 0 ? (complete.to_f / total * 100).round(1) : 0.0
+          }
+        end
+        summary
+      end
+
+      # Returns referrals with any missing checklist items.
+      # Each entry: { referral_identifier: str, missing_items: [sym] }
+      def deficiency_report(tenant:, date_range: nil)
+        checklists = scoped_checklists(tenant, date_range)
+          .includes(:prc_referral)
+
+        checklists.filter_map do |checklist|
+          missing = checklist.missing_items
+          next if missing.empty?
+
+          {
+            referral_identifier: checklist.prc_referral.referral_identifier,
+            missing_items: missing,
+            compliance_percentage: checklist.compliance_percentage
+          }
+        end
+      end
+
+      # Simulates an auditor pulling a random sample and scoring each
+      # against the 7 documentation categories.
+      # Returns { item: { passed: N, sampled: N, percentage: F }, ... }
+      def sample_audit(tenant:, sample_size: 60, date_range: nil)
+        checklists = scoped_checklists(tenant, date_range).order("RANDOM()").limit(sample_size)
+        sampled = checklists.to_a
+        count = sampled.size
+
+        result = {}
+        Corvid::EligibilityChecklist::ITEMS.each do |item|
+          passed = sampled.count { |c| c.send(item) }
+          result[item] = {
+            passed: passed,
+            sampled: count,
+            percentage: count > 0 ? (passed.to_f / count * 100).round(1) : 0.0
+          }
+        end
+        result
+      end
+
+      private
+
+      def scoped_checklists(tenant, date_range)
+        Corvid::TenantContext.with_tenant(tenant) do
+          scope = Corvid::EligibilityChecklist.all
+          if date_range
+            scope = scope.where(created_at: date_range)
+          end
+          return scope
+        end
+      end
+    end
+  end
+end

--- a/app/services/corvid/prc_audit_report_service.rb
+++ b/app/services/corvid/prc_audit_report_service.rb
@@ -45,7 +45,7 @@ module Corvid
       # against the 7 documentation categories.
       # Returns { item: { passed: N, sampled: N, percentage: F }, ... }
       def sample_audit(tenant:, sample_size: 60, date_range: nil)
-        checklists = scoped_checklists(tenant, date_range).order("RANDOM()").limit(sample_size)
+        checklists = scoped_checklists(tenant, date_range).order(Arel.sql("RANDOM()")).limit(sample_size)
         sampled = checklists.to_a
         count = sampled.size
 

--- a/features/prc/audit_compliance_report.feature
+++ b/features/prc/audit_compliance_report.feature
@@ -1,0 +1,36 @@
+Feature: PRC audit compliance report
+  As a tribal health officer
+  I need an audit compliance report showing documentation completeness
+  So that I can demonstrate to auditors that Finding #2023-005 is resolved
+
+  Background:
+    Given a tenant "tnt_yakama" with facility "fac_toppenish"
+
+  Scenario: 100% compliance when all checklists are complete
+    Given 10 PRC referrals with complete eligibility checklists
+    When I generate the compliance summary
+    Then every audit category should show 100% compliance
+    And the total referrals should be 10
+
+  Scenario: Deficiency report shows referrals with missing items
+    Given 8 PRC referrals with complete eligibility checklists
+    And 2 PRC referrals missing management approval
+    When I generate the deficiency report
+    Then 2 referrals should appear in the deficiency report
+    And each deficient referral should list "management_approved" as missing
+
+  Scenario: Sample audit of 10 referrals returns per-category pass rates
+    Given 10 PRC referrals with complete eligibility checklists
+    When I run a sample audit of 10 referrals
+    Then the sample audit should show 10 of 10 with complete applications
+    And the sample audit should show 10 of 10 with identity documentation
+    And the sample audit should show 10 of 10 with insurance verification
+    And the sample audit should show 10 of 10 with residency verification
+    And the sample audit should show 10 of 10 with tribal enrollment
+    And the sample audit should show 10 of 10 with management approval
+
+  Scenario: Sample audit detects deficiencies
+    Given 8 PRC referrals with complete eligibility checklists
+    And 2 PRC referrals missing identity verification
+    When I run a sample audit of 10 referrals
+    Then the sample audit should show 8 of 10 with identity documentation

--- a/features/step_definitions/audit_compliance_report_steps.rb
+++ b/features/step_definitions/audit_compliance_report_steps.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+def create_referral_with_checklist(index, overrides = {})
+  kase = Corvid::Case.create!(
+    patient_identifier: "pt_audit_#{index}",
+    facility_identifier: @facility
+  )
+  referral = Corvid::PrcReferral.create!(
+    case: kase,
+    referral_identifier: "rf_audit_#{index}",
+    facility_identifier: @facility
+  )
+  defaults = {
+    application_complete: true,
+    identity_verified: true,
+    insurance_verified: true,
+    residency_verified: true,
+    enrollment_verified: true,
+    clinical_necessity_documented: true,
+    management_approved: true
+  }
+  Corvid::EligibilityChecklist.create!(
+    prc_referral: referral,
+    facility_identifier: @facility,
+    **defaults.merge(overrides)
+  )
+  referral
+end
+
+Given("{int} PRC referrals with complete eligibility checklists") do |count|
+  @audit_offset ||= 0
+  count.times do |i|
+    create_referral_with_checklist(@audit_offset + i)
+  end
+  @audit_offset += count
+end
+
+Given("{int} PRC referrals missing management approval") do |count|
+  count.times do |i|
+    create_referral_with_checklist(@audit_offset + i, management_approved: false)
+  end
+  @audit_offset += count
+end
+
+Given("{int} PRC referrals missing identity verification") do |count|
+  count.times do |i|
+    create_referral_with_checklist(@audit_offset + i, identity_verified: false)
+  end
+  @audit_offset += count
+end
+
+When("I generate the compliance summary") do
+  @summary = Corvid::PrcAuditReportService.compliance_summary(tenant: @tenant)
+end
+
+When("I generate the deficiency report") do
+  @deficiencies = Corvid::PrcAuditReportService.deficiency_report(tenant: @tenant)
+end
+
+When("I run a sample audit of {int} referrals") do |sample_size|
+  @audit_result = Corvid::PrcAuditReportService.sample_audit(tenant: @tenant, sample_size: sample_size)
+end
+
+Then("every audit category should show 100% compliance") do
+  Corvid::EligibilityChecklist::ITEMS.each do |item|
+    assert_equal 100.0, @summary[item][:percentage],
+      "Expected #{item} to be 100% but was #{@summary[item][:percentage]}%"
+  end
+end
+
+Then("the total referrals should be {int}") do |count|
+  assert_equal count, @summary[:total_referrals]
+end
+
+Then("{int} referrals should appear in the deficiency report") do |count|
+  assert_equal count, @deficiencies.size
+end
+
+Then("each deficient referral should list {string} as missing") do |item|
+  @deficiencies.each do |deficiency|
+    assert_includes deficiency[:missing_items], item.to_sym,
+      "Expected #{item} in missing items for referral #{deficiency[:referral_identifier]}"
+  end
+end
+
+Then("the sample audit should show {int} of {int} with complete applications") do |pass, total|
+  assert_equal pass, @audit_result[:application_complete][:passed]
+  assert_equal total, @audit_result[:application_complete][:sampled]
+end
+
+Then("the sample audit should show {int} of {int} with identity documentation") do |pass, total|
+  assert_equal pass, @audit_result[:identity_verified][:passed]
+  assert_equal total, @audit_result[:identity_verified][:sampled]
+end
+
+Then("the sample audit should show {int} of {int} with insurance verification") do |pass, total|
+  assert_equal pass, @audit_result[:insurance_verified][:passed]
+  assert_equal total, @audit_result[:insurance_verified][:sampled]
+end
+
+Then("the sample audit should show {int} of {int} with residency verification") do |pass, total|
+  assert_equal pass, @audit_result[:residency_verified][:passed]
+  assert_equal total, @audit_result[:residency_verified][:sampled]
+end
+
+Then("the sample audit should show {int} of {int} with tribal enrollment") do |pass, total|
+  assert_equal pass, @audit_result[:enrollment_verified][:passed]
+  assert_equal total, @audit_result[:enrollment_verified][:sampled]
+end
+
+Then("the sample audit should show {int} of {int} with management approval") do |pass, total|
+  assert_equal pass, @audit_result[:management_approved][:passed]
+  assert_equal total, @audit_result[:management_approved][:sampled]
+end


### PR DESCRIPTION
## Summary

- New `Corvid::PrcAuditReportService` with `compliance_summary`, `deficiency_report`, `sample_audit`
- `compliance_summary` returns per-category pass rates matching FY23 audit format
- `deficiency_report` lists referrals with missing items
- `sample_audit` pulls random sample and scores against 7 categories — the "60/60 compliant" moment

Closes #6

## Test plan

- [x] BDD: `bundle exec cucumber features/prc/audit_compliance_report.feature` — 4 scenarios, 25 steps passing
- [x] Full suite: 42 unit tests + 33 BDD scenarios (231 steps), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)