### PR TITLE
Remove RPMS-specific strings from engine code

### DIFF
--- a/app/models/corvid/care_team.rb
+++ b/app/models/corvid/care_team.rb
@@ -49,8 +49,8 @@ module Corvid
     end
 
     # Adapter-sourced care team for an external patient identifier.
-    # NOT an AR scope — this resolves the EHR-owned care team (e.g. RPMS
-    # Patient Care Team) via Corvid.adapter.get_care_team, which returns
+    # NOT an AR scope — this resolves the EHR-owned care team via
+    # Corvid.adapter.get_care_team, which returns
     # a plain data structure (array of CareTeamMemberReference), not
     # CareTeam AR rows. Engine-owned care teams are accessed through
     # the usual .where / instance methods.

--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -13,7 +13,7 @@ module Corvid
     include Determinable
     include AASM
 
-    # CHS approval status codes (RPMS File 90001 field 1112).
+    # CHS approval status codes for EHR sync.
     # Engine-owned mapping — no dependency on EHR-side constants.
     CHS_STATUS_MAP = { "authorized" => "A", "denied" => "D" }.freeze
     CHS_STATUS_DEFAULT = "P"

--- a/app/services/corvid/committee_review_sync_service.rb
+++ b/app/services/corvid/committee_review_sync_service.rb
@@ -17,7 +17,7 @@ module Corvid
         if success
           build_success_result(committee_review)
         else
-          { success: false, error: "RPMS update failed" }
+          { success: false, error: "Backend update failed" }
         end
       rescue => e
         { success: false, error: Corvid.sanitize_phi(e.message) }
@@ -25,7 +25,7 @@ module Corvid
 
       def sync_and_apply!(committee_review)
         sync_result = sync_decision(committee_review)
-        rpms_synced = sync_result[:success]
+        backend_synced = sync_result[:success]
 
         referral_updated = false
         begin
@@ -36,10 +36,10 @@ module Corvid
         end
 
         {
-          success: rpms_synced && referral_updated,
-          rpms_synced: rpms_synced,
+          success: backend_synced && referral_updated,
+          backend_synced: backend_synced,
           referral_updated: referral_updated,
-          sync_pending: !rpms_synced
+          sync_pending: !backend_synced
         }
       end
 
@@ -75,13 +75,13 @@ module Corvid
 
         case committee_review.decision
         when "approved", "modified"
-          result[:rpms_status] = "AUTHORIZED"
+          result[:backend_status] = "AUTHORIZED"
           result[:synced_amount] = committee_review.approved_amount
         when "denied"
-          result[:rpms_status] = "DENIED"
+          result[:backend_status] = "DENIED"
           result[:denial_reason] = Corvid.adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
         when "deferred"
-          result[:rpms_status] = "PENDING"
+          result[:backend_status] = "PENDING"
           result[:defer_reason] = Corvid.adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
         end
 

