### PR TITLE
Track CMS-0057-F API usage metrics

### DIFF
--- a/app/models/corvid/api_call_log.rb
+++ b/app/models/corvid/api_call_log.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Per-call usage record for CMS-0057-F API metrics reporting.
+  #
+  # Not an audit log — we don't store request/response bodies here (see #56
+  # for that). This table exists purely to support the public metrics
+  # payers must publish annually: unique patients, unique apps, total calls,
+  # calls by endpoint.
+  #
+  # All columns are low-cardinality or opaque identifiers — no PHI at rest.
+  class ApiCallLog < ::ActiveRecord::Base
+    self.table_name = "corvid_api_call_logs"
+
+    include TenantScoped
+
+    # Mirrors the migration's check constraint.
+    API_NAMES = %w[pas patient_access provider_access payer_to_payer].freeze
+
+    validates :api_name, presence: true, inclusion: { in: API_NAMES }
+    validates :endpoint, presence: true
+    validates :called_at, presence: true
+
+    scope :for_api, ->(name) { where(api_name: name) }
+    scope :in_year, ->(year) {
+      start_of = Time.zone.local(year, 1, 1)
+      end_of = Time.zone.local(year + 1, 1, 1)
+      where(called_at: start_of...end_of)
+    }
+  end
+end

--- a/app/models/corvid/api_call_log.rb
+++ b/app/models/corvid/api_call_log.rb
@@ -23,8 +23,11 @@ module Corvid
 
     scope :for_api, ->(name) { where(api_name: name) }
     scope :in_year, ->(year) {
-      start_of = Time.zone.local(year, 1, 1)
-      end_of = Time.zone.local(year + 1, 1, 1)
+      # Coerce string query params ("2026") to Integer so Time.zone.local
+      # doesn't raise TypeError; raises ArgumentError for non-numeric input.
+      y = Integer(year.to_s)
+      start_of = Time.zone.local(y, 1, 1)
+      end_of = Time.zone.local(y + 1, 1, 1)
       where(called_at: start_of...end_of)
     }
   end

--- a/app/services/corvid/api_metrics_service.rb
+++ b/app/services/corvid/api_metrics_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS-0057-F API usage metrics.
+  #
+  # Payers subject to 45 CFR 156.223 must publish annual public metrics for
+  # each implemented API (Patient Access, Provider Access, Payer-to-Payer,
+  # Prior Authorization). This service records each API call and aggregates
+  # the required metrics into an annual report.
+  #
+  # Host apps call `.record!` from their mounted FHIR controllers. The PA
+  # service does this automatically for its public methods.
+  #
+  # Reference: https://www.cms.gov/newsroom/fact-sheets/cms-interoperability-prior-authorization-final-rule-cms-0057-f
+  class ApiMetricsService
+    class << self
+      # Log a single API call. Silently skips if no tenant context is set
+      # so callers outside a tenant scope (e.g. background maintenance)
+      # don't accidentally pollute metrics.
+      def record!(api:, endpoint:, patient_identifier: nil, app_identifier: nil, called_at: Time.current)
+        tenant = Corvid::TenantContext.current_tenant_identifier
+        return nil unless tenant
+
+        Corvid::ApiCallLog.create!(
+          tenant_identifier: tenant,
+          facility_identifier: Corvid::TenantContext.current_facility_identifier,
+          api_name: api.to_s,
+          endpoint: endpoint.to_s,
+          patient_identifier: patient_identifier,
+          app_identifier: app_identifier,
+          called_at: called_at
+        )
+      end
+
+      # Aggregate metrics for a calendar year. Returns the shape CMS
+      # expects in the annual public report.
+      #
+      #   {
+      #     tenant: "tnt_foo",
+      #     year: 2026,
+      #     api: "pas" | nil,
+      #     total_calls: 1234,
+      #     unique_patients: 87,
+      #     unique_apps: 12,
+      #     calls_by_endpoint: { "submit" => 400, "read" => 800, "search" => 34 }
+      #   }
+      def annual_report(tenant:, year: Date.current.year, api: nil)
+        Corvid::TenantContext.with_tenant(tenant) do
+          scope = Corvid::ApiCallLog.in_year(year)
+          scope = scope.for_api(api) if api
+
+          {
+            tenant: tenant,
+            year: year,
+            api: api,
+            total_calls: scope.count,
+            unique_patients: scope.where.not(patient_identifier: nil)
+              .distinct.count(:patient_identifier),
+            unique_apps: scope.where.not(app_identifier: nil)
+              .distinct.count(:app_identifier),
+            calls_by_endpoint: scope.group(:endpoint).count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/corvid/api_metrics_service.rb
+++ b/app/services/corvid/api_metrics_service.rb
@@ -17,6 +17,12 @@ module Corvid
       # Log a single API call. Silently skips if no tenant context is set
       # so callers outside a tenant scope (e.g. background maintenance)
       # don't accidentally pollute metrics.
+      #
+      # Metrics recording MUST NOT fail a real API call. A DB hiccup or
+      # validation miss on this table is an observability problem, not a
+      # client-facing error, so we rescue and log rather than propagate.
+      # The `!` in the name matches other Corvid services; it doesn't
+      # imply the caller needs to handle exceptions.
       def record!(api:, endpoint:, patient_identifier: nil, app_identifier: nil, called_at: Time.current)
         tenant = Corvid::TenantContext.current_tenant_identifier
         return nil unless tenant
@@ -30,6 +36,9 @@ module Corvid
           app_identifier: app_identifier,
           called_at: called_at
         )
