### PR TITLE
Model tests batch: Task, ARC, CommitteeReview, BillingTransaction, Determination, FeeSchedule, ClaimSubmission

### DIFF
--- a/test/models/corvid/alternate_resource_check_test.rb
+++ b/test/models/corvid/alternate_resource_check_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::AlternateResourceCheckTest < ActiveSupport::TestCase
+  TENANT = "tnt_arc_test"
+
+  setup do
+    Corvid::AlternateResourceCheck.unscoped.delete_all
+    Corvid::PrcReferral.unscoped.delete_all
+    Corvid::Case.unscoped.delete_all
+  end
+
+  # -- Validation -------------------------------------------------------------
+
+  test "valid with required fields" do
+    with_tenant(TENANT) do
+      check = build_check(resource_type: "medicare_a")
+      assert check.valid?
+    end
+  end
+
+  test "requires valid resource_type" do
+    with_tenant(TENANT) do
+      check = build_check(resource_type: "invalid_type")
+      refute check.valid?
+    end
+  end
+
+  test "resource_type unique per referral" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      Corvid::AlternateResourceCheck.create!(prc_referral: referral, resource_type: "medicare_a")
+      dup = Corvid::AlternateResourceCheck.new(prc_referral: referral, resource_type: "medicare_a")
+      refute dup.valid?
+    end
+  end
+
+  # -- Status -----------------------------------------------------------------
+
+  test "defaults to not_checked" do
+    with_tenant(TENANT) do
+      check = build_check
+      assert_equal "not_checked", check.status
+    end
+  end
+
+  test "verify! transitions to enrolled or not_enrolled" do
+    with_tenant(TENANT) do
+      check = Corvid::AlternateResourceCheck.create!(
+        prc_referral: create_referral, resource_type: "medicare_a"
+      )
+      check.verify!
+      assert %w[enrolled not_enrolled].include?(check.status)
+    end
+  end
+
+  # -- Scopes -----------------------------------------------------------------
+
+  test "active_coverage scope" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      enrolled = Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicare_a", status: "enrolled"
+      )
+      not_enrolled = Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicare_b", status: "not_enrolled"
+      )
+
+      assert_includes Corvid::AlternateResourceCheck.active_coverage, enrolled
+      refute_includes Corvid::AlternateResourceCheck.active_coverage, not_enrolled
+    end
+  end
+
+  test "unavailable scope" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      denied = Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicaid", status: "denied"
+      )
+      enrolled = Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicare_a", status: "enrolled"
+      )
+
+      assert_includes Corvid::AlternateResourceCheck.unavailable, denied
+      refute_includes Corvid::AlternateResourceCheck.unavailable, enrolled
+    end
+  end
+
+  # -- Class methods ----------------------------------------------------------
+
+  test "all_exhausted? when all checks are unavailable" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicare_a", status: "not_enrolled"
+      )
+      Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicaid", status: "denied"
+      )
+
+      assert Corvid::AlternateResourceCheck.all_exhausted?(referral)
+    end
+  end
+
+  test "any_pending? when checks still pending" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      Corvid::AlternateResourceCheck.create!(
+        prc_referral: referral, resource_type: "medicare_a", status: "not_checked"
+      )
+
+      assert Corvid::AlternateResourceCheck.any_pending?(referral)
+    end
+  end
+
+  # -- Coordination -----------------------------------------------------------
+
+  test "requires_coordination? for enrolled federal resources" do
+    with_tenant(TENANT) do
+      check = Corvid::AlternateResourceCheck.create!(
+        prc_referral: create_referral, resource_type: "medicare_a", status: "enrolled"
+      )
+      assert check.requires_coordination?
+    end
+  end
+
+  private
+
+  def create_case
+    Corvid::Case.create!(
+      patient_identifier: "pt_arc_test",
+      lifecycle_status: "intake",
+      facility_identifier: "fac_test"
+    )
+  end
+
+  def create_referral
+    Corvid::PrcReferral.create!(case: create_case, referral_identifier: "ref_#{SecureRandom.hex(4)}")
+  end
+
+  def build_check(resource_type: "medicare_a")
+    Corvid::AlternateResourceCheck.new(
+      prc_referral: create_referral,
+      resource_type: resource_type
+    )
+  end
+end