--- a/test/models/corvid/committee_threshold_test.rb
+++ b/test/models/corvid/committee_threshold_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Corvid
+  class CommitteeThresholdTest < ActiveSupport::TestCase
+    TENANT = "tnt_threshold"
+    FACILITY = "fac_threshold"
+
+    # -- Cost boundary tests --
+
+    test "cost at threshold requires committee" do
+      with_tenant(TENANT) { assert build_referral(estimated_cost: 50_000).requires_committee? }
+    end
+
+    test "cost below threshold does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: 49_999.99).requires_committee? }
+    end
+
+    test "cost above threshold requires committee" do
+      with_tenant(TENANT) { assert build_referral(estimated_cost: 50_000.01).requires_committee? }
+    end
+
+    test "zero cost does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: 0).requires_committee? }
+    end
+
+    test "nil cost does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: nil).requires_committee? }
+    end
+
+    # -- Priority tests --
+
+    test "priority 3 requires committee" do
+      with_tenant(TENANT) { assert build_referral(estimated_cost: 100, medical_priority: 3).requires_committee? }
+    end
+
+    test "priority 2 does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: 100, medical_priority: 2).requires_committee? }
+    end
+
+    test "priority 4 requires committee" do
+      with_tenant(TENANT) { assert build_referral(estimated_cost: 100, medical_priority: 4).requires_committee? }
+    end
+
+    test "nil priority does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: 100, medical_priority: nil).requires_committee? }
+    end
+
+    # -- Flag tests --
+
+    test "flagged referral requires committee regardless of cost" do
+      with_tenant(TENANT) { assert build_referral(estimated_cost: 100, flagged_for_review: true).requires_committee? }
+    end
+
+    test "unflagged low-cost referral does not require committee" do
+      with_tenant(TENANT) { refute build_referral(estimated_cost: 100, flagged_for_review: false).requires_committee? }
+    end
+
+    # -- Parity with CommitteeReview class method --
+
+    test "class method agrees with instance method at threshold" do
+      with_tenant(TENANT) do
+        r = build_referral(estimated_cost: 50_000)
+        assert_equal r.requires_committee?, CommitteeReview.requires_committee_review?(r)
+      end
+    end
+
+    test "class method agrees with instance method below threshold" do
+      with_tenant(TENANT) do
+        r = build_referral(estimated_cost: 49_999)
+        assert_equal r.requires_committee?, CommitteeReview.requires_committee_review?(r)
+      end
+    end
+
+    test "class method agrees for high priority" do
+      with_tenant(TENANT) do
+        r = build_referral(estimated_cost: 100, medical_priority: 3)
+        assert_equal r.requires_committee?, CommitteeReview.requires_committee_review?(r)
+      end
+    end
+
+    private
+
+    def build_referral(estimated_cost: nil, medical_priority: nil, flagged_for_review: false)
+      kase = Case.create!(patient_identifier: "pt_thr", facility_identifier: FACILITY)
+      PrcReferral.create!(
+        case: kase,
+        referral_identifier: "rf_#{SecureRandom.hex(4)}",
+        facility_identifier: FACILITY,
+        estimated_cost: estimated_cost,
+        medical_priority: medical_priority,
+        flagged_for_review: flagged_for_review
+      )
+    end
+  end
+end

--- a/test/models/corvid/denial_pathway_test.rb
+++ b/test/models/corvid/denial_pathway_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Corvid
+  class DenialPathwayTest < ActiveSupport::TestCase
+    TENANT = "tnt_deny"
+    FACILITY = "fac_deny"
+
+    setup do
+      Corvid.adapter.reset! if Corvid.adapter.respond_to?(:reset!)
+    end
+
+    # -- Denial from eligibility_review --
+
+    test "denied from eligibility_review" do
+      with_tenant(TENANT) do
+        r = referral_in(:eligibility_review)
+        r.mark_denied!
+        assert_equal "denied", r.status
+      end
+    end
+
+    test "denied referral cannot be authorized" do
+      with_tenant(TENANT) do
+        r = referral_in(:eligibility_review)
+        r.mark_denied!
+        refute r.may_authorize?
+      end
+    end
+
+    # -- Deferral from priority_assignment --
+
+    test "deferred from priority_assignment" do
+      with_tenant(TENANT) do
+        r = referral_in(:priority_assignment)
+        r.mark_deferred!
+        assert_equal "deferred", r.status
+      end
+    end
+
+    test "deferred referral cannot be authorized" do
+      with_tenant(TENANT) do
+        r = referral_in(:priority_assignment)
+        r.mark_deferred!
+        refute r.may_authorize?
+      end
+    end
+
+    # -- Distinct outcomes --
+
+    test "denied and deferred are distinct states" do
+      with_tenant(TENANT) do
+        denied = referral_in(:eligibility_review)
+        denied.mark_denied!
+        deferred = referral_in(:priority_assignment)
+        deferred.mark_deferred!
+        refute_equal denied.status, deferred.status
+      end
+    end
+
+    test "CHS status map: authorized=A denied=D deferred=nil" do
+      assert_equal "A", PrcReferral::CHS_STATUS_MAP["authorized"]
+      assert_equal "D", PrcReferral::CHS_STATUS_MAP["denied"]
+      assert_nil PrcReferral::CHS_STATUS_MAP["deferred"]
+    end
+
+    # -- Cancellation --
+
+    test "draft can be cancelled" do
+      with_tenant(TENANT) do
+        r = create_referral
+        r.cancel!
+        assert_equal "cancelled", r.status
+        refute r.may_submit?
+      end
+    end
+
+    private
+
+    def create_referral
+      kase = Case.create!(patient_identifier: "pt_deny", facility_identifier: FACILITY)
+      PrcReferral.create!(
+        case: kase,
+        referral_identifier: "rf_#{SecureRandom.hex(4)}",
+        facility_identifier: FACILITY,
+        estimated_cost: 5_000
+      )
+    end
+
+    def referral_in(target)
+      r = create_referral
+      seed_adapter(r)
+
+      r.submit!
+      return r if target == :submitted
+
+      r.begin_eligibility_review!
+      return r if target == :eligibility_review
+
+      # eligibility_review → management_approval → alternate_resource_review → priority_assignment
+      complete_non_approval_checklist!(r)
+      r.request_management_approval!
+      return r if target == :management_approval
+
+      r.pending_approval_by = "pr_mgr"
+      r.approve_management!
+      return r if target == :alternate_resource_review
+
+      r.verify_alternate_resources!
+      return r if target == :priority_assignment
+
+      r
+    end
+
+    def complete_non_approval_checklist!(referral)
+      checklist = referral.eligibility_checklist || referral.create_eligibility_checklist!(
+        tenant_identifier: referral.tenant_identifier,
+        facility_identifier: referral.facility_identifier
+      )
+
+      checklist.verify_item!(:application_complete, by: "clerk_1")
+      checklist.verify_item!(:identity_verified, source: "manual")
+      checklist.verify_item!(:insurance_verified, source: "manual")
+      checklist.verify_item!(:residency_verified, source: "manual")
+      checklist.verify_item!(:enrollment_verified, source: "manual")
+      checklist.verify_item!(:clinical_necessity_documented, source: "manual")
+    end
+
+    def seed_adapter(referral)
+      Corvid.adapter.add_referral(referral.referral_identifier,
+        patient_identifier: "pt_deny", status: "pending",
+        estimated_cost: 5_000, emergent: false, urgent: false,
+        chs_approval_status: "P", service_requested: "TEST")
+    end
+  end
+end

