### PR TITLE
Port Task lifecycle from rpms_redux

### DIFF
--- a/app/models/corvid/task.rb
+++ b/app/models/corvid/task.rb
@@ -8,8 +8,8 @@ module Corvid
 
     belongs_to :taskable, polymorphic: true
 
-    enum :status, { pending: "pending", in_progress: "in_progress", completed: "completed", cancelled: "cancelled" }
-    enum :priority, { asap: "asap", urgent: "urgent", routine: "routine" }, prefix: :priority
+    enum :status, { pending: "pending", in_progress: "in_progress", completed: "completed", cancelled: "cancelled", on_hold: "on_hold" }
+    enum :priority, { routine: "routine", urgent: "urgent", asap: "asap", stat: "stat" }, prefix: :priority
 
     validates :description, presence: true
     validate :taskable_in_same_tenant
@@ -18,7 +18,9 @@ module Corvid
     scope :overdue, -> { incomplete.where("due_at < ?", Time.current) }
     scope :unassigned, -> { where(assignee_identifier: nil) }
     scope :for_assignee, ->(identifier) { where(assignee_identifier: identifier) }
+    scope :due_soon, ->(days = 7) { incomplete.where("due_at <= ?", days.days.from_now) }
     scope :milestones, -> { where.not(milestone_key: nil) }
+    scope :required_milestones, -> { milestones.where(required: true) }
 
     before_save :set_completed_at, if: :status_changed_to_completed?
 
@@ -34,15 +36,58 @@ module Corvid
       update!(assignee_identifier: nil)
     end
 
+    # FHIR status mapping
+    FHIR_STATUS_MAP = {
+      "pending" => "requested",
+      "in_progress" => "in-progress",
+      "completed" => "completed",
+      "cancelled" => "cancelled",
+      "on_hold" => "on-hold"
+    }.freeze
+
+    FHIR_STATUS_REVERSE_MAP = FHIR_STATUS_MAP.invert.transform_values { |v| v.tr("-", "_") }.freeze
+
+    def incomplete?
+      !completed? && !cancelled?
+    end
+
     def overdue?
-      !completed? && due_at.present? && due_at < Time.current
+      incomplete? && due_at.present? && due_at < Time.current
     end
 
     def milestone?
       milestone_key.present?
     end
 
+    def fhir_status
+      FHIR_STATUS_MAP[status.to_s] || status.to_s
+    end
+
+    def to_fhir
+      {
+        resourceType: "Task",
+        id: id&.to_s,
+        status: fhir_status,
+        intent: "order",
+        priority: priority,
+        description: description,
+        focus: taskable_type.present? ? { reference: "#{fhir_taskable_type}/#{taskable_id}" } : nil,
+        owner: assignee_identifier.present? ? { reference: "Practitioner/#{assignee_identifier}" } : nil,
+        executionPeriod: due_at.present? ? { end: due_at.to_date.iso8601 } : nil,
+        authoredOn: created_at&.iso8601,
+        lastModified: updated_at&.iso8601
+      }.compact
+    end
+
     private
+
+    def fhir_taskable_type
+      case taskable_type
+      when "Corvid::Case" then "EpisodeOfCare"
+      when "Corvid::PrcReferral" then "ServiceRequest"
+      else taskable_type
+      end
+    end
 
     def taskable_in_same_tenant
       return unless taskable && tenant_identifier && taskable.respond_to?(:tenant_identifier)

--- a/db/migrate/20260415000003_add_on_hold_and_stat_to_task_constraints.rb
+++ b/db/migrate/20260415000003_add_on_hold_and_stat_to_task_constraints.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AddOnHoldAndStatToTaskConstraints < ActiveRecord::Migration[8.1]
+  TASK_STATUSES = %w[pending in_progress completed cancelled on_hold].freeze
+  TASK_PRIORITIES = %w[routine urgent asap stat].freeze
+
+  def up
+    remove_check_constraint :corvid_tasks, name: "corvid_tasks_status_check"
+    add_check_constraint :corvid_tasks,
+                         "status IN (#{TASK_STATUSES.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_tasks_status_check"
+
+    remove_check_constraint :corvid_tasks, name: "corvid_tasks_priority_check"
+    add_check_constraint :corvid_tasks,
+                         "priority IN (#{TASK_PRIORITIES.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_tasks_priority_check"
+  end
+
+  def down
+    old_statuses = TASK_STATUSES - %w[on_hold]
+    old_priorities = TASK_PRIORITIES - %w[stat]
+
+    execute "UPDATE corvid_tasks SET status = 'pending' WHERE status = 'on_hold'"
+
+    remove_check_constraint :corvid_tasks, name: "corvid_tasks_status_check"
+    add_check_constraint :corvid_tasks,
+                         "status IN (#{old_statuses.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_tasks_status_check"
+
+    execute "UPDATE corvid_tasks SET priority = 'asap' WHERE priority = 'stat'"
+
+    remove_check_constraint :corvid_tasks, name: "corvid_tasks_priority_check"
+    add_check_constraint :corvid_tasks,
+                         "priority IN (#{old_priorities.map { |s| "'#{s}'" }.join(',')})",
+                         name: "corvid_tasks_priority_check"
+  end
+end

