### PR TITLE
Fix committee review sync tests using instance_variable_get

### DIFF
--- a/test/services/corvid/committee_review_sync_service_test.rb
+++ b/test/services/corvid/committee_review_sync_service_test.rb
@@ -203,8 +203,6 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
         { "condition" => "Pre-auth from Medicare", "required" => true }
       ]
       token = Corvid.adapter.store_text(case_token: "ct_test", kind: :conditions, text: conditions)
-      # Store as array in mock so fetch_text returns it
-      Corvid.adapter.instance_variable_get(:@text_store)[token] = conditions
 
       review = Corvid::CommitteeReview.create!(
         prc_referral: referral, committee_date: Date.current,
@@ -229,7 +227,6 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
         { "name" => "Jane Johnson", "role" => "Care Manager" }
       ]
       token = Corvid.adapter.store_text(case_token: "ct_test", kind: :attendees, text: attendees)
-      Corvid.adapter.instance_variable_get(:@text_store)[token] = attendees
 
       review = Corvid::CommitteeReview.create!(
         prc_referral: referral, committee_date: Date.current,


### PR DESCRIPTION
Closes #134

Remove redundant `@text_store` mutation via `instance_variable_get`. 
`store_text` already stores the data at the returned token — the 
extra line was a no-op that coupled tests to adapter internals.

## Test plan
- [x] All 582 minitest pass
- [x] All BDD scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)