+      rescue => e
+        Rails.logger.warn("ApiMetricsService.record! failed: #{Corvid.sanitize_phi(e.message)}")
+        nil
       end
 
       # Aggregate metrics for a calendar year. Returns the shape CMS

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -39,7 +39,10 @@ module Corvid
     class << self
       # POST /Claim/$submit handler. Accepts a FHIR Claim (as hash) and
       # creates a PrcReferral. Returns a ClaimResponse hash.
-      def submit_from_claim(fhir_claim)
+      #
+      # Hosts pass app_identifier (the authenticated OAuth client_id) so
+      # CMS-0057-F annual usage metrics (#46) can count distinct apps.
+      def submit_from_claim(fhir_claim, app_identifier: nil)
         patient_id = extract_patient_identifier(fhir_claim)
         provider_id = extract_provider_identifier(fhir_claim)
         service_description = extract_service_description(fhir_claim)
@@ -69,6 +72,12 @@ module Corvid
           current_activity: "Submitted via FHIR PAS"
         )
         referral.submit!
+
+        Corvid::ApiMetricsService.record!(
+          api: :pas, endpoint: "submit",
+          patient_identifier: patient_id,
+          app_identifier: app_identifier
+        )
 
         claim_response_for(referral)
       end

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -79,25 +79,32 @@ module Corvid
           app_identifier: app_identifier
         )
 
-        claim_response_for(referral)
+        build_claim_response(referral)
       end
 
-      # GET /ClaimResponse/{id} handler. Records a "read" metrics event and
-      # returns the serialized response. Internal callers that already
-      # counted a different endpoint (submit / search) should use
-      # claim_response_for directly to avoid double-counting.
-      def read_claim_response(referral, app_identifier: nil)
+      # GET /ClaimResponse/{id} handler. Records a "read" metrics event
+      # and returns the serialized response. This is the method host
+      # FHIR controllers should call for a read endpoint so metrics are
+      # never silently missed. Internal callers (submit_from_claim,
+      # bundle_for_patient) use build_claim_response to avoid double
+      # counting against a different endpoint they already recorded.
+      def claim_response_for(referral, app_identifier: nil)
         Corvid::ApiMetricsService.record!(
           api: :pas, endpoint: "read",
           patient_identifier: referral.case.patient_identifier,
           app_identifier: app_identifier
         )
-        claim_response_for(referral)
+        build_claim_response(referral)
       end
 
-      # Generate a FHIR ClaimResponse for a PrcReferral. Pure serializer —
-      # does not record a metrics event (the caller's endpoint does).
-      def claim_response_for(referral)
+      # Backward-compatible alias for callers wired before
+      # claim_response_for itself recorded metrics.
+      alias_method :read_claim_response, :claim_response_for
+
+      # Pure serializer: build a FHIR ClaimResponse hash from a referral
+      # without recording a metrics event. Used by submit_from_claim and
+      # bundle_for_patient so their outer endpoints own the count.
+      def build_claim_response(referral)
         mapping = STATUS_TO_DISPOSITION.fetch(referral.status,
           { outcome: "queued", disposition: "pended" })
 
@@ -151,7 +158,7 @@ module Corvid
       # Generate a FHIR Bundle of ClaimResponses for a patient.
       # Tenant filtering happens via TenantScoped#default_scope; the
       # PrcReferral.for_patient_identifier scope centralizes the Case join
-      # and eager-loads to prevent N+1 case lookups in claim_response_for.
+      # and eager-loads to prevent N+1 case lookups.
       def bundle_for_patient(patient_identifier, app_identifier: nil)
         referrals = Corvid::PrcReferral.for_patient_identifier(patient_identifier)
 
@@ -166,7 +173,7 @@ module Corvid
           type: "searchset",
           total: referrals.count,
           entry: referrals.map do |ref|
-            { resource: claim_response_for(ref) }
+            { resource: build_claim_response(ref) }
           end
         }
       end

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -82,7 +82,21 @@ module Corvid
         claim_response_for(referral)
       end
 