--- a/features/prc/task_management.feature
+++ b/features/prc/task_management.feature
@@ -1,0 +1,115 @@
+Feature: Task Management
+  As a care coordinator
+  I want to manage tasks for cases and referrals
+  So that work items are tracked and assigned
+
+  Background:
+    Given a tenant "tnt_test" with facility "fac_test"
+    And a patient "pt_001" with a PRC case
+
+  # =============================================================================
+  # TASK LIFECYCLE
+  # =============================================================================
+
+  Scenario: Create a task for a case
+    When I create a task with description "Follow up on referral"
+    Then a task should exist with description "Follow up on referral"
+    And the task status should be "pending"
+
+  Scenario: Task requires a description
+    When I try to create a task without a description
+    Then the task should be invalid
+    And I should see an error about description
+
+  Scenario: Start working on a task
+    Given a pending task exists
+    When I start the task
+    Then the task status should be "in_progress"
+
+  Scenario: Complete a task
+    Given a task in progress exists
+    When I complete the task
+    Then the task status should be "completed"
+    And the task should have a completed_at timestamp
+
+  Scenario: Cancel a task
+    Given a pending task exists
+    When I cancel the task
+    Then the task status should be "cancelled"
+
+  Scenario: Put a task on hold
+    Given a task in progress exists
+    When I put the task on hold
+    Then the task status should be "on_hold"
+
+  # =============================================================================
+  # TASK ASSIGNMENT
+  # =============================================================================
+
+  Scenario: Assign a task to a practitioner
+    Given a pending task exists
+    When I assign the task to practitioner "pr_101"
+    Then the task should be assigned to practitioner "pr_101"
+
+  Scenario: Unassign a task
+    Given a task assigned to practitioner "pr_101" exists
+    When I unassign the task
+    Then the task should be unassigned
+
+  # =============================================================================
+  # TASK PRIORITY
+  # =============================================================================
+
+  Scenario: Create a routine priority task
+    When I create a task with priority "routine"
+    Then the task priority should be "routine"
+
+  Scenario: Create an urgent priority task
+    When I create a task with priority "urgent"
+    Then the task priority should be "urgent"
+
+  Scenario: Create a STAT priority task
+    When I create a task with priority "stat"
+    Then the task priority should be "stat"
+
+  # =============================================================================
+  # TASK DUE DATES AND OVERDUE
+  # =============================================================================
+
+  Scenario: Task with due date in the future is not overdue
+    Given a task due in 3 days exists
+    Then the task should not be overdue
+
+  Scenario: Task with due date in the past is overdue
+    Given a task due 2 days ago exists
+    Then the task should be overdue
+
+  Scenario: Completed task is not overdue
+    Given a completed task due 2 days ago exists
+    Then the task should not be overdue
+
+  # =============================================================================
+  # TASK SCOPES
+  # =============================================================================
+
+  Scenario: Find incomplete tasks
+    Given the following tasks exist:
+      | description | status     |
+      | Task A      | pending    |
+      | Task B      | in_progress|
+      | Task C      | completed  |
+      | Task D      | cancelled  |
+    When I query for incomplete tasks
+    Then I should see 2 incomplete tasks
+
+  Scenario: Find overdue tasks
+    Given a task due 5 days ago exists
+    And a task due in 5 days exists
+    When I query for overdue tasks
+    Then I should see 1 overdue task
+
+  Scenario: Find tasks due soon
+    Given a task due in 3 days exists
+    And a task due in 10 days exists
+    When I query for tasks due within 7 days
+    Then I should see 1 task due soon

