### PR TITLE
Fix adapter wiring to use Corvid.configure

### DIFF
--- a/features/step_definitions/enrollment_demo_steps.rb
+++ b/features/step_definitions/enrollment_demo_steps.rb
@@ -5,12 +5,12 @@ require "corvid/adapters/enrollment_demo_adapter"
 Given("the enrollment demo adapter is active") do
   @previous_adapter = Corvid.adapter
   @adapter = Corvid::Adapters::EnrollmentDemoAdapter.new
-  Corvid.instance_variable_set(:@adapter, @adapter)
+  Corvid.configure { |c| c.adapter = @adapter }
 end
 
 After do
   if @previous_adapter
-    Corvid.instance_variable_set(:@adapter, @previous_adapter)
+    Corvid.configure { |c| c.adapter = @previous_adapter }
     @previous_adapter = nil
   end
 end


### PR DESCRIPTION
## Summary

- Fixes enrollment demo steps to use `Corvid.configure { |c| c.adapter = ... }` instead of `Corvid.instance_variable_set(:@adapter, ...)`
- The old pattern bypassed `Corvid.configuration.adapter`, so `EligibilityChecklistService.populate!` and other code paths that read `Corvid.adapter` never saw the demo adapter

Closes #7

## Test plan

- [x] Full suite: 42 unit tests + 28 BDD scenarios (206 steps), all green
- [x] Demo script runs end-to-end (stashed locally, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)