-      # Generate a FHIR ClaimResponse for a PrcReferral.
+      # GET /ClaimResponse/{id} handler. Records a "read" metrics event and
+      # returns the serialized response. Internal callers that already
+      # counted a different endpoint (submit / search) should use
+      # claim_response_for directly to avoid double-counting.
+      def read_claim_response(referral, app_identifier: nil)
+        Corvid::ApiMetricsService.record!(
+          api: :pas, endpoint: "read",
+          patient_identifier: referral.case.patient_identifier,
+          app_identifier: app_identifier
+        )
+        claim_response_for(referral)
+      end
+
+      # Generate a FHIR ClaimResponse for a PrcReferral. Pure serializer —
+      # does not record a metrics event (the caller's endpoint does).
       def claim_response_for(referral)
         mapping = STATUS_TO_DISPOSITION.fetch(referral.status,
           { outcome: "queued", disposition: "pended" })
@@ -138,8 +152,14 @@ module Corvid
       # Tenant filtering happens via TenantScoped#default_scope; the
       # PrcReferral.for_patient_identifier scope centralizes the Case join
       # and eager-loads to prevent N+1 case lookups in claim_response_for.
-      def bundle_for_patient(patient_identifier)
+      def bundle_for_patient(patient_identifier, app_identifier: nil)
         referrals = Corvid::PrcReferral.for_patient_identifier(patient_identifier)
+
+        Corvid::ApiMetricsService.record!(
+          api: :pas, endpoint: "search",
+          patient_identifier: patient_identifier,
+          app_identifier: app_identifier
+        )
 
         {
           resourceType: "Bundle",
@@ -152,7 +172,11 @@ module Corvid
       end
 
       # List of covered items and services requiring prior authorization.
-      def covered_services
+      def covered_services(app_identifier: nil)
+        Corvid::ApiMetricsService.record!(
+          api: :pas, endpoint: "covered_services",
+          app_identifier: app_identifier
+        )
         {
           resourceType: "Bundle",
           type: "collection",
@@ -169,7 +193,11 @@ module Corvid
       end
 
       # Documentation requirements for a specific service (Da Vinci DTR).
-      def documentation_requirements_for(service_description)
+      def documentation_requirements_for(service_description, app_identifier: nil)
+        Corvid::ApiMetricsService.record!(
+          api: :pas, endpoint: "documentation",
+          app_identifier: app_identifier
+        )
         {
           resourceType: "Questionnaire",
           title: "Documentation requirements for #{service_description}",

--- a/db/migrate/20260416000001_create_corvid_api_call_logs.rb
+++ b/db/migrate/20260416000001_create_corvid_api_call_logs.rb
@@ -17,12 +17,19 @@ class CreateCorvidApiCallLogs < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :called_at ],
-      name: "idx_corvid_api_calls_tenant_api_time"
-    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :patient_identifier ],
-      name: "idx_corvid_api_calls_tenant_patient"
-    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :app_identifier ],
-      name: "idx_corvid_api_calls_tenant_app"
+    # annual_report queries filter by (tenant, api, called_at range) first,
+    # then aggregate distinct patient/app. Leading tenant+api+called_at
+    # narrows to the year window; trailing patient_identifier / app_identifier
+    # lets PG answer the count(distinct ...) from the index alone.
+    add_index :corvid_api_call_logs,
+      [ :tenant_identifier, :api_name, :called_at, :patient_identifier ],
+      name: "idx_corvid_api_calls_tenant_api_time_patient"
+    add_index :corvid_api_call_logs,
+      [ :tenant_identifier, :api_name, :called_at, :app_identifier ],
+      name: "idx_corvid_api_calls_tenant_api_time_app"
+    add_index :corvid_api_call_logs,
+      [ :tenant_identifier, :api_name, :endpoint, :called_at ],
+      name: "idx_corvid_api_calls_tenant_api_endpoint_time"
 
     add_check_constraint :corvid_api_call_logs,
       "api_name IN (#{API_NAMES.map { |s| "'#{s}'" }.join(',')})",

