### PR TITLE
Task milestone tests + close billing/model port issues

### DIFF
--- a/test/models/corvid/task_test.rb
+++ b/test/models/corvid/task_test.rb
@@ -512,6 +512,67 @@ class Corvid::TaskTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Required milestones scope ---------------------------------------------
+
+  test "required_milestones scope returns only required milestone tasks" do
+    with_tenant(TENANT) do
+      taskable = create_case
+      required = Corvid::Task.create!(
+        taskable: taskable, description: "HBIG",
+        milestone_key: "hbig", milestone_position: 1, required: true
+      )
+      optional = Corvid::Task.create!(
+        taskable: taskable, description: "Dose 2",
+        milestone_key: "dose_2", milestone_position: 2, required: false
+      )
+
+      results = Corvid::Task.required_milestones
+      assert_includes results, required
+      refute_includes results, optional
+    end
+  end
+
+  # -- Milestone key uniqueness ----------------------------------------------
+
+  test "milestone_key is unique per taskable" do
+    with_tenant(TENANT) do
+      taskable = create_case
+      Corvid::Task.create!(
+        taskable: taskable, description: "First",
+        milestone_key: "hbig", milestone_position: 1
+      )
+
+      duplicate = Corvid::Task.new(
+        taskable: taskable, description: "Duplicate",
+        milestone_key: "hbig", milestone_position: 1
+      )
+      assert_raises(ActiveRecord::RecordNotUnique) { duplicate.save! }
+    end
+  end
+
+  test "same milestone_key allowed on different taskables" do
+    with_tenant(TENANT) do
+      case1 = create_case
+      case2 = Corvid::Case.create!(
+        patient_identifier: "pt_task_test_2",
+        lifecycle_status: "intake",
+        facility_identifier: "fac_test"
+      )
+
+      t1 = Corvid::Task.create!(
+        taskable: case1, description: "HBIG",
+        milestone_key: "hbig", milestone_position: 1
+      )
+      t2 = Corvid::Task.create!(
+        taskable: case2, description: "HBIG",
+        milestone_key: "hbig", milestone_position: 1
+      )
+
+      assert t1.persisted?
+      assert t2.persisted?
+    end
+  end
+
   # -- Priority ---------------------------------------------------------------
 
   test "can set urgent priority" do


### PR DESCRIPTION
## Summary

- Add 3 missing task milestone tests: `required_milestones` scope, milestone_key uniqueness per taskable, same key across different taskables
- Closes #124 — billing BDD scenarios already fully ported (69 scenarios in corvid vs 49 in rpms_redux)
- Closes #126 — task milestone gaps filled (+3 tests); patient_care_team belongs in lakeraven-ehr, not corvid

## Analysis

**#124 (Billing BDD):** Corvid already has 69 billing scenarios across 6 features (claims_submission 12, claim_status 16, remittance 21, payment 8, article6 5, sliding_fee_scale 7) — these match or exceed the 49 rpms_redux clearinghouse_* scenarios with vendor-neutral naming already applied.

**#126 (Model tests):**
- `task_milestone_test.rb` (7 tests): 4 already covered in corvid's 62-test task_test.rb, 3 added here
- `patient_care_team_test.rb` (17 tests): Tests rpms_redux's ActiveModel `PatientCareTeam` with US Core FHIR serialization — this is EHR-layer, not corvid scope. Corvid's `CareTeam` is an AR model with different semantics.

## Test plan

- [x] `bundle exec rake test` — 582 runs, 0 failures
- [x] `bundle exec cucumber` — 315 scenarios, 315 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)