--- a/test/models/corvid/billing_transaction_test.rb
+++ b/test/models/corvid/billing_transaction_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::BillingTransactionTest < ActiveSupport::TestCase
+  TENANT = "tnt_bt_test"
+
+  setup do
+    Corvid::BillingTransaction.unscoped.delete_all
+  end
+
+  test "log_transaction! creates a record" do
+    with_tenant(TENANT) do
+      tx = Corvid::BillingTransaction.log_transaction!(
+        tenant: TENANT, type: "eligibility", direction: "outbound",
+        status: "completed"
+      )
+      assert tx.persisted?
+      assert_equal "eligibility", tx.transaction_type
+      assert_equal "outbound", tx.direction
+    end
+  end
+
+  test "validates transaction_type" do
+    with_tenant(TENANT) do
+      tx = Corvid::BillingTransaction.new(transaction_type: "bogus", direction: "outbound")
+      refute tx.valid?
+    end
+  end
+
+  test "validates direction" do
+    with_tenant(TENANT) do
+      tx = Corvid::BillingTransaction.new(transaction_type: "eligibility", direction: "bogus")
+      refute tx.valid?
+    end
+  end
+
+  test "by_type scope" do
+    with_tenant(TENANT) do
+      elig = Corvid::BillingTransaction.log_transaction!(tenant: TENANT, type: "eligibility", direction: "outbound")
+      claim = Corvid::BillingTransaction.log_transaction!(tenant: TENANT, type: "claim", direction: "outbound")
+
+      assert_includes Corvid::BillingTransaction.by_type("eligibility"), elig
+      refute_includes Corvid::BillingTransaction.by_type("eligibility"), claim
+    end
+  end
+
+  test "recent scope orders by created_at desc" do
+    with_tenant(TENANT) do
+      old = Corvid::BillingTransaction.log_transaction!(tenant: TENANT, type: "eligibility", direction: "outbound")
+      new_tx = Corvid::BillingTransaction.log_transaction!(tenant: TENANT, type: "claim", direction: "outbound")
+
+      assert_equal new_tx, Corvid::BillingTransaction.recent.first
+    end
+  end
+end

--- a/test/models/corvid/claim_submission_test.rb
+++ b/test/models/corvid/claim_submission_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::ClaimSubmissionTest < ActiveSupport::TestCase
+  TENANT = "tnt_cs_test"
+
+  setup do
+    Corvid::ClaimSubmission.unscoped.delete_all
+  end
+
+  test "creates with required fields" do
+    with_tenant(TENANT) do
+      claim = Corvid::ClaimSubmission.create!(
+        patient_identifier: "pt_1",
+        claim_type: "professional",
+        service_date: Date.current,
+        billed_amount: 500.00
+      )
+      assert claim.persisted?
+      assert_equal "draft", claim.status
+    end
+  end
+
+  test "validates patient_identifier" do
+    with_tenant(TENANT) do
+      claim = Corvid::ClaimSubmission.new(claim_type: "professional")
+      refute claim.valid?
+    end
+  end
+
+  test "validates claim_type" do
+    with_tenant(TENANT) do
+      claim = Corvid::ClaimSubmission.new(patient_identifier: "pt_1", claim_type: "bogus")
+      refute claim.valid?
+    end
+  end
+
+  test "pending scope" do
+    with_tenant(TENANT) do
+      submitted = create_claim(status: "submitted")
+      paid = create_claim(status: "paid")
+
+      assert_includes Corvid::ClaimSubmission.pending, submitted
+      refute_includes Corvid::ClaimSubmission.pending, paid
+    end
+  end
+
+  test "paid scope" do
+    with_tenant(TENANT) do
+      paid = create_claim(status: "paid")
+      submitted = create_claim(status: "submitted")
+
+      assert_includes Corvid::ClaimSubmission.paid, paid
+      refute_includes Corvid::ClaimSubmission.paid, submitted
+    end
+  end
+
+  test "for_patient scope" do
+    with_tenant(TENANT) do
+      mine = create_claim(patient_identifier: "pt_1")
+      other = create_claim(patient_identifier: "pt_2")
+
+      assert_includes Corvid::ClaimSubmission.for_patient("pt_1"), mine
+      refute_includes Corvid::ClaimSubmission.for_patient("pt_1"), other
+    end
+  end
+
+  test "balance_due calculates remaining" do
+    with_tenant(TENANT) do
+      claim = create_claim(billed_amount: 500.0, paid_amount: 300.0, adjustment_amount: 50.0)
+      assert_in_delta 150.0, claim.balance_due
+    end
+  end
+
+  private
+
+  def create_claim(patient_identifier: "pt_cs", status: "submitted", **attrs)
+    Corvid::ClaimSubmission.create!(
+      patient_identifier: patient_identifier,
+      claim_type: "professional",
+      service_date: Date.current,
+      status: status,
+      billed_amount: attrs.delete(:billed_amount) || 100.0,
+      **attrs
+    )
+  end
+end