--- a/db/migrate/20260416000001_create_corvid_api_call_logs.rb
+++ b/db/migrate/20260416000001_create_corvid_api_call_logs.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateCorvidApiCallLogs < ActiveRecord::Migration[8.1]
+  # CMS-0057-F recognized APIs. Each API carries its own required public
+  # reporting metrics (see 45 CFR 156.223).
+  API_NAMES = %w[pas patient_access provider_access payer_to_payer].freeze
+
+  def change
+    create_table :corvid_api_call_logs do |t|
+      t.string :tenant_identifier, null: false
+      t.string :facility_identifier
+      t.string :api_name, null: false
+      t.string :endpoint, null: false
+      t.string :patient_identifier
+      t.string :app_identifier
+      t.datetime :called_at, null: false
+      t.timestamps
+    end
+
+    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :called_at ],
+      name: "idx_corvid_api_calls_tenant_api_time"
+    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :patient_identifier ],
+      name: "idx_corvid_api_calls_tenant_patient"
+    add_index :corvid_api_call_logs, [ :tenant_identifier, :api_name, :app_identifier ],
+      name: "idx_corvid_api_calls_tenant_app"
+
+    add_check_constraint :corvid_api_call_logs,
+      "api_name IN (#{API_NAMES.map { |s| "'#{s}'" }.join(',')})",
+      name: "corvid_api_call_logs_api_name_check"
+  end
+end

--- a/features/prc/compliance_metrics.feature
+++ b/features/prc/compliance_metrics.feature
@@ -72,3 +72,23 @@ Feature: CMS-0057-F API usage metrics
     When a provider submits a FHIR PA request for service "MRI" with estimated cost 2000 as app "app_ehr_a"
     Then the annual report for tenant "tnt_metrics" api "pas" should show 1 total calls
     And the annual report for tenant "tnt_metrics" api "pas" should show 1 unique patients
+
+  Scenario: Reading a ClaimResponse records a metrics event (not double-counted from submit)
+    Given a patient "pt_m_700" with a PRC case
+    And a PRC referral "rf_m_700" for that case
+    When a host app reads ClaimResponse "rf_m_700" as app "app_ehr_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "read"
+
+  Scenario: Searching ClaimResponses records a search metrics event
+    Given a patient "pt_m_800" with a PRC case
+    When a host app searches ClaimResponses for patient "pt_m_800" as app "app_ehr_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "search"
+
+  Scenario: Retrieving covered services records a metrics event without a patient
+    When a host app requests the covered services list as app "app_ehr_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "covered_services"
+    And the annual report for tenant "tnt_metrics" api "pas" should show 0 unique patients
+
+  Scenario: Retrieving documentation requirements records a metrics event
+    When a host app requests documentation requirements for "MRI" as app "app_ehr_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "documentation"

--- a/features/prc/compliance_metrics.feature
+++ b/features/prc/compliance_metrics.feature
@@ -1,0 +1,74 @@
+Feature: CMS-0057-F API usage metrics
+  As a payer subject to CMS-0057-F annual reporting
+  I need corvid to track API call volume and distinct users/apps/patients
+  So that I can publish the required public metrics by March 31 each year
+
+  Background:
+    Given a tenant "tnt_metrics" with facility "fac_metrics"
+
+  # ===========================================================================
+  # PER-CALL RECORDING
+  # ===========================================================================
+
+  Scenario: Recording a PAS API call
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_001" app "app_ehr_a"
+    Then there should be 1 API call logged for tenant "tnt_metrics"
+    And the call should be scoped to api "pas" endpoint "submit"
+
+  Scenario: Recording counts each call separately
+    When I record 3 API calls for "pas" endpoint "submit" patient "pt_m_002" app "app_ehr_a"
+    Then there should be 3 API calls logged for tenant "tnt_metrics"
+
+  # ===========================================================================
+  # ANNUAL AGGREGATION
+  # ===========================================================================
+
+  Scenario: Annual report counts unique patients
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_100" app "app_a"
+    And I record an API call for "pas" endpoint "submit" patient "pt_m_100" app "app_a"
+    And I record an API call for "pas" endpoint "submit" patient "pt_m_101" app "app_a"
+    Then the annual report for tenant "tnt_metrics" should show 2 unique patients
+    And the annual report for tenant "tnt_metrics" should show 3 total calls
+
+  Scenario: Annual report counts unique apps
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_200" app "app_x"
+    And I record an API call for "pas" endpoint "submit" patient "pt_m_201" app "app_y"
+    And I record an API call for "pas" endpoint "submit" patient "pt_m_202" app "app_x"
+    Then the annual report for tenant "tnt_metrics" should show 2 unique apps
+
+  Scenario: Annual report breaks down calls by endpoint
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_300" app "app_a"
+    And I record an API call for "pas" endpoint "read" patient "pt_m_300" app "app_a"
+    And I record an API call for "pas" endpoint "read" patient "pt_m_300" app "app_a"
+    Then the annual report for tenant "tnt_metrics" should show 1 calls to "submit"
+    And the annual report for tenant "tnt_metrics" should show 2 calls to "read"
+
+  # ===========================================================================
+  # TENANT SCOPING
+  # ===========================================================================
+
+  Scenario: Metrics are tenant-scoped
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_400" app "app_a"
+    And tenant "tnt_other" records an API call for "pas" endpoint "submit" patient "pt_m_401" app "app_b"
+    Then the annual report for tenant "tnt_metrics" should show 1 total calls
+    And the annual report for tenant "tnt_other" should show 1 total calls
+
+  # ===========================================================================
+  # API FILTERING
+  # ===========================================================================
+
+  Scenario: Annual report can filter by API
+    When I record an API call for "pas" endpoint "submit" patient "pt_m_500" app "app_a"
+    And I record an API call for "patient_access" endpoint "read" patient "pt_m_500" app "app_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 total calls
+    And the annual report for tenant "tnt_metrics" api "patient_access" should show 1 total calls
+
+  # ===========================================================================
+  # PAS INTEGRATION
+  # ===========================================================================
+
+  Scenario: Submitting a PA request records a metrics event
+    Given a patient "pt_m_600" with a PRC case
+    When a provider submits a FHIR PA request for service "MRI" with estimated cost 2000 as app "app_ehr_a"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 total calls
+    And the annual report for tenant "tnt_metrics" api "pas" should show 1 unique patients

