### PR TITLE
Add CMS-0057-F Prior Authorization API (Da Vinci PAS)

### DIFF
--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -27,6 +27,14 @@ module Corvid
     validates :referral_identifier, presence: true
     validates :referral_identifier, uniqueness: { scope: [ :tenant_identifier, :facility_identifier ] }
 
+    # Referrals for a given patient. Joins the parent Case since the
+    # patient_identifier lives there (the referral is case-scoped).
+    # Eager-loads the case so callers iterating referrals don't N+1.
+    scope :for_patient_identifier, ->(patient_identifier) {
+      includes(:case).references(:case)
+        .where(corvid_cases: { patient_identifier: patient_identifier })
+    }
+
     aasm column: :status, whiny_transitions: false do
       state :draft, initial: true
       state :submitted, :eligibility_review, :management_approval, :alternate_resource_review

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS-0057-F Prior Authorization API (Da Vinci PAS) serialization.
+  #
+  # Translates between corvid's PrcReferral domain model and FHIR Claim /
+  # ClaimResponse resources per the Da Vinci PAS Implementation Guide.
+  #
+  # Host apps (corvid-saas, rpms_redux) wire these into FHIR endpoints:
+  #   POST /Claim/$submit           -> submit_from_claim(fhir_claim_hash)
+  #   GET /ClaimResponse/{id}       -> claim_response_for(referral)
+  #   GET /Bundle?ClaimResponse...  -> bundle_for_patient(patient_identifier)
+  #
+  # Reference: https://hl7.org/fhir/us/davinci-pas/
+  class PriorAuthorizationApiService
+    # Map PrcReferral AASM status -> FHIR ClaimResponse disposition + outcome.
+    STATUS_TO_DISPOSITION = {
+      "draft"                   => { outcome: "queued",   disposition: "draft" },
+      "submitted"               => { outcome: "queued",   disposition: "submitted" },
+      "eligibility_review"      => { outcome: "queued",   disposition: "pended" },
+      "management_approval"     => { outcome: "queued",   disposition: "pended" },
+      "alternate_resource_review" => { outcome: "queued", disposition: "pended" },
+      "priority_assignment"     => { outcome: "queued",   disposition: "pended" },
+      "committee_review"        => { outcome: "queued",   disposition: "pended" },
+      "exception_review"        => { outcome: "queued",   disposition: "pended" },
+      "authorized"              => { outcome: "complete", disposition: "approved" },
+      "denied"                  => { outcome: "complete", disposition: "denied" },
+      "deferred"                => { outcome: "queued",   disposition: "pended" },
+      "cancelled"               => { outcome: "error",    disposition: "cancelled" }
+    }.freeze
+
+    class << self
+      # POST /Claim/$submit handler. Accepts a FHIR Claim (as hash) and
+      # creates a PrcReferral. Returns a ClaimResponse hash.
+      def submit_from_claim(fhir_claim)
+        patient_id = extract_patient_identifier(fhir_claim)
+        provider_id = extract_provider_identifier(fhir_claim)
+        service_description = extract_service_description(fhir_claim)
+        estimated_cost = extract_estimated_cost(fhir_claim)
+
+        kase = Corvid::Case.find_or_create_by!(patient_identifier: patient_id) do |c|
+          c.facility_identifier = Corvid::TenantContext.current_facility_identifier
+        end
+
+        referral_id = Corvid.adapter.create_referral(patient_id, {
+          service_requested: service_description,
+          reason: service_description,
+          estimated_cost: estimated_cost,
+          requesting_provider_identifier: provider_id
+        })
+
+        referral = Corvid::PrcReferral.create!(
+          case: kase,
+          referral_identifier: referral_id,
+          estimated_cost: estimated_cost,
+          facility_identifier: kase.facility_identifier,
+          current_activity: "Submitted via FHIR PAS"
+        )
+        referral.submit!
+
+        claim_response_for(referral)
+      end
+
+      # Generate a FHIR ClaimResponse for a PrcReferral.
+      def claim_response_for(referral)
+        mapping = STATUS_TO_DISPOSITION.fetch(referral.status,
+          { outcome: "queued", disposition: "pended" })
+
+        response = {
+          resourceType: "ClaimResponse",
+          id: referral.referral_identifier,
+          status: "active",
+          type: { coding: [{ system: "http://terminology.hl7.org/CodeSystem/claim-type",
+                             code: "professional" }] },
+          use: "preauthorization",
+          patient: { reference: "Patient/#{referral.case.patient_identifier}" },
+          created: referral.created_at.iso8601,
+          insurer: { reference: "Organization/#{referral.facility_identifier}" },
+          outcome: mapping[:outcome],
+          disposition: mapping[:disposition],
+          preAuthRef: referral.authorization_number
+        }.compact
+
+        # Include denial reasons from latest determination
+        latest = referral.latest_determination
+        if latest && latest.outcome == "denied"
+          response[:processNote] = [{ type: "disclaimer",
+                                      text: denial_reason(referral, latest) }]
+        end
+
+        # Pended referrals flagged for review may require additional info.
+        # Flagged-for-review overrides disposition to "pended" regardless of
+        # underlying workflow state so payers see a consistent status.
+        if referral.status == "deferred" || (referral.flagged_for_review? && !referral.authorized? && !referral.denied?)
+          response[:disposition] = "pended" unless referral.authorized? || referral.denied?
+          response[:communicationRequest] = [{
+            reference: "CommunicationRequest/#{referral.id}-info-request"
+          }]
+          response[:additionalInfoRequired] = additional_info_for(referral)
+        end
+
+        response
+      end
+
+      # Generate a FHIR Bundle of ClaimResponses for a patient.
+      def bundle_for_patient(patient_identifier)
+        referrals = Corvid::PrcReferral.joins(:case)
+          .where(corvid_cases: { patient_identifier: patient_identifier })
+
+        {
+          resourceType: "Bundle",
+          type: "searchset",
+          total: referrals.count,
+          entry: referrals.map do |ref|
+            { resource: claim_response_for(ref) }
+          end
+        }
+      end
+
+      # List of covered items and services requiring prior authorization.
+      def covered_services
+        {
+          resourceType: "Bundle",
+          type: "collection",
+          entry: [
+            { resource: { resourceType: "ActivityDefinition", title: "Cardiology Consultation",
+                          kind: "ServiceRequest", status: "active",
+                          description: "Requires prior authorization" } },
+            { resource: { resourceType: "ActivityDefinition", title: "MRI", kind: "ServiceRequest",
+                          status: "active", description: "Requires prior authorization" } },
+            { resource: { resourceType: "ActivityDefinition", title: "Surgery", kind: "ServiceRequest",
+                          status: "active", description: "Requires prior authorization" } }
+          ]
+        }
+      end
+
+      # Documentation requirements for a specific service (Da Vinci DTR).
+      def documentation_requirements_for(service_description)
+        {
+          resourceType: "Questionnaire",
+          title: "Documentation requirements for #{service_description}",
+          status: "active",
+          item: [
+            { linkId: "clinical_justification", text: "Clinical justification", type: "text", required: true },
+            { linkId: "diagnosis_codes", text: "Diagnosis codes (ICD-10)", type: "string", required: true },
+            { linkId: "prior_treatments", text: "Prior treatments attempted", type: "text", required: false }
+          ]
+        }
+      end
+
+      private
+
+      def extract_patient_identifier(fhir_claim)
+        ref = fhir_claim.dig(:patient, :reference) || fhir_claim.dig("patient", "reference")
+        ref&.split("/")&.last
+      end
+
+      def extract_provider_identifier(fhir_claim)
+        ref = fhir_claim.dig(:provider, :reference) || fhir_claim.dig("provider", "reference")
+        ref&.split("/")&.last
+      end
+
+      def extract_service_description(fhir_claim)
+        items = fhir_claim[:item] || fhir_claim["item"] || []
+        first = items.first || {}
+        first[:productOrService] || first["productOrService"] ||
+          first.dig(:productOrService, :text) ||
+          "Service"
+      end
+
+      def extract_estimated_cost(fhir_claim)
+        total = fhir_claim[:total] || fhir_claim["total"] || {}
+        total[:value] || total["value"]
+      end
+
+      def denial_reason(referral, determination)
+        return "Denial reason not recorded" unless referral.deferred_reason_token
+
+        Corvid.adapter.fetch_text(referral.deferred_reason_token) ||
+          "Denied per #{determination.decision_method}"
+      end
+
+      def additional_info_for(referral)
+        ["Additional clinical documentation requested"]
+      end
+    end
+  end
+end

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -109,14 +109,13 @@ module Corvid
         # Pended referrals flagged for review may require additional info.
         # Flagged-for-review overrides disposition to "pended" regardless of
         # underlying workflow state so payers see a consistent status.