--- a/test/models/corvid/committee_review_test.rb
+++ b/test/models/corvid/committee_review_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::CommitteeReviewTest < ActiveSupport::TestCase
+  TENANT = "tnt_cr_test"
+
+  setup do
+    Corvid::CommitteeReview.unscoped.delete_all
+    Corvid::PrcReferral.unscoped.delete_all
+    Corvid::Case.unscoped.delete_all
+  end
+
+  # -- Creation ---------------------------------------------------------------
+
+  test "creates with referral and pending decision" do
+    with_tenant(TENANT) do
+      review = create_review
+      assert review.persisted?
+      assert review.pending?
+    end
+  end
+
+  test "defaults decision to pending" do
+    with_tenant(TENANT) do
+      review = create_review
+      assert_equal "pending", review.decision
+    end
+  end
+
+  # -- Decision transitions ---------------------------------------------------
+
+  test "can approve" do
+    with_tenant(TENANT) do
+      review = create_review
+      review.approved!
+      assert review.approved?
+    end
+  end
+
+  test "can deny" do
+    with_tenant(TENANT) do
+      review = create_review
+      review.denied!
+      assert review.denied?
+    end
+  end
+
+  test "can defer" do
+    with_tenant(TENANT) do
+      review = create_review
+      review.deferred!
+      assert review.deferred?
+    end
+  end
+
+  test "can modify" do
+    with_tenant(TENANT) do
+      review = create_review
+      review.modified!
+      assert review.modified?
+    end
+  end
+
+  # -- Predicates -------------------------------------------------------------
+
+  test "finalized? false when pending" do
+    with_tenant(TENANT) do
+      refute create_review.finalized?
+    end
+  end
+
+  test "finalized? true when approved" do
+    with_tenant(TENANT) do
+      review = create_review
+      review.approved!
+      assert review.finalized?
+    end
+  end
+
+  # -- Scopes -----------------------------------------------------------------
+
+  test "upcoming returns pending reviews with future date" do
+    with_tenant(TENANT) do
+      upcoming = create_review(committee_date: 1.week.from_now)
+      past = create_review(committee_date: 1.week.ago)
+
+      assert_includes Corvid::CommitteeReview.upcoming, upcoming
+      refute_includes Corvid::CommitteeReview.upcoming, past
+    end
+  end
+
+  test "finalized returns non-pending reviews" do
+    with_tenant(TENANT) do
+      pending_review = create_review
+      approved_review = create_review
+      approved_review.approved!
+
+      refute_includes Corvid::CommitteeReview.finalized, pending_review
+      assert_includes Corvid::CommitteeReview.finalized, approved_review
+    end
+  end
+
+  private
+
+  def create_case
+    Corvid::Case.create!(
+      patient_identifier: "pt_cr_test",
+      lifecycle_status: "intake",
+      facility_identifier: "fac_test"
+    )
+  end
+
+  def create_referral
+    Corvid::PrcReferral.create!(
+      case: create_case,
+      referral_identifier: "ref_#{SecureRandom.hex(4)}"
+    )
+  end
+
+  def create_review(committee_date: Date.current, **attrs)
+    Corvid::CommitteeReview.create!(
+      prc_referral: create_referral,
+      committee_date: committee_date,
+      **attrs
+    )
+  end
+end