--- a/features/prc/compliance_metrics.feature
+++ b/features/prc/compliance_metrics.feature
@@ -40,7 +40,7 @@ Feature: CMS-0057-F API usage metrics
     When I record an API call for "pas" endpoint "submit" patient "pt_m_300" app "app_a"
     And I record an API call for "pas" endpoint "read" patient "pt_m_300" app "app_a"
     And I record an API call for "pas" endpoint "read" patient "pt_m_300" app "app_a"
-    Then the annual report for tenant "tnt_metrics" should show 1 calls to "submit"
+    Then the annual report for tenant "tnt_metrics" should show 1 call to "submit"
     And the annual report for tenant "tnt_metrics" should show 2 calls to "read"
 
   # ===========================================================================
@@ -77,18 +77,18 @@ Feature: CMS-0057-F API usage metrics
     Given a patient "pt_m_700" with a PRC case
     And a PRC referral "rf_m_700" for that case
     When a host app reads ClaimResponse "rf_m_700" as app "app_ehr_a"
-    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "read"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 call to "read"
 
   Scenario: Searching ClaimResponses records a search metrics event
     Given a patient "pt_m_800" with a PRC case
     When a host app searches ClaimResponses for patient "pt_m_800" as app "app_ehr_a"
-    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "search"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 call to "search"
 
   Scenario: Retrieving covered services records a metrics event without a patient
     When a host app requests the covered services list as app "app_ehr_a"
-    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "covered_services"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 call to "covered_services"
     And the annual report for tenant "tnt_metrics" api "pas" should show 0 unique patients
 
   Scenario: Retrieving documentation requirements records a metrics event
     When a host app requests documentation requirements for "MRI" as app "app_ehr_a"
-    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 calls to "documentation"
+    Then the annual report for tenant "tnt_metrics" api "pas" should show 1 call to "documentation"

--- a/features/step_definitions/compliance_metrics_steps.rb
+++ b/features/step_definitions/compliance_metrics_steps.rb
@@ -35,6 +35,23 @@ When("a provider submits a FHIR PA request for service {string} with estimated c
   Corvid::PriorAuthorizationApiService.submit_from_claim(claim, app_identifier: app)
 end
 
+When("a host app reads ClaimResponse {string} as app {string}") do |identifier, app|
+  referral = Corvid::PrcReferral.find_by!(referral_identifier: identifier)
+  Corvid::PriorAuthorizationApiService.read_claim_response(referral, app_identifier: app)
+end
+
+When("a host app searches ClaimResponses for patient {string} as app {string}") do |patient, app|
+  Corvid::PriorAuthorizationApiService.bundle_for_patient(patient, app_identifier: app)
+end
+
+When("a host app requests the covered services list as app {string}") do |app|
+  Corvid::PriorAuthorizationApiService.covered_services(app_identifier: app)
+end
+
+When("a host app requests documentation requirements for {string} as app {string}") do |service, app|
+  Corvid::PriorAuthorizationApiService.documentation_requirements_for(service, app_identifier: app)
+end
+
 Then("there should be {int} API call logged for tenant {string}") do |count, tenant|
   Corvid::TenantContext.with_tenant(tenant) do
     assert_equal count, Corvid::ApiCallLog.count
@@ -83,4 +100,9 @@ end
 Then("the annual report for tenant {string} api {string} should show {int} unique patients") do |tenant, api, count|
   report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year, api: api)
   assert_equal count, report[:unique_patients]
+end
+
+Then("the annual report for tenant {string} api {string} should show {int} calls to {string}") do |tenant, api, count, endpoint|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year, api: api)
+  assert_equal count, report[:calls_by_endpoint][endpoint].to_i
 end

