### PR TITLE
Rename payer_id and remittance_id to *_identifier

### DIFF
--- a/features/step_definitions/billing_remaining_steps.rb
+++ b/features/step_definitions/billing_remaining_steps.rb
@@ -27,7 +27,7 @@ end
 Given("no claim exists with Stedi ID {string}") do |stedi_id|
   refute Corvid::ClaimSubmission.exists?(claim_identifier: stedi_id)
   Corvid.adapter.add_remittance("REM_ORPHAN_#{stedi_id}", {
-    remittance_id: "REM_ORPHAN_#{stedi_id}",
+    remittance_identifier: "REM_ORPHAN_#{stedi_id}",
     payer_name: "Test Payer", payment_date: Date.current, total_paid: 100.00,
     line_items: [{ claim_identifier: stedi_id, paid_amount: 100.00 }]
   })
@@ -87,7 +87,7 @@ Given("a remittance includes payments for all three claims") do
     { claim_identifier: c.claim_identifier, paid_amount: c.billed_amount.to_f * 0.9 }
   end
   Corvid.adapter.add_remittance("REM_ALL_THREE", {
-    remittance_id: "REM_ALL_THREE",
+    remittance_identifier: "REM_ALL_THREE",
     payer_name: "Test Payer", payment_date: Date.current,
     total_paid: line_items.sum { |li| li[:paid_amount] },
     line_items: line_items
@@ -114,7 +114,7 @@ Given("a remittance includes payments:") do |table|
       paid_amount: amount_str.to_s.gsub("$", "").to_f }
   end
   Corvid.adapter.add_remittance("REM_BATCH", {
-    remittance_id: "REM_BATCH",
+    remittance_identifier: "REM_BATCH",
     payer_name: "Test Payer", payment_date: Date.current,
     total_paid: line_items.sum { |li| li[:paid_amount] },
     line_items: line_items
@@ -133,7 +133,7 @@ end
 
 Given("there are unprocessed remittances from today") do
   Corvid.adapter.add_remittance("REM_TODAY_1", {
-    remittance_id: "REM_TODAY_1", payer_name: "Test Payer",
+    remittance_identifier: "REM_TODAY_1", payer_name: "Test Payer",
     payment_date: Date.current, total_paid: 100.00, line_items: []
   })
 end
@@ -178,7 +178,7 @@ end
 
 Given("a remittance includes denial for {string} with reason {string}") do |claim_id, reason|
   Corvid.adapter.add_remittance("REM_DENY_SPEC_#{claim_id}", {
-    remittance_id: "REM_DENY_SPEC_#{claim_id}", payer_name: "Test Payer",
+    remittance_identifier: "REM_DENY_SPEC_#{claim_id}", payer_name: "Test Payer",
     payment_date: Date.current, total_paid: 0,
     line_items: [{ claim_identifier: claim_id, paid_amount: 0,
                    status: "denied", denial_reason: reason }]
@@ -203,7 +203,7 @@ Given("a remittance includes payment for {string}:") do |claim_id, table|
   codes = [adjustment_raw.split(":").first, denial_raw.split(":").first].compact.reject(&:empty?)
 
   Corvid.adapter.add_remittance("REM_ADJ_SPEC_#{claim_id}", {
-    remittance_id: "REM_ADJ_SPEC_#{claim_id}", payer_name: "Test Payer",
+    remittance_identifier: "REM_ADJ_SPEC_#{claim_id}", payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: paid_amount,
     line_items: [{
@@ -287,7 +287,7 @@ end
 Given("there are {int} unprocessed remittances") do |count|
   count.times do |i|
     Corvid.adapter.add_remittance("REM_UP_#{i}", {
-      remittance_id: "REM_UP_#{i}", payer_name: "Test Payer",
+      remittance_identifier: "REM_UP_#{i}", payer_name: "Test Payer",
       payment_date: Date.current, total_paid: 50.00, line_items: []
     })
   end

--- a/features/step_definitions/billing_undefined_steps.rb
+++ b/features/step_definitions/billing_undefined_steps.rb
@@ -551,7 +551,7 @@ end
 Given("there are remittances from the last {int} days") do |days|
   (1..3).each do |i|
     Corvid.adapter.add_remittance("REM_DAY_#{i}", {
-      remittance_id: "REM_DAY_#{i}",
+      remittance_identifier: "REM_DAY_#{i}",
       payer_name: "Test Payer",
       payment_date: (days - i * (days / 3)).days.ago.to_date,
       total_paid: 100.00 * i,
@@ -577,17 +577,17 @@ end
 
 Given("a remittance exists with ID {string}") do |id|
   Corvid.adapter.add_remittance(id, {
-    remittance_id: id,
+    remittance_identifier: id,
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 250.00,
     line_items: [{ claim_identifier: "CLM_X", paid_amount: 250.00 }]
   })
-  @remittance_id = id
+  @remittance_identifier = id
 end
 
 When("I fetch remittance {string}") do |id|
-  @remittances = Corvid.adapter.fetch_remittances.select { |r| r[:remittance_id] == id }
+  @remittances = Corvid.adapter.fetch_remittances.select { |r| r[:remittance_identifier] == id }
 end
 
 Then("I should see the remittance details") do
@@ -617,7 +617,7 @@ end
 
 Given("a remittance includes payment for {string}") do |claim_id|
   Corvid.adapter.add_remittance("REM_FOR_#{claim_id}", {
-    remittance_id: "REM_FOR_#{claim_id}",
+    remittance_identifier: "REM_FOR_#{claim_id}",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 150.00,
@@ -627,7 +627,7 @@ end
 
 Given("a remittance includes payment for {string} with amount {string}") do |claim_id, amount|
   Corvid.adapter.add_remittance("REM_AMT_#{claim_id}", {
-    remittance_id: "REM_AMT_#{claim_id}",
+    remittance_identifier: "REM_AMT_#{claim_id}",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: amount.gsub("$", "").to_f,

--- a/features/step_definitions/remittance_steps.rb
+++ b/features/step_definitions/remittance_steps.rb
@@ -4,7 +4,7 @@
 
 Given("remittances are available from the clearinghouse") do
   Corvid.adapter.add_remittance("REM_001", {
-    remittance_id: "REM_001",
+    remittance_identifier: "REM_001",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 450.00,
@@ -30,7 +30,7 @@ end
 
 Given("remittance shows claim {string} paid {string} with adjustment {string}") do |ref, paid, adj|
   Corvid.adapter.add_remittance("REM_#{ref}", {
-    remittance_id: "REM_#{ref}",
+    remittance_identifier: "REM_#{ref}",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: paid.gsub("$", "").to_f,
@@ -43,7 +43,7 @@ end
 
 Given("remittance shows claim {string} denied with reason {string}") do |ref, reason|
   Corvid.adapter.add_remittance("REM_DENY_#{ref}", {
-    remittance_id: "REM_DENY_#{ref}",
+    remittance_identifier: "REM_DENY_#{ref}",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 0,
@@ -56,7 +56,7 @@ end
 
 Given("remittance shows patient responsibility of {string} for claim {string}") do |amount, ref|
   Corvid.adapter.add_remittance("REM_PR_#{ref}", {
-    remittance_id: "REM_PR_#{ref}",
+    remittance_identifier: "REM_PR_#{ref}",
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 0,

--- a/lib/corvid/adapters/base.rb
+++ b/lib/corvid/adapters/base.rb
@@ -201,7 +201,7 @@ module Corvid
       end
 
       # Detailed eligibility check (270/271). Returns coverage details hash.
-      def check_eligibility_detailed(patient_identifier, payer_id)
+      def check_eligibility_detailed(patient_identifier, payer_identifier)
         raise NotImplementedError, "#{self.class}#check_eligibility_detailed not implemented"
       end
 

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -292,14 +292,14 @@ module Corvid
         @remittances.values
       end
 
-      def check_eligibility_detailed(patient_identifier, payer_id)
-        { eligible: true, payer_name: "MOCK #{payer_id}", plan_name: "Mock Plan",
+      def check_eligibility_detailed(patient_identifier, payer_identifier)
+        { eligible: true, payer_name: "MOCK #{payer_identifier}", plan_name: "Mock Plan",
           coverage_start: Date.new(Date.current.year, 1, 1),
           coverage_end: Date.new(Date.current.year, 12, 31) }
       end
 
       def search_payers(query)
-        [{ payer_id: "MOCK_PAYER", name: "Mock Payer matching '#{query}'" }]
+        [{ payer_identifier: "MOCK_PAYER", name: "Mock Payer matching '#{query}'" }]
       end
 
       def process_payment(amount_cents:, patient_identifier:, description:)


### PR DESCRIPTION
## Summary

Convention: \`*_id\` is reserved for ActiveRecord FKs. External IDs use \`*_identifier\`.

- \`payer_id\` → \`payer_identifier\` (adapter Base signature, MockAdapter output)
- \`remittance_id\` → \`remittance_identifier\` (remittance hash key)

## Test plan
- [x] 165 BDD scenarios passing
- [x] Unit tests pass (pre-existing flake in CaseTest is unrelated, tracked in #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)