### PR TITLE
Remove unused minitest/mock require

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,6 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "dummy/config/environment"
 require "rails/test_help"
-require "minitest/mock"
 
 # Reset state between tests
 module ActiveSupport


### PR DESCRIPTION
Extracted to separate gem in Minitest 6. Not used — adapter tests use DI, not Minitest::Mock.

## Test plan
- [x] 582 minitest, 315 cucumber — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)