--- a/features/step_definitions/compliance_metrics_steps.rb
+++ b/features/step_definitions/compliance_metrics_steps.rb
@@ -52,15 +52,9 @@ When("a host app requests documentation requirements for {string} as app {string
   Corvid::PriorAuthorizationApiService.documentation_requirements_for(service, app_identifier: app)
 end
 
-Then("there should be {int} API call logged for tenant {string}") do |count, tenant|
+Then(/^there should be (\d+) API calls? logged for tenant "([^"]+)"$/) do |count, tenant|
   Corvid::TenantContext.with_tenant(tenant) do
-    assert_equal count, Corvid::ApiCallLog.count
-  end
-end
-
-Then("there should be {int} API calls logged for tenant {string}") do |count, tenant|
-  Corvid::TenantContext.with_tenant(tenant) do
-    assert_equal count, Corvid::ApiCallLog.count
+    assert_equal count.to_i, Corvid::ApiCallLog.count
   end
 end
 
@@ -87,9 +81,9 @@ Then("the annual report for tenant {string} should show {int} total calls") do |
   assert_equal count, report[:total_calls]
 end
 
-Then("the annual report for tenant {string} should show {int} calls to {string}") do |tenant, count, endpoint|
+Then(/^the annual report for tenant "([^"]+)" should show (\d+) calls? to "([^"]+)"$/) do |tenant, count, endpoint|
   report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year)
-  assert_equal count, report[:calls_by_endpoint][endpoint].to_i
+  assert_equal count.to_i, report[:calls_by_endpoint][endpoint].to_i
 end
 
 Then("the annual report for tenant {string} api {string} should show {int} total calls") do |tenant, api, count|
@@ -102,7 +96,7 @@ Then("the annual report for tenant {string} api {string} should show {int} uniqu
   assert_equal count, report[:unique_patients]
 end
 
-Then("the annual report for tenant {string} api {string} should show {int} calls to {string}") do |tenant, api, count, endpoint|
+Then(/^the annual report for tenant "([^"]+)" api "([^"]+)" should show (\d+) calls? to "([^"]+)"$/) do |tenant, api, count, endpoint|
   report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year, api: api)
-  assert_equal count, report[:calls_by_endpoint][endpoint].to_i
+  assert_equal count.to_i, report[:calls_by_endpoint][endpoint].to_i
 end

--- a/features/step_definitions/compliance_metrics_steps.rb
+++ b/features/step_definitions/compliance_metrics_steps.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# CMS-0057-F API usage metrics step definitions.
+
+def record_call(api:, endpoint:, patient:, app:, tenant: nil)
+  Corvid::TenantContext.with_tenant(tenant || @tenant) do
+    Corvid::ApiMetricsService.record!(
+      api: api, endpoint: endpoint,
+      patient_identifier: patient, app_identifier: app
+    )
+  end
+end
+
+When("I record an API call for {string} endpoint {string} patient {string} app {string}") do |api, endpoint, patient, app|
+  record_call(api: api, endpoint: endpoint, patient: patient, app: app)
+end
+
+When("I record {int} API calls for {string} endpoint {string} patient {string} app {string}") do |n, api, endpoint, patient, app|
+  n.times { record_call(api: api, endpoint: endpoint, patient: patient, app: app) }
+end
+
+When("tenant {string} records an API call for {string} endpoint {string} patient {string} app {string}") do |tenant, api, endpoint, patient, app|
+  record_call(api: api, endpoint: endpoint, patient: patient, app: app, tenant: tenant)
+end
+
+When("a provider submits a FHIR PA request for service {string} with estimated cost {int} as app {string}") do |service, cost, app|
+  claim = {
+    resourceType: "Claim",
+    status: "active",
+    use: "preauthorization",
+    patient: { reference: "Patient/#{@case.patient_identifier}" },
+    total: { value: cost, currency: "USD" },
+    item: [ { productOrService: service } ]
+  }
+  Corvid::PriorAuthorizationApiService.submit_from_claim(claim, app_identifier: app)
+end
+
+Then("there should be {int} API call logged for tenant {string}") do |count, tenant|
+  Corvid::TenantContext.with_tenant(tenant) do
+    assert_equal count, Corvid::ApiCallLog.count
+  end
+end
+
+Then("there should be {int} API calls logged for tenant {string}") do |count, tenant|
+  Corvid::TenantContext.with_tenant(tenant) do
+    assert_equal count, Corvid::ApiCallLog.count
+  end
+end
+
+Then("the call should be scoped to api {string} endpoint {string}") do |api, endpoint|
+  Corvid::TenantContext.with_tenant(@tenant) do
+    call = Corvid::ApiCallLog.last
+    assert_equal api, call.api_name
+    assert_equal endpoint, call.endpoint
+  end
+end
+
+Then("the annual report for tenant {string} should show {int} unique patients") do |tenant, count|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year)
+  assert_equal count, report[:unique_patients]
+end
+
+Then("the annual report for tenant {string} should show {int} unique apps") do |tenant, count|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year)
+  assert_equal count, report[:unique_apps]
+end
+
+Then("the annual report for tenant {string} should show {int} total calls") do |tenant, count|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year)
+  assert_equal count, report[:total_calls]
+end
+
+Then("the annual report for tenant {string} should show {int} calls to {string}") do |tenant, count, endpoint|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year)
+  assert_equal count, report[:calls_by_endpoint][endpoint].to_i
+end
+
+Then("the annual report for tenant {string} api {string} should show {int} total calls") do |tenant, api, count|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year, api: api)
+  assert_equal count, report[:total_calls]
+end
+
+Then("the annual report for tenant {string} api {string} should show {int} unique patients") do |tenant, api, count|
+  report = Corvid::ApiMetricsService.annual_report(tenant: tenant, year: Date.current.year, api: api)
+  assert_equal count, report[:unique_patients]
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,6 +22,7 @@ end
 # runs (cucumber scenarios are not wrapped in transactions).
 def clean_corvid_tables!
   # Order matters due to foreign keys.