--- a/test/services/corvid/committee_review_sync_service_test.rb
+++ b/test/services/corvid/committee_review_sync_service_test.rb
@@ -36,7 +36,7 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
       result = Corvid::CommitteeReviewSyncService.sync_decision(review)
 
       assert result[:success]
-      assert_equal "AUTHORIZED", result[:rpms_status]
+      assert_equal "AUTHORIZED", result[:backend_status]
     end
   end
 
@@ -68,7 +68,7 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
       result = Corvid::CommitteeReviewSyncService.sync_decision(review)
 
       assert result[:success]
-      assert_equal "DENIED", result[:rpms_status]
+      assert_equal "DENIED", result[:backend_status]
     end
   end
 
@@ -90,7 +90,7 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
       result = Corvid::CommitteeReviewSyncService.sync_decision(review)
 
       assert result[:success]
-      assert_equal "PENDING", result[:rpms_status]
+      assert_equal "PENDING", result[:backend_status]
     end
   end
 
@@ -119,7 +119,7 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
       result = Corvid::CommitteeReviewSyncService.sync_decision(review)
 
       assert result[:success]
-      assert_equal "AUTHORIZED", result[:rpms_status]
+      assert_equal "AUTHORIZED", result[:backend_status]
       assert_equal 75_000, result[:synced_amount]
     end
   end
@@ -180,7 +180,7 @@ class Corvid::CommitteeReviewSyncServiceTest < ActiveSupport::TestCase
       review = create_approved_review
       result = Corvid::CommitteeReviewSyncService.sync_and_apply!(review)
 
-      assert result[:rpms_synced]
+      assert result[:backend_synced]
       assert result[:referral_updated]
     end
   end


### PR DESCRIPTION
Closes #221

Rename rpms_synced → backend_synced, rpms_status → backend_status
in CommitteeReviewSyncService. Remove RPMS references from model
comments. Engine stays EHR-agnostic.

## Test plan
- [x] All 582 minitest pass
- [x] All 339 BDD scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)