--- a/features/step_definitions/task_management_steps.rb
+++ b/features/step_definitions/task_management_steps.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+# Task Management step definitions (ported from rpms_redux)
+
+Given("a pending task exists") do
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Test task",
+    status: :pending,
+    facility_identifier: @facility
+  )
+end
+
+Given("a task in progress exists") do
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Test task",
+    status: :in_progress,
+    facility_identifier: @facility
+  )
+end
+
+Given("a task assigned to practitioner {string} exists") do |identifier|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Assigned task",
+    status: :pending,
+    assignee_identifier: identifier,
+    facility_identifier: @facility
+  )
+end
+
+Given("a task due in {int} days exists") do |days|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Future task",
+    status: :pending,
+    due_at: days.days.from_now,
+    facility_identifier: @facility
+  )
+end
+
+Given("a task due {int} days ago exists") do |days|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Past task",
+    status: :pending,
+    due_at: days.days.ago,
+    facility_identifier: @facility
+  )
+end
+
+Given("a completed task due {int} days ago exists") do |days|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Completed past task",
+    status: :completed,
+    due_at: days.days.ago,
+    completed_at: 1.day.ago,
+    facility_identifier: @facility
+  )
+end
+
+Given("the following tasks exist:") do |table|
+  table.hashes.each do |row|
+    Corvid::Task.create!(
+      taskable: @case,
+      description: row["description"],
+      status: row["status"].to_sym,
+      facility_identifier: @facility
+    )
+  end
+end
+
+When("I create a task with description {string}") do |description|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: description,
+    facility_identifier: @facility
+  )
+end
+
+When("I try to create a task without a description") do
+  @task = Corvid::Task.new(
+    taskable: @case,
+    description: nil,
+    facility_identifier: @facility
+  )
+  @task.valid?
+end
+
+When("I create a task with priority {string}") do |priority|
+  @task = Corvid::Task.create!(
+    taskable: @case,
+    description: "Priority task",
+    priority: priority.to_sym,
+    facility_identifier: @facility
+  )
+end
+
+When("I start the task") do
+  @task.update!(status: :in_progress)
+end
+
+When("I complete the task") do
+  @task.update!(status: :completed)
+end
+
+When("I cancel the task") do
+  @task.update!(status: :cancelled)
+end
+
+When("I put the task on hold") do
+  @task.update!(status: :on_hold)
+end
+
+When("I assign the task to practitioner {string}") do |identifier|
+  @task.assign_to!(identifier)
+end
+
+When("I unassign the task") do
+  @task.unassign!
+end
+
+When("I query for incomplete tasks") do
+  @queried_tasks = Corvid::Task.incomplete
+end
+
+When("I query for overdue tasks") do
+  @queried_tasks = Corvid::Task.overdue
+end
+
+When("I query for tasks due within {int} days") do |days|
+  @queried_tasks = Corvid::Task.due_soon(days)
+end
+
+Then("a task should exist with description {string}") do |description|
+  task = Corvid::Task.find_by(description: description)
+  refute_nil task, "Expected task with description '#{description}' to exist"
+end
+
+Then("the task status should be {string}") do |expected_status|
+  @task.reload
+  assert_equal expected_status, @task.status
+end
+
+Then("the task should be invalid") do
+  refute @task.valid?, "Expected task to be invalid"
+end
+
+Then("I should see an error about description") do
+  assert_includes @task.errors[:description], "can't be blank"
+end
+
+Then("the task should have a completed_at timestamp") do
+  @task.reload
+  refute_nil @task.completed_at, "Expected task to have completed_at timestamp"
+end
+
+Then("the task should be assigned to practitioner {string}") do |identifier|
+  @task.reload
+  assert_equal identifier, @task.assignee_identifier
+end
+
+Then("the task should be unassigned") do
+  @task.reload
+  assert_nil @task.assignee_identifier, "Expected task to be unassigned"
+end
+
+Then("the task priority should be {string}") do |expected_priority|
+  assert_equal expected_priority, @task.priority
+end
+
+Then("the task should not be overdue") do
+  @task.reload
+  refute @task.overdue?, "Expected task to not be overdue"
+end
+
+Then("the task should be overdue") do
+  @task.reload
+  assert @task.overdue?, "Expected task to be overdue"
+end
+
+Then("I should see {int} incomplete tasks") do |count|
+  assert_equal count, @queried_tasks.count
+end
+
+Then("I should see {int} overdue task(s)") do |count|
+  assert_equal count, @queried_tasks.count
+end
+
+Then("I should see {int} task(s) due soon") do |count|
+  assert_equal count, @queried_tasks.count
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -205,7 +205,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000002) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -231,8 +231,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000002) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['asap'::character varying::text, 'urgent'::character varying::text, 'routine'::character varying::text])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
   end
 
   add_foreign_key "corvid_alternate_resource_checks", "corvid_prc_referrals", column: "prc_referral_id"


### PR DESCRIPTION
## Summary

- Ported from rpms_redux `app/models/task.rb` and `features/prc/task_management.feature`
- Added `on_hold` status, `stat` priority, `due_soon` scope, `required_milestones` scope
- Added FHIR Task serialization (`to_fhir` with status mapping)
- Added `incomplete?` helper
- Migration updates CHECK constraints for new enum values (safe rollback)
- 17 scenarios, 82 steps ported and passing

Closes #18

## Test plan

- [x] BDD: 17 scenarios, 82 steps passing
- [x] Full suite: 42 unit tests + 51 BDD scenarios (322 steps), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)