-        # We surface the "more info needed" signal via standard R4 elements —
-        # a CommunicationRequest reference + a processNote — rather than a
-        # custom top-level key, so strict R4 validators accept the response.
+        # The "more info needed" signal is surfaced via processNote (a
+        # standard R4 ClaimResponse element). A top-level communicationRequest
+        # is NOT defined on ClaimResponse in base R4 — Da Vinci PAS models
+        # that pattern via Communication resources and IG extensions, which
+        # this foundation does not yet emit.
         if referral.status == "deferred" || (referral.flagged_for_review? && !referral.authorized? && !referral.denied?)
           response[:disposition] = "pended" unless referral.authorized? || referral.denied?
-          response[:communicationRequest] = [{
-            reference: "CommunicationRequest/#{referral.id}-info-request"
-          }]
           additional_info_for(referral).each do |msg|
             notes << { type: "display", text: msg }
           end
@@ -127,12 +126,11 @@ module Corvid
       end
 
       # Generate a FHIR Bundle of ClaimResponses for a patient.
-      # Tenant filtering happens via TenantScoped#default_scope; the explicit
-      # table-qualified patient filter ensures we hit the tenant-scoped cases.
-      # includes(:case) prevents N+1 case lookups in claim_response_for.
+      # Tenant filtering happens via TenantScoped#default_scope; the
+      # PrcReferral.for_patient_identifier scope centralizes the Case join
+      # and eager-loads to prevent N+1 case lookups in claim_response_for.
       def bundle_for_patient(patient_identifier)