--- a/test/models/corvid/determination_test.rb
+++ b/test/models/corvid/determination_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::DeterminationTest < ActiveSupport::TestCase
+  TENANT = "tnt_det_test"
+
+  setup do
+    Corvid::Determination.unscoped.delete_all
+    Corvid::PrcReferral.unscoped.delete_all
+    Corvid::Case.unscoped.delete_all
+  end
+
+  test "creates with polymorphic determinable" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      det = Corvid::Determination.create!(
+        determinable: referral,
+        decision_method: "staff_review",
+        outcome: "approved",
+        determined_by_identifier: "pr_001",
+        reasons_token: "tok_test"
+      )
+      assert det.persisted?
+      assert det.approved?
+    end
+  end
+
+  test "automated determination does not require determined_by" do
+    with_tenant(TENANT) do
+      det = Corvid::Determination.new(
+        determinable: create_referral,
+        decision_method: "automated",
+        outcome: "approved"
+      )
+      assert det.valid?
+    end
+  end
+
+  test "manual determination requires determined_by" do
+    with_tenant(TENANT) do
+      det = Corvid::Determination.new(
+        determinable: create_referral,
+        decision_method: "staff_review",
+        outcome: "approved",
+        determined_by_identifier: nil
+      )
+      refute det.valid?
+    end
+  end
+
+  test "outcome enum values" do
+    with_tenant(TENANT) do
+      referral = create_referral
+      %w[approved denied deferred].each do |outcome|
+        det = Corvid::Determination.create!(
+          determinable: referral,
+          decision_method: "automated",
+          outcome: outcome,
+          
+        )
+        assert det.send("#{outcome}?")
+      end
+    end
+  end
+
+  private
+
+  def create_referral
+    c = Corvid::Case.create!(patient_identifier: "pt_det", lifecycle_status: "intake", facility_identifier: "fac_test")
+    Corvid::PrcReferral.create!(case: c, referral_identifier: "ref_#{SecureRandom.hex(4)}")
+  end
+end

--- a/test/models/corvid/fee_schedule_test.rb
+++ b/test/models/corvid/fee_schedule_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::FeeScheduleTest < ActiveSupport::TestCase
+  TENANT = "tnt_fs_test"
+
+  setup do
+    Corvid::FeeSchedule.unscoped.delete_all
+  end
+
+  test "creates with name" do
+    with_tenant(TENANT) do
+      fs = Corvid::FeeSchedule.create!(
+        name: "Standard Sliding Fee",
+        facility_identifier: "fac_test",
+        program: "general",
+        active: true
+      )
+      assert fs.persisted?
+    end
+  end
+
+  test "requires name" do
+    with_tenant(TENANT) do
+      fs = Corvid::FeeSchedule.new(name: nil)
+      refute fs.valid?
+    end
+  end
+
+  test "current scope returns active schedules" do
+    with_tenant(TENANT) do
+      active = Corvid::FeeSchedule.create!(name: "Active", facility_identifier: "fac_test", active: true)
+      inactive = Corvid::FeeSchedule.create!(name: "Inactive", facility_identifier: "fac_test", active: false)
+
+      assert_includes Corvid::FeeSchedule.current, active
+      refute_includes Corvid::FeeSchedule.current, inactive
+    end
+  end
+end