+  Corvid::ApiCallLog.unscoped.delete_all
   Corvid::Payment.unscoped.delete_all
   Corvid::ClaimSubmission.unscoped.delete_all
   Corvid::BillingTransaction.unscoped.delete_all

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000006) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -31,6 +31,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000006) do
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
     t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
     t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
+  end
+
+  create_table "corvid_api_call_logs", force: :cascade do |t|
+    t.string "api_name", null: false
+    t.string "app_identifier"
+    t.datetime "called_at", null: false
+    t.datetime "created_at", null: false
+    t.string "endpoint", null: false
+    t.string "facility_identifier"
+    t.string "patient_identifier"
+    t.string "tenant_identifier", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tenant_identifier", "api_name", "app_identifier"], name: "idx_corvid_api_calls_tenant_app"
+    t.index ["tenant_identifier", "api_name", "called_at"], name: "idx_corvid_api_calls_tenant_api_time"
+    t.index ["tenant_identifier", "api_name", "patient_identifier"], name: "idx_corvid_api_calls_tenant_patient"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -136,7 +152,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000006) do
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
     t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_committee_reviews", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000001) do
     t.index ["tenant_identifier", "api_name", "app_identifier"], name: "idx_corvid_api_calls_tenant_app"
     t.index ["tenant_identifier", "api_name", "called_at"], name: "idx_corvid_api_calls_tenant_api_time"
     t.index ["tenant_identifier", "api_name", "patient_identifier"], name: "idx_corvid_api_calls_tenant_patient"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|

--- a/test/services/corvid/api_metrics_service_test.rb
+++ b/test/services/corvid/api_metrics_service_test.rb
@@ -74,6 +74,29 @@ class Corvid::ApiMetricsServiceTest < ActiveSupport::TestCase
     assert_equal 1, r2026[:total_calls]
   end
 
+  test "PAS read/search/covered_services/documentation record distinct endpoints" do
+    with_tenant(TENANT) do
+      Corvid::TenantContext.current_facility_identifier = "fac_u"
+      kase = Corvid::Case.create!(patient_identifier: "pt_u_450", facility_identifier: "fac_u")
+      referral = Corvid::PrcReferral.create!(
+        case: kase, referral_identifier: "rf_u_450",
+        facility_identifier: "fac_u", status: "submitted"
+      )
+
+      Corvid::PriorAuthorizationApiService.read_claim_response(referral, app_identifier: "app_a")
+      Corvid::PriorAuthorizationApiService.bundle_for_patient("pt_u_450", app_identifier: "app_a")
+      Corvid::PriorAuthorizationApiService.covered_services(app_identifier: "app_a")
+      Corvid::PriorAuthorizationApiService.documentation_requirements_for("MRI", app_identifier: "app_a")
+    ensure
+      Corvid::TenantContext.reset!
+    end
+
+    report = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: Date.current.year, api: "pas")
+    assert_equal 4, report[:total_calls]
+    assert_equal({ "read" => 1, "search" => 1, "covered_services" => 1, "documentation" => 1 },
+      report[:calls_by_endpoint])
+  end
+
   test "annual_report does not count cross-tenant calls" do
     with_tenant(TENANT) do
       Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",