-        referrals = Corvid::PrcReferral.includes(:case).references(:case)
-          .where(corvid_cases: { patient_identifier: patient_identifier })
+        referrals = Corvid::PrcReferral.for_patient_identifier(patient_identifier)
 
         {
           resourceType: "Bundle",

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -6,10 +6,17 @@ module Corvid
   # Translates between corvid's PrcReferral domain model and FHIR Claim /
   # ClaimResponse resources per the Da Vinci PAS Implementation Guide.
   #
-  # Host apps (corvid-saas, rpms_redux) wire these into FHIR endpoints:
+  # Host apps wire these into FHIR endpoints:
   #   POST /Claim/$submit           -> submit_from_claim(fhir_claim_hash)
   #   GET /ClaimResponse/{id}       -> claim_response_for(referral)
   #   GET /Bundle?ClaimResponse...  -> bundle_for_patient(patient_identifier)
+  #
+  # SCOPE: This is a PAS-shaped foundation, not a conformance-complete
+  # implementation. It emits resource shapes with the fields corvid tracks
+  # today; it does NOT yet emit Da Vinci PAS profiles, extension URLs,
+  # Insurance/coverage references, item detail, or the X12 278 bridge
+  # (issue #47). Formal CMS-0057-F certification requires IG-driven
+  # validation and a richer mapping layer.
   #
   # Reference: https://hl7.org/fhir/us/davinci-pas/
   class PriorAuthorizationApiService
@@ -38,9 +45,14 @@ module Corvid
         service_description = extract_service_description(fhir_claim)
         estimated_cost = extract_estimated_cost(fhir_claim)
 
-        kase = Corvid::Case.find_or_create_by!(patient_identifier: patient_id) do |c|
-          c.facility_identifier = Corvid::TenantContext.current_facility_identifier
-        end
+        # Scope the find by facility so patients with cases at multiple
+        # facilities in the same tenant don't attach a PA to the wrong case.
+        # Tenant is applied automatically by TenantScoped#default_scope.
+        facility_id = Corvid::TenantContext.current_facility_identifier
+        kase = Corvid::Case.find_or_create_by!(
+          patient_identifier: patient_id,
+          facility_identifier: facility_id
+        )
 
         referral_id = Corvid.adapter.create_referral(patient_id, {
           service_requested: service_description,
@@ -103,6 +115,8 @@ module Corvid
       end
 
       # Generate a FHIR Bundle of ClaimResponses for a patient.
+      # Tenant filtering happens via TenantScoped#default_scope; the explicit
+      # table-qualified patient filter ensures we hit the tenant-scoped cases.
       def bundle_for_patient(patient_identifier)
         referrals = Corvid::PrcReferral.joins(:case)
           .where(corvid_cases: { patient_identifier: patient_identifier })
@@ -173,6 +187,11 @@ module Corvid
         total[:value] || total["value"]
       end
 
+      # Resolve human-readable denial text from the vault.
+      # NOTE: today the engine stores free-text reasons in deferred_reason_token
+      # (a misnomer inherited from the referral model — it covers both
+      # deferrals and denials). A follow-up should move denial text onto the
+      # Determination's reasons_token so the two cases are separable.
       def denial_reason(referral, determination)
         return "Denial reason not recorded" unless referral.deferred_reason_token
 

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -87,38 +87,51 @@ module Corvid
           use: "preauthorization",
           patient: { reference: "Patient/#{referral.case.patient_identifier}" },
           created: referral.created_at.iso8601,
-          insurer: { reference: "Organization/#{referral.facility_identifier}" },
+          # insurer is required by FHIR R4 ClaimResponse profile but
+          # facility_identifier is nullable on PrcReferral; omit the reference
+          # when we can't build a valid one rather than emitting "Organization/".
+          insurer: referral.facility_identifier.present? ?
+            { reference: "Organization/#{referral.facility_identifier}" } : nil,
           outcome: mapping[:outcome],
           disposition: mapping[:disposition],
           preAuthRef: referral.authorization_number
         }.compact
 
-        # Include denial reasons from latest determination
+        # Collect processNote entries from denial reasons and info-request text.
+        # FHIR R4 ClaimResponse.processNote.type is a coded value from the
+        # `note-type` valueset (display | print | printoper). Use "display"
+        # so the note renders for human review without a constrained code-set
+        # validation failure.
+        notes = []
         latest = referral.latest_determination
-        if latest && latest.outcome == "denied"
-          response[:processNote] = [{ type: "disclaimer",
-                                      text: denial_reason(referral, latest) }]
-        end
+        notes << { type: "display", text: denial_reason(referral, latest) } if latest && latest.outcome == "denied"
 
         # Pended referrals flagged for review may require additional info.
         # Flagged-for-review overrides disposition to "pended" regardless of
         # underlying workflow state so payers see a consistent status.
+        # We surface the "more info needed" signal via standard R4 elements —
+        # a CommunicationRequest reference + a processNote — rather than a
+        # custom top-level key, so strict R4 validators accept the response.
         if referral.status == "deferred" || (referral.flagged_for_review? && !referral.authorized? && !referral.denied?)
           response[:disposition] = "pended" unless referral.authorized? || referral.denied?
           response[:communicationRequest] = [{
             reference: "CommunicationRequest/#{referral.id}-info-request"
           }]
-          response[:additionalInfoRequired] = additional_info_for(referral)
+          additional_info_for(referral).each do |msg|
+            notes << { type: "display", text: msg }
+          end
         end
 
+        response[:processNote] = notes if notes.any?
         response
       end
 
       # Generate a FHIR Bundle of ClaimResponses for a patient.
       # Tenant filtering happens via TenantScoped#default_scope; the explicit
       # table-qualified patient filter ensures we hit the tenant-scoped cases.
+      # includes(:case) prevents N+1 case lookups in claim_response_for.
       def bundle_for_patient(patient_identifier)
-        referrals = Corvid::PrcReferral.joins(:case)
+        referrals = Corvid::PrcReferral.includes(:case).references(:case)
           .where(corvid_cases: { patient_identifier: patient_identifier })
 
         {
@@ -177,9 +190,23 @@ module Corvid
       def extract_service_description(fhir_claim)
         items = fhir_claim[:item] || fhir_claim["item"] || []
         first = items.first || {}
-        first[:productOrService] || first["productOrService"] ||
-          first.dig(:productOrService, :text) ||
-          "Service"
+        raw = first[:productOrService] || first["productOrService"]
+        normalize_codeable_concept(raw) || "Service"
+      end
+
+      # productOrService is a FHIR CodeableConcept — may be a Hash with
+      # text/coding in real payloads, or a simple String in lightweight
+      # callers. Return a String suitable for persistence as service_requested.
+      def normalize_codeable_concept(value)
+        case value
+        when String
+          value
+        when Hash
+          v = value.transform_keys(&:to_sym)
+          v[:text] ||
+            v.dig(:coding, 0, :display) ||
+            v.dig(:coding, 0, :code)
+        end
       end
 
       def extract_estimated_cost(fhir_claim)

--- a/features/prc/prior_authorization_api.feature
+++ b/features/prc/prior_authorization_api.feature
@@ -1,0 +1,82 @@
+Feature: CMS-0057-F Prior Authorization API (Da Vinci PAS)
+  As a payer required to comply with CMS-0057-F by January 1, 2027
+  I need a Da Vinci PAS-conforming FHIR API for prior authorization
+  So that providers can submit PA requests and receive decisions
+
+  Background:
+    Given a tenant "tnt_test" with facility "fac_test"
+    And a patient "pt_pa_001" with a PRC case
+
+  # =============================================================================
+  # PA SUBMISSION (Claim/$submit)
+  # =============================================================================
+
+  Scenario: Submit a new PA request via Claim/$submit
+    When a provider submits a FHIR PA request for service "Cardiology Consultation" with estimated cost 5000
+    Then a PrcReferral should be created in "submitted" status
+    And the FHIR response should be a ClaimResponse with outcome "queued"
+    And the ClaimResponse should reference the new PrcReferral
+
+  Scenario: PA submission records provenance
+    When a provider "pr_npi_1234567890" submits a FHIR PA request for service "MRI"
+    Then a PrcReferral should be created
+    And the PrcReferral should record the requesting provider as "pr_npi_1234567890"
+
+  # =============================================================================
+  # PA DECISION (ClaimResponse)
+  # =============================================================================
+
+  Scenario: Retrieve ClaimResponse for an approved referral
+    Given an authorized PRC referral "rf_pa_approved" exists
+    When I retrieve the ClaimResponse for "rf_pa_approved"
+    Then the ClaimResponse outcome should be "complete"
+    And the ClaimResponse disposition should be "approved"
+
+  Scenario: Retrieve ClaimResponse for a denied referral
+    Given a denied PRC referral "rf_pa_denied" exists with reason "Service not medically necessary"
+    When I retrieve the ClaimResponse for "rf_pa_denied"
+    Then the ClaimResponse outcome should be "complete"
+    And the ClaimResponse disposition should be "denied"
+    And the ClaimResponse should include the denial reason
+
+  Scenario: Retrieve ClaimResponse for a pending referral
+    Given a pending PRC referral "rf_pa_pending" exists in "committee_review" state
+    When I retrieve the ClaimResponse for "rf_pa_pending"
+    Then the ClaimResponse outcome should be "queued"
+    And the ClaimResponse disposition should be "pended"
+
+  # =============================================================================
+  # BUNDLE SEARCH (list PA responses for a patient)
+  # =============================================================================
+
+  Scenario: List all ClaimResponses for a patient
+    Given the following PRC referrals exist for patient "pt_pa_001":
+      | identifier   | status     |
+      | rf_pa_bundle_1 | authorized |
+      | rf_pa_bundle_2 | denied     |
+      | rf_pa_bundle_3 | submitted  |
+    When I request all ClaimResponses for patient "pt_pa_001"
+    Then the Bundle should contain 3 ClaimResponse entries
+
+  # =============================================================================
+  # COVERED SERVICES AND DOCUMENTATION
+  # =============================================================================
+
+  Scenario: Retrieve list of covered services
+    When I request the list of covered items and services
+    Then the response should list service categories requiring prior authorization
+
+  Scenario: Retrieve documentation requirements for a service
+    When I request documentation requirements for service "Cardiology Consultation"
+    Then the response should list required clinical documentation
+
+  # =============================================================================
+  # REQUEST FOR MORE INFORMATION
+  # =============================================================================
+
+  Scenario: PA pended with request for more information
+    Given a PRC referral "rf_pa_needs_info" exists
+    When the referral is pended for additional clinical documentation
+    And I retrieve the ClaimResponse for "rf_pa_needs_info"
+    Then the ClaimResponse disposition should be "pended"
+    And the ClaimResponse should list required additional information

--- a/features/step_definitions/prior_authorization_api_steps.rb
+++ b/features/step_definitions/prior_authorization_api_steps.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# CMS-0057-F Prior Authorization API (Da Vinci PAS) step definitions
+
+def build_fhir_claim(patient_id:, service: "Cardiology Consultation", cost: 5000, provider: nil)
+  {
+    resourceType: "Claim",
+    status: "active",
+    use: "preauthorization",
+    patient: { reference: "Patient/#{patient_id}" },
+    provider: provider ? { reference: "Practitioner/#{provider}" } : nil,
+    total: { value: cost, currency: "USD" },
+    item: [ { productOrService: service } ]
+  }.compact
+end
+
+When("a provider submits a FHIR PA request for service {string} with estimated cost {int}") do |service, cost|
+  @fhir_claim = build_fhir_claim(patient_id: @case.patient_identifier, service: service, cost: cost)
+  @claim_response = Corvid::PriorAuthorizationApiService.submit_from_claim(@fhir_claim)
+  @referral = Corvid::PrcReferral.order(created_at: :desc).first
+end
+
+When("a provider {string} submits a FHIR PA request for service {string}") do |provider_id, service|
+  @fhir_claim = build_fhir_claim(patient_id: @case.patient_identifier, service: service, provider: provider_id)
+  @claim_response = Corvid::PriorAuthorizationApiService.submit_from_claim(@fhir_claim)
+  @referral = Corvid::PrcReferral.order(created_at: :desc).first
+end
+
+Then("a PrcReferral should be created in {string} status") do |status|
+  refute_nil @referral
+  assert_equal status, @referral.status
+end
+
+Then("a PrcReferral should be created") do
+  refute_nil @referral
+end
+
+Then("the PrcReferral should record the requesting provider as {string}") do |provider_id|
+  ref = Corvid.adapter.find_referral(@referral.referral_identifier)
+  refute_nil ref, "Expected adapter to know the referral"
+  # MockAdapter stores requesting_provider_identifier in the referral attrs hash
+  stored = Corvid.adapter.instance_variable_get(:@referrals)[@referral.referral_identifier]
+  assert_equal provider_id, stored[:requesting_provider_identifier]
+end
+
+Then("the FHIR response should be a ClaimResponse with outcome {string}") do |outcome|
+  assert_equal "ClaimResponse", @claim_response[:resourceType]
+  assert_equal outcome, @claim_response[:outcome]
+end
+
+Then("the ClaimResponse should reference the new PrcReferral") do
+  assert_equal @referral.referral_identifier, @claim_response[:id]
+end
+
+Given("an authorized PRC referral {string} exists") do |identifier|
+  @referral = Corvid::PrcReferral.create!(
+    case: @case,
+    referral_identifier: identifier,
+    facility_identifier: @facility,
+    status: "authorized",
+    authorization_number: "AUTH-#{identifier}"
+  )
+end
+
+Given("a denied PRC referral {string} exists with reason {string}") do |identifier, reason|
+  reason_token = Corvid.adapter.store_text(
+    case_token: @case.id.to_s, kind: :reason, text: reason
+  )
+  @referral = Corvid::PrcReferral.create!(
+    case: @case,
+    referral_identifier: identifier,
+    facility_identifier: @facility,
+    status: "denied",
+    deferred_reason_token: reason_token
+  )
+  @referral.record_determination!(
+    outcome: "denied",
+    decision_method: "staff_review",
+    reasons: [ reason ],
+    determined_by_identifier: "pr_reviewer_001"
+  )
+end
+
+Given("a pending PRC referral {string} exists in {string} state") do |identifier, state|
+  @referral = Corvid::PrcReferral.create!(
+    case: @case,
+    referral_identifier: identifier,
+    facility_identifier: @facility,
+    status: state
+  )
+end
+
+Given("a PRC referral {string} exists") do |identifier|
+  @referral = Corvid::PrcReferral.create!(
+    case: @case,
+    referral_identifier: identifier,
+    facility_identifier: @facility,
+    status: "submitted"
+  )
+end
+
+When("I retrieve the ClaimResponse for {string}") do |identifier|
+  ref = Corvid::PrcReferral.find_by!(referral_identifier: identifier)
+  @claim_response = Corvid::PriorAuthorizationApiService.claim_response_for(ref)
+end
+
+Then("the ClaimResponse outcome should be {string}") do |outcome|
+  assert_equal outcome, @claim_response[:outcome]
+end
+
+Then("the ClaimResponse disposition should be {string}") do |disposition|
+  assert_equal disposition, @claim_response[:disposition]
+end
+
+Then("the ClaimResponse should include the denial reason") do
+  notes = @claim_response[:processNote]
+  refute_nil notes, "Expected processNote with denial reason"
+  assert notes.any? { |n| n[:text].to_s.length > 0 }, "Expected non-empty denial text"
+end
+
+Given("the following PRC referrals exist for patient {string}:") do |patient_id, table|
+  kase = Corvid::Case.find_or_create_by!(
+    patient_identifier: patient_id,
+    facility_identifier: @facility
+  )
+  table.hashes.each do |row|
+    Corvid::PrcReferral.create!(
+      case: kase,
+      referral_identifier: row["identifier"],
+      facility_identifier: @facility,
+      status: row["status"]
+    )
+  end
+end
+
+When("I request all ClaimResponses for patient {string}") do |patient_id|
+  @bundle = Corvid::PriorAuthorizationApiService.bundle_for_patient(patient_id)
+end
+
+Then("the Bundle should contain {int} ClaimResponse entries") do |count|
+  assert_equal "Bundle", @bundle[:resourceType]
+  assert_equal count, @bundle[:entry].size
+  @bundle[:entry].each do |entry|
+    assert_equal "ClaimResponse", entry[:resource][:resourceType]
+  end
+end
+
+When("I request the list of covered items and services") do
+  @covered = Corvid::PriorAuthorizationApiService.covered_services
+end
+
+Then("the response should list service categories requiring prior authorization") do
+  assert_equal "Bundle", @covered[:resourceType]
+  assert @covered[:entry].any?, "Expected at least one covered service"
+  @covered[:entry].each do |entry|
+    assert_equal "ActivityDefinition", entry[:resource][:resourceType]
+  end
+end
+
+When("I request documentation requirements for service {string}") do |service|
+  @questionnaire = Corvid::PriorAuthorizationApiService.documentation_requirements_for(service)
+end
+
+Then("the response should list required clinical documentation") do
+  assert_equal "Questionnaire", @questionnaire[:resourceType]
+  assert @questionnaire[:item].any? { |i| i[:required] }, "Expected at least one required item"
+end
+
+When("the referral is pended for additional clinical documentation") do
+  @referral.update!(flagged_for_review: true)
+end
+
+Then("the ClaimResponse should list required additional information") do
+  assert_equal "pended", @claim_response[:disposition]
+  refute_nil @claim_response[:additionalInfoRequired]
+  assert @claim_response[:additionalInfoRequired].any?
+end

--- a/features/step_definitions/prior_authorization_api_steps.rb
+++ b/features/step_definitions/prior_authorization_api_steps.rb
@@ -17,13 +17,13 @@ end
 When("a provider submits a FHIR PA request for service {string} with estimated cost {int}") do |service, cost|
   @fhir_claim = build_fhir_claim(patient_id: @case.patient_identifier, service: service, cost: cost)
   @claim_response = Corvid::PriorAuthorizationApiService.submit_from_claim(@fhir_claim)
-  @referral = Corvid::PrcReferral.order(created_at: :desc).first
+  @referral = Corvid::PrcReferral.find_by!(referral_identifier: @claim_response[:id])
 end
 
 When("a provider {string} submits a FHIR PA request for service {string}") do |provider_id, service|
   @fhir_claim = build_fhir_claim(patient_id: @case.patient_identifier, service: service, provider: provider_id)
   @claim_response = Corvid::PriorAuthorizationApiService.submit_from_claim(@fhir_claim)
-  @referral = Corvid::PrcReferral.order(created_at: :desc).first
+  @referral = Corvid::PrcReferral.find_by!(referral_identifier: @claim_response[:id])
 end
 
 Then("a PrcReferral should be created in {string} status") do |status|
@@ -38,9 +38,7 @@ end
 Then("the PrcReferral should record the requesting provider as {string}") do |provider_id|
   ref = Corvid.adapter.find_referral(@referral.referral_identifier)
   refute_nil ref, "Expected adapter to know the referral"
-  # MockAdapter stores requesting_provider_identifier in the referral attrs hash
-  stored = Corvid.adapter.instance_variable_get(:@referrals)[@referral.referral_identifier]
-  assert_equal provider_id, stored[:requesting_provider_identifier]
+  assert_equal provider_id, ref.requesting_provider_identifier
 end
 
 Then("the FHIR response should be a ClaimResponse with outcome {string}") do |outcome|
@@ -172,6 +170,7 @@ end
 
 Then("the ClaimResponse should list required additional information") do
   assert_equal "pended", @claim_response[:disposition]
-  refute_nil @claim_response[:additionalInfoRequired]
-  assert @claim_response[:additionalInfoRequired].any?
+  refute_nil @claim_response[:communicationRequest]
+  assert @claim_response[:communicationRequest].any?
+  assert @claim_response[:processNote].any? { |n| n[:text].to_s.length > 0 }
 end

--- a/features/step_definitions/prior_authorization_api_steps.rb
+++ b/features/step_definitions/prior_authorization_api_steps.rb
@@ -170,7 +170,6 @@ end
 
 Then("the ClaimResponse should list required additional information") do
   assert_equal "pended", @claim_response[:disposition]
-  refute_nil @claim_response[:communicationRequest]
-  assert @claim_response[:communicationRequest].any?
+  refute_nil @claim_response[:processNote]
   assert @claim_response[:processNote].any? { |n| n[:text].to_s.length > 0 }
 end

--- a/lib/corvid/adapters/fhir_adapter.rb
+++ b/lib/corvid/adapters/fhir_adapter.rb
@@ -388,7 +388,8 @@ module Corvid
           emergent: resource["priority"] == "stat",
           urgent: resource["priority"] == "urgent",
           chs_approval_status: nil,
-          service_requested: resource.dig("code", "text") || resource.dig("code", "coding", 0, "display")
+          service_requested: resource.dig("code", "text") || resource.dig("code", "coding", 0, "display"),
+          requesting_provider_identifier: resource.dig("requester", "reference")&.split("/")&.last
         )
       end
 

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -382,7 +382,8 @@ module Corvid
           emergent: attrs[:emergent],
           urgent: attrs[:urgent],
           chs_approval_status: attrs[:chs_approval_status],
-          service_requested: attrs[:service_requested]
+          service_requested: attrs[:service_requested],
+          requesting_provider_identifier: attrs[:requesting_provider_identifier]
         )
       end
 

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -112,7 +112,8 @@ module Corvid
           emergent: false,
           urgent: false,
           chs_approval_status: "P",
-          service_requested: params[:service_requested]
+          service_requested: params[:service_requested],
+          requesting_provider_identifier: params[:requesting_provider_identifier]
         }
         token
       end

--- a/lib/corvid/value_objects.rb
+++ b/lib/corvid/value_objects.rb
@@ -28,7 +28,8 @@ module Corvid
     :emergent,
     :urgent,
     :chs_approval_status,
-    :service_requested
+    :service_requested,
+    :requesting_provider_identifier
   ) do
     def emergent? = emergent == true
     def urgent? = urgent == true

--- a/test/corvid/value_objects_test.rb
+++ b/test/corvid/value_objects_test.rb
@@ -49,6 +49,7 @@ class Corvid::ValueObjectsTest < Minitest::Test
       identifier patient_identifier status reason_token
       estimated_cost medical_priority_level authorization_number
       emergent urgent chs_approval_status service_requested
+      requesting_provider_identifier
     ]
     assert_equal expected, Corvid::ReferralReference.members
   end
@@ -108,7 +109,8 @@ class Corvid::ValueObjectsTest < Minitest::Test
       emergent: false,
       urgent: false,
       chs_approval_status: "P",
-      service_requested: nil
+      service_requested: nil,
+      requesting_provider_identifier: nil
     }
     Corvid::ReferralReference.new(**defaults.merge(overrides))
   end

--- a/test/services/corvid/prior_authorization_api_service_test.rb
+++ b/test/services/corvid/prior_authorization_api_service_test.rb
@@ -108,7 +108,8 @@ class Corvid::PriorAuthorizationApiServiceTest < ActiveSupport::TestCase
 
       response = Corvid::PriorAuthorizationApiService.claim_response_for(referral)
       assert_equal "pended", response[:disposition]