--- a/test/models/corvid/task_test.rb
+++ b/test/models/corvid/task_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::TaskTest < ActiveSupport::TestCase
+  TENANT = "tnt_task_test"
+
+  setup do
+    Corvid::Task.unscoped.delete_all
+    Corvid::Case.unscoped.delete_all
+  end
+
+  # -- Creation ---------------------------------------------------------------
+
+  test "creates task with description" do
+    with_tenant(TENANT) do
+      task = create_task(description: "Follow up on lab results")
+      assert task.persisted?
+      assert_equal "Follow up on lab results", task.description
+    end
+  end
+
+  test "requires description" do
+    with_tenant(TENANT) do
+      task = Corvid::Task.new(taskable: create_case, description: nil)
+      refute task.valid?
+      assert task.errors[:description].any?
+    end
+  end
+
+  test "defaults to pending status" do
+    with_tenant(TENANT) do
+      assert create_task.pending?
+    end
+  end
+
+  test "defaults to routine priority" do
+    with_tenant(TENANT) do
+      assert create_task.priority_routine?
+    end
+  end
+
+  # -- Status transitions -----------------------------------------------------
+
+  test "can transition to in_progress" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.in_progress!
+      assert task.in_progress?
+    end
+  end
+
+  test "can transition to completed" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.completed!
+      assert task.completed?
+    end
+  end
+
+  test "can transition to cancelled" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.cancelled!
+      assert task.cancelled?
+    end
+  end
+
+  test "can transition to on_hold" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.on_hold!
+      assert task.on_hold?
+    end
+  end
+
+  # -- Assignment -------------------------------------------------------------
+
+  test "assign_to! sets assignee" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.assign_to!("pr_001")
+      assert_equal "pr_001", task.assignee_identifier
+    end
+  end
+
+  test "unassign! clears assignee" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.assign_to!("pr_001")
+      task.unassign!
+      assert_nil task.assignee_identifier
+    end
+  end
+
+  # -- Scopes -----------------------------------------------------------------
+
+  test "incomplete scope returns pending and in_progress" do
+    with_tenant(TENANT) do
+      pending_task = create_task(description: "Pending")
+      ip_task = create_task(description: "In progress")
+      ip_task.in_progress!
+      completed = create_task(description: "Done")
+      completed.completed!
+
+      incomplete = Corvid::Task.incomplete
+      assert_includes incomplete, pending_task
+      assert_includes incomplete, ip_task
+      refute_includes incomplete, completed
+    end
+  end
+
+  test "overdue scope returns incomplete tasks past due" do
+    with_tenant(TENANT) do
+      overdue = create_task(description: "Overdue", due_at: 1.day.ago)
+      future = create_task(description: "Future", due_at: 1.day.from_now)
+
+      assert_includes Corvid::Task.overdue, overdue
+      refute_includes Corvid::Task.overdue, future
+    end
+  end
+
+  test "unassigned scope" do
+    with_tenant(TENANT) do
+      unassigned = create_task(description: "No one")
+      assigned = create_task(description: "Someone")
+      assigned.assign_to!("pr_001")
+
+      assert_includes Corvid::Task.unassigned, unassigned
+      refute_includes Corvid::Task.unassigned, assigned
+    end
+  end
+
+  test "for_assignee scope" do
+    with_tenant(TENANT) do
+      task = create_task
+      task.assign_to!("pr_001")
+      other = create_task(description: "Other")
+      other.assign_to!("pr_002")
+
+      assert_includes Corvid::Task.for_assignee("pr_001"), task
+      refute_includes Corvid::Task.for_assignee("pr_001"), other
+    end
+  end
+
+  test "milestones scope returns tasks with milestone_key" do
+    with_tenant(TENANT) do
+      milestone = create_task(description: "Milestone", milestone_key: "initial_assessment")
+      regular = create_task(description: "Regular")
+
+      assert_includes Corvid::Task.milestones, milestone
+      refute_includes Corvid::Task.milestones, regular
+    end
+  end
+
+  # -- Predicates -------------------------------------------------------------
+
+  test "incomplete? returns true for pending and in_progress" do
+    with_tenant(TENANT) do
+      task = create_task
+      assert task.incomplete?
+
+      task.in_progress!
+      assert task.incomplete?
+
+      task.completed!
+      refute task.incomplete?
+    end
+  end
+
+  private
+
+  def create_case
+    Corvid::Case.create!(
+      patient_identifier: "pt_task_test",
+      lifecycle_status: "intake",
+      facility_identifier: "fac_test"
+    )
+  end
+
+  def create_task(description: "Test task", **attrs)
+    Corvid::Task.create!(
+      taskable: attrs.delete(:taskable) || create_case,
+      description: description,
+      **attrs
+    )
+  end
+end


### PR DESCRIPTION
## Summary
Port model-level unit tests from rpms_redux for 7 corvid models:

| Model | Tests | Issue |
|---|---|---|
| Task | 16 | #78 |
| AlternateResourceCheck | 10 | #70 |
| CommitteeReview | 10 | #74 |
| BillingTransaction | 5 | #71 |
| Determination | 4 | #75 |
| FeeSchedule | 3 | #76 |
| ClaimSubmission | 7 | #79 |
| **Total** | **55** | |

Closes #78, closes #70, closes #74, closes #71, closes #75, closes #76, closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)