### PR TITLE
Add EDI adapter dashboard scaffold

### DIFF
--- a/app/controllers/corvid/dashboard_controller.rb
+++ b/app/controllers/corvid/dashboard_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Corvid
+  class DashboardController < ActionController::Base
+    layout false
+
+    def show
+      @edi_adapter = Corvid.edi_adapter
+      @edi_adapter_class = @edi_adapter&.class&.name || "Not configured"
+
+      if @edi_adapter
+        request = Lakeraven::Fhir::CoverageEligibilityRequest.new(
+          patient_dfn: "demo-001",
+          coverage_type: "medicaid",
+          payer_id: "DEMO_MEDICAID",
+          subscriber_id: "DEMO-SUB-001",
+          subscriber_first_name: "Demo",
+          subscriber_last_name: "Patient",
+          subscriber_dob: "1985-06-15",
+          provider_npi: "1234567890"
+        )
+        @eligibility_response = @edi_adapter.check_eligibility(request)
+      end
+    end
+  end
+end

--- a/app/views/corvid/dashboard/show.html.erb
+++ b/app/views/corvid/dashboard/show.html.erb
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Corvid Dashboard</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #1a1a1a; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #1a1a1a; padding-bottom: 8px; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; color: #444; }
+    .status { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.85rem; font-weight: 600; }
+    .status-ok { background: #d4edda; color: #155724; }
+    .status-error { background: #f8d7da; color: #721c24; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    td, th { text-align: left; padding: 6px 12px; border-bottom: 1px solid #e0e0e0; }
+    th { color: #666; font-weight: 500; width: 200px; }
+    pre { background: #f5f5f5; padding: 12px; border-radius: 4px; overflow-x: auto; font-size: 0.8rem; }
+  </style>
+</head>
+<body>
+  <h1>Corvid Engine</h1>
+
+  <h2>EDI Adapter</h2>
+  <table>
+    <tr><th>Adapter</th><td><%= @edi_adapter_class %></td></tr>
+    <tr><th>Status</th><td><span class="status <%= @edi_adapter ? 'status-ok' : 'status-error' %>"><%= @edi_adapter ? 'Wired' : 'Not configured' %></span></td></tr>
+  </table>
+
+  <% if @eligibility_response %>
+    <h2>Eligibility Check (Demo)</h2>
+    <table>
+      <tr><th>Patient</th><td><%= @eligibility_response.patient_dfn %></td></tr>
+      <tr><th>Coverage Type</th><td><%= @eligibility_response.coverage_type %></td></tr>
+      <tr><th>Status</th><td><span class="status <%= @eligibility_response.enrolled? ? 'status-ok' : 'status-error' %>"><%= @eligibility_response.status %></span></td></tr>
+      <tr><th>Plan</th><td><%= @eligibility_response.plan_name %></td></tr>
+      <tr><th>Insurer</th><td><%= @eligibility_response.insurer_name %></td></tr>
+      <tr><th>Coverage Period</th><td><%= @eligibility_response.start_date %> to <%= @eligibility_response.end_date %></td></tr>
+      <tr><th>Active Coverage</th><td><span class="status <%= @eligibility_response.active_coverage? ? 'status-ok' : 'status-error' %>"><%= @eligibility_response.active_coverage? %></span></td></tr>
+    </table>
+
+    <h2>FHIR R4 Response</h2>
+    <pre><%= JSON.pretty_generate(JSON.parse(@eligibility_response.to_json)) %></pre>
+  <% end %>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Corvid::Engine.routes.draw do
+  root to: "dashboard#show"
+end


### PR DESCRIPTION
## Summary

- `Corvid::DashboardController#show` wires to `Corvid.edi_adapter` (config slot from 70c0db6)
- Dashboard view displays adapter status and demo eligibility check response
- Engine routes mount dashboard at root

Closes #14

## Test plan

- [ ] Needs test coverage before merge — scaffold only

🤖 Generated with [Claude Code](https://claude.com/claude-code)