-      assert response[:additionalInfoRequired].any?
+      assert response[:communicationRequest].any?
+      assert response[:processNote].any? { |n| n[:type] == "display" }
     end
   end
 

--- a/test/services/corvid/prior_authorization_api_service_test.rb
+++ b/test/services/corvid/prior_authorization_api_service_test.rb
@@ -108,8 +108,8 @@ class Corvid::PriorAuthorizationApiServiceTest < ActiveSupport::TestCase
 
       response = Corvid::PriorAuthorizationApiService.claim_response_for(referral)
       assert_equal "pended", response[:disposition]
-      assert response[:communicationRequest].any?
-      assert response[:processNote].any? { |n| n[:type] == "display" }
+      assert response[:processNote].any? { |n| n[:type] == "display" },
+        "expected a processNote carrying the info-request text"
     end
   end
 

--- a/test/services/corvid/prior_authorization_api_service_test.rb
+++ b/test/services/corvid/prior_authorization_api_service_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::PriorAuthorizationApiServiceTest < ActiveSupport::TestCase
+  TENANT = "tnt_pa"
+  FACILITY = "fac_pa"
+
+  def build_fhir_claim(overrides = {})
+    {
+      resourceType: "Claim",
+      status: "active",
+      use: "preauthorization",
+      patient: { reference: "Patient/pt_pa_unit_001" },
+      provider: { reference: "Practitioner/pr_pa_unit_001" },
+      total: { value: 2500, currency: "USD" },
+      item: [ { productOrService: "MRI" } ]
+    }.merge(overrides)
+  end
+
+  test "submit_from_claim creates a Case and PrcReferral in submitted status" do
+    with_tenant(TENANT) do
+      Corvid::TenantContext.current_facility_identifier = FACILITY
+      response = Corvid::PriorAuthorizationApiService.submit_from_claim(build_fhir_claim)
+
+      assert_equal "ClaimResponse", response[:resourceType]
+      assert_equal "queued", response[:outcome]
+      assert_equal "submitted", response[:disposition]
+
+      referral = Corvid::PrcReferral.order(created_at: :desc).first
+      assert_equal "submitted", referral.status
+      assert_equal "pt_pa_unit_001", referral.case.patient_identifier
+    ensure
+      Corvid::TenantContext.reset!
+    end
+  end
+
+  test "submit_from_claim scopes case lookup by facility" do
+    with_tenant(TENANT) do
+      Corvid::TenantContext.current_facility_identifier = "fac_a"
+      Corvid::PriorAuthorizationApiService.submit_from_claim(build_fhir_claim)
+
+      Corvid::TenantContext.current_facility_identifier = "fac_b"
+      Corvid::PriorAuthorizationApiService.submit_from_claim(build_fhir_claim)
+
+      cases = Corvid::Case.where(patient_identifier: "pt_pa_unit_001")
+      facilities = cases.pluck(:facility_identifier).sort
+      assert_equal [ "fac_a", "fac_b" ], facilities,
+        "expected one Case per facility for the same patient"
+    ensure
+      Corvid::TenantContext.reset!
+    end
+  end
+
+  test "claim_response_for maps authorized status to complete/approved" do
+    with_tenant(TENANT) do
+      kase = Corvid::Case.create!(patient_identifier: "pt_pa_unit_002", facility_identifier: FACILITY)
+      referral = Corvid::PrcReferral.create!(
+        case: kase,
+        referral_identifier: "rf_unit_authorized",
+        facility_identifier: FACILITY,
+        status: "authorized",
+        authorization_number: "AUTH-UNIT-1"
+      )
+
+      response = Corvid::PriorAuthorizationApiService.claim_response_for(referral)
+      assert_equal "complete", response[:outcome]
+      assert_equal "approved", response[:disposition]
+      assert_equal "AUTH-UNIT-1", response[:preAuthRef]
+    end
+  end
+
+  test "claim_response_for includes denial reason when status is denied" do
+    with_tenant(TENANT) do
+      kase = Corvid::Case.create!(patient_identifier: "pt_pa_unit_003", facility_identifier: FACILITY)
+      token = Corvid.adapter.store_text(
+        case_token: kase.id.to_s, kind: :reason, text: "Service not medically necessary"
+      )
+      referral = Corvid::PrcReferral.create!(
+        case: kase,
+        referral_identifier: "rf_unit_denied",
+        facility_identifier: FACILITY,
+        status: "denied",
+        deferred_reason_token: token
+      )
+      referral.record_determination!(
+        outcome: "denied",
+        decision_method: "staff_review",
+        determined_by_identifier: "pr_rev_001"
+      )
+
+      response = Corvid::PriorAuthorizationApiService.claim_response_for(referral)
+      assert_equal "denied", response[:disposition]
+      assert response[:processNote].any? { |n| n[:text] == "Service not medically necessary" }
+    end
+  end
+
+  test "claim_response_for overrides disposition to pended for flagged-for-review" do
+    with_tenant(TENANT) do
+      kase = Corvid::Case.create!(patient_identifier: "pt_pa_unit_004", facility_identifier: FACILITY)
+      referral = Corvid::PrcReferral.create!(
+        case: kase,
+        referral_identifier: "rf_unit_flagged",
+        facility_identifier: FACILITY,
+        status: "submitted",
+        flagged_for_review: true
+      )
+
+      response = Corvid::PriorAuthorizationApiService.claim_response_for(referral)
+      assert_equal "pended", response[:disposition]
+      assert response[:additionalInfoRequired].any?
+    end
+  end
+
+  test "bundle_for_patient returns a searchset Bundle scoped to the patient" do
+    with_tenant(TENANT) do
+      kase = Corvid::Case.create!(patient_identifier: "pt_pa_unit_005", facility_identifier: FACILITY)
+      Corvid::PrcReferral.create!(case: kase, referral_identifier: "rf_b1",
+        facility_identifier: FACILITY, status: "authorized")
+      Corvid::PrcReferral.create!(case: kase, referral_identifier: "rf_b2",
+        facility_identifier: FACILITY, status: "denied")
+
+      other_case = Corvid::Case.create!(patient_identifier: "pt_other", facility_identifier: FACILITY)
+      Corvid::PrcReferral.create!(case: other_case, referral_identifier: "rf_other",
+        facility_identifier: FACILITY, status: "authorized")
+
+      bundle = Corvid::PriorAuthorizationApiService.bundle_for_patient("pt_pa_unit_005")
+      assert_equal "Bundle", bundle[:resourceType]
+      assert_equal "searchset", bundle[:type]
+      assert_equal 2, bundle[:entry].size
+      ids = bundle[:entry].map { |e| e[:resource][:id] }.sort
+      assert_equal [ "rf_b1", "rf_b2" ], ids
+    end
+  end
+
+  test "covered_services returns a Bundle of ActivityDefinitions" do
+    result = Corvid::PriorAuthorizationApiService.covered_services
+    assert_equal "Bundle", result[:resourceType]
+    assert result[:entry].all? { |e| e[:resource][:resourceType] == "ActivityDefinition" }
+  end
+
+  test "documentation_requirements_for returns a Questionnaire with required items" do
+    q = Corvid::PriorAuthorizationApiService.documentation_requirements_for("MRI")
+    assert_equal "Questionnaire", q[:resourceType]
+    assert q[:item].any? { |i| i[:required] }
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `PriorAuthorizationApiService` for Da Vinci PAS FHIR translation
- Maps PrcReferral AASM states to ClaimResponse outcome/disposition
- Supports Claim/\$submit, ClaimResponse retrieval, Bundle search, covered services, and DTR questionnaires

Closes #40

## Test plan
- [x] 9 BDD scenarios in features/prc/prior_authorization_api.feature pass
- [x] Full cucumber suite: 174 scenarios / 1164 steps passing
- [x] No regressions in rails test

🤖 Generated with [Claude Code](https://claude.com/claude-code)