--- a/test/services/corvid/api_metrics_service_test.rb
+++ b/test/services/corvid/api_metrics_service_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::ApiMetricsServiceTest < ActiveSupport::TestCase
+  TENANT = "tnt_metrics_unit"
+
+  test "record! creates an ApiCallLog scoped to the current tenant" do
+    with_tenant(TENANT) do
+      Corvid::ApiMetricsService.record!(
+        api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_001", app_identifier: "app_a"
+      )
+      log = Corvid::ApiCallLog.last
+      assert_equal TENANT, log.tenant_identifier
+      assert_equal "pas", log.api_name
+      assert_equal "submit", log.endpoint
+      assert_equal "pt_u_001", log.patient_identifier
+      assert_equal "app_a", log.app_identifier
+      refute_nil log.called_at
+    end
+  end
+
+  test "record! silently no-ops when tenant context is not set" do
+    Corvid::TenantContext.reset!
+    result = Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit")
+    assert_nil result
+  end
+
+  test "annual_report aggregates unique patients, apps, and total calls" do
+    with_tenant(TENANT) do
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_100", app_identifier: "app_x")
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "read",
+        patient_identifier: "pt_u_100", app_identifier: "app_x")
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "read",
+        patient_identifier: "pt_u_101", app_identifier: "app_y")
+    end
+
+    report = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: Date.current.year)
+    assert_equal 3, report[:total_calls]
+    assert_equal 2, report[:unique_patients]
+    assert_equal 2, report[:unique_apps]
+    assert_equal({ "submit" => 1, "read" => 2 }, report[:calls_by_endpoint])
+  end
+
+  test "annual_report can filter by api" do
+    with_tenant(TENANT) do
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_200", app_identifier: "app_a")
+      Corvid::ApiMetricsService.record!(api: :patient_access, endpoint: "read",
+        patient_identifier: "pt_u_200", app_identifier: "app_a")
+    end
+
+    pas = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: Date.current.year, api: "pas")
+    assert_equal 1, pas[:total_calls]
+    pa = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: Date.current.year, api: "patient_access")
+    assert_equal 1, pa[:total_calls]
+  end
+
+  test "annual_report scopes to the requested year" do
+    with_tenant(TENANT) do
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_300", app_identifier: "app_a",
+        called_at: Time.zone.local(2025, 6, 15))
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_301", app_identifier: "app_b",
+        called_at: Time.zone.local(2026, 6, 15))
+    end
+
+    r2025 = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: 2025)
+    r2026 = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: 2026)
+    assert_equal 1, r2025[:total_calls]
+    assert_equal 1, r2026[:total_calls]
+  end
+
+  test "annual_report does not count cross-tenant calls" do
+    with_tenant(TENANT) do
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_400", app_identifier: "app_a")
+    end
+    Corvid::TenantContext.with_tenant("tnt_other_unit") do
+      Corvid::ApiMetricsService.record!(api: :pas, endpoint: "submit",
+        patient_identifier: "pt_u_401", app_identifier: "app_a")
+    end
+
+    report = Corvid::ApiMetricsService.annual_report(tenant: TENANT, year: Date.current.year)
+    assert_equal 1, report[:total_calls]
+  end
+end


### PR DESCRIPTION
## Summary
- New \`corvid_api_call_logs\` table + \`Corvid::ApiCallLog\` model + \`Corvid::ApiMetricsService\`
- Per-tenant, per-year aggregation: unique patients, unique apps, total calls, calls by endpoint
- All five PAS public methods (\`submit\`, \`read\`, \`search\`, \`covered_services\`, \`documentation\`) record distinct endpoints via a new \`read_claim_response\` wrapper; internal delegates don't double-count
- 12 BDD scenarios + 7 Minitest unit tests

Closes #46

## CMS-0057-F context

Under 45 CFR 156.223, impacted payers must publish annual public metrics for each implemented API (Patient Access, Provider Access, Payer-to-Payer, Prior Authorization). This lands the engine-side plumbing; host apps call \`ApiMetricsService.annual_report\` to generate the published figures.

## What's instrumented in this PR

- **PAS (Prior Authorization)**: all five public methods of \`Corvid::PriorAuthorizationApiService\` record metrics internally.
- **Patient Access (#43), Provider Access (#41), Payer-to-Payer (#42)**: the schema already reserves \`api_name\` buckets for these, but the engine doesn't instrument them yet — host controllers for those APIs will call \`Corvid::ApiMetricsService.record!\` directly when the APIs land.

## Follow-ups (not in this PR)

- **#61** — Retention + rollup strategy for \`corvid_api_call_logs\` (append-only rows need a prune/archive/rollup story before production)
- **#56** — Audit log of request/response bodies (separate table, different retention)
- **#58** — Mountable PAS controller will wire \`read\`/\`search\` metrics from routes

## Test plan
- [x] \`bundle exec cucumber features/prc/compliance_metrics.feature\` — 12/12 green
- [x] \`bundle exec rake test TEST=test/services/corvid/api_metrics_service_test.rb\` — 7/7 green
- [x] Full cucumber suite — 250/250 green
- [x] Full rake test — 208/208 green (no pre-existing failures either; #50 landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)