### PR TITLE
Move program identity from Case to CaseProgram

### DIFF
--- a/app/models/corvid/case.rb
+++ b/app/models/corvid/case.rb
@@ -23,10 +23,11 @@ module Corvid
     LIFECYCLE_STATUSES = %w[intake active_followup closure closed].freeze
 
     validates :patient_identifier, presence: true
-    validate :program_type_in_registry, if: -> { program_type.present? }
     validates :lifecycle_status, inclusion: { in: LIFECYCLE_STATUSES }
 
-    scope :for_program, ->(type) { where(program_type: type) }
+    scope :for_program, lambda { |code|
+      joins(:case_programs).where(corvid_case_programs: { program_code: code })
+    }
     scope :in_lifecycle, ->(status) { where(lifecycle_status: status) }
 
     # Resolve patient via adapter. Returns a Corvid::PatientReference or nil.
@@ -51,15 +52,7 @@ module Corvid
     end
 
     def program_case?
-      program_type.present?
-    end
-
-    private
-
-    def program_type_in_registry
-      return if Corvid::ProgramRegistry.exists?(program_type)
-
-      errors.add(:program_type, "is not a registered program")
+      case_programs.exists?
     end
   end
 end

--- a/app/models/corvid/case_program.rb
+++ b/app/models/corvid/case_program.rb
@@ -20,6 +20,7 @@ module Corvid
     validates :program_name, presence: true
     validates :program_code, presence: true
     validates :program_code, uniqueness: { scope: :case_id }
+    validate :program_code_in_registry, if: -> { program_code.present? }
     validates :enrollment_date, presence: true
     validate :disenrollment_after_enrollment, if: -> { disenrollment_date.present? && enrollment_date.present? }
 
@@ -45,6 +46,12 @@ module Corvid
       return unless disenrollment_date < enrollment_date
 
       errors.add(:disenrollment_date, "must be on or after enrollment date")
+    end
+
+    def program_code_in_registry
+      return if Corvid::ProgramRegistry.exists?(program_code)
+
+      errors.add(:program_code, "is not a registered program")
     end
   end
 end

--- a/app/services/corvid/program_case_audit_service.rb
+++ b/app/services/corvid/program_case_audit_service.rb
@@ -37,7 +37,7 @@ module Corvid
 
       def program_compliance_summary(program_type:, facility_identifier: nil, facility: nil)
         fac_id = facility_identifier || facility&.id&.to_s
-        cases = Corvid::Case.where(program_type: program_type)
+        cases = Corvid::Case.for_program(program_type)
         cases = cases.for_facility(fac_id) if fac_id.present?
         case_ids = cases.pluck(:id)
 

--- a/app/services/corvid/program_template_service.rb
+++ b/app/services/corvid/program_template_service.rb
@@ -19,16 +19,26 @@ module Corvid
           )
         end
 
-        kase = Corvid::Case.create!(
-          patient_identifier: patient_identifier,
-          facility_identifier: facility_identifier,
-          program_type: program_type,
-          lifecycle_status: "intake",
-          intake_at: Time.current,
-          program_data_token: program_data_token
-        )
-
         anchor = anchor_date || Date.current
+        program = Corvid::ProgramRegistry.find(program_type)
+
+        kase = Corvid::Case.transaction do
+          k = Corvid::Case.create!(
+            patient_identifier: patient_identifier,
+            facility_identifier: facility_identifier,
+            lifecycle_status: "intake",
+            intake_at: Time.current,
+            program_data_token: program_data_token
+          )
+          Corvid::CaseProgram.create!(
+            case: k,
+            program_code: program_type,
+            program_name: program&.display_name || program_type,
+            enrollment_date: anchor
+          )
+          k
+        end
+
         create_milestones(kase, program_type, anchor)
         record_provenance(kase)
         kase
@@ -52,14 +62,16 @@ module Corvid
       end
 
       def overdue_milestones_by_program(facility_identifier:)
-        cases = Corvid::Case.for_facility(facility_identifier).where.not(program_type: nil)
+        cases = Corvid::Case.for_facility(facility_identifier).joins(:case_programs).distinct
         case_ids = cases.pluck(:id)
 
         overdue_tasks = Corvid::Task.where(taskable_type: "Corvid::Case", taskable_id: case_ids)
                                     .milestones
                                     .overdue
 
-        overdue_tasks.includes(:taskable).group_by { |t| t.taskable.program_type }
+        overdue_tasks.includes(taskable: :case_programs).group_by do |t|
+          t.taskable.case_programs.first&.program_code
+        end
       end
 
       private

--- a/db/migrate/20260506000001_move_program_type_to_case_programs.rb
+++ b/db/migrate/20260506000001_move_program_type_to_case_programs.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class MoveProgramTypeToCasePrograms < ActiveRecord::Migration[8.1]
+  def up
+    backfill_case_programs!
+
+    remove_index :corvid_cases, %i[tenant_identifier program_type],
+                 if_exists: true
+    remove_column :corvid_cases, :program_type
+  end
+
+  def down
+    add_column :corvid_cases, :program_type, :string
+    add_index :corvid_cases, %i[tenant_identifier program_type]
+
+    Corvid::Case.reset_column_information
+    Corvid::Case.unscoped.find_each do |kase|
+      cp = Corvid::CaseProgram.unscoped.where(case_id: kase.id).first
+      next unless cp
+
+      kase.update_column(:program_type, cp.program_code)
+    end
+  end
+
+  private
+
+  # For each case with a program_type set, ensure a corresponding CaseProgram
+  # row exists. Idempotent: skips when a row already exists for the same
+  # case + program_code.
+  def backfill_case_programs!
+    return unless column_exists?(:corvid_cases, :program_type)
+
+    Corvid::Case.reset_column_information
+    Corvid::Case.unscoped.where.not(program_type: nil).find_each do |kase|
+      next if Corvid::CaseProgram.unscoped
+                                 .where(case_id: kase.id, program_code: kase.program_type)
+                                 .exists?
+
+      Corvid::CaseProgram.unscoped.create!(
+        case_id: kase.id,
+        tenant_identifier: kase.tenant_identifier,
+        facility_identifier: kase.facility_identifier,
+        program_code: kase.program_type,
+        program_name: registry_display_name(kase.program_type),
+        enrollment_date: kase.intake_at&.to_date || kase.created_at.to_date,
+        enrollment_status: 'active'
+      )
+    end
+  end
+
+  def registry_display_name(code)
+    Corvid::ProgramRegistry.find(code)&.display_name || code
+  end
+end

--- a/features/step_definitions/program_registry_steps.rb
+++ b/features/step_definitions/program_registry_steps.rb
@@ -32,15 +32,18 @@ Then("the case should have milestones {string}") do |comma_list|
 end
 
 When("I try to create a case with program type {string}") do |program_code|
-  @attempted_case = Corvid::Case.new(
-    patient_identifier: "pt_invalid",
-    program_type: program_code
+  kase = Corvid::Case.create!(patient_identifier: "pt_invalid")
+  @attempted_case_program = Corvid::CaseProgram.new(
+    case: kase,
+    program_name: program_code,
+    program_code: program_code,
+    enrollment_date: Date.current
   )
-  @attempted_case.valid?
+  @attempted_case_program.valid?
 end
 
 Then("the case should be invalid with a program_type error") do
-  refute @attempted_case.valid?, "expected case to be invalid"
-  assert @attempted_case.errors[:program_type].any?,
-         "expected program_type validation error, got: #{@attempted_case.errors.full_messages.inspect}"
+  refute @attempted_case_program.valid?, "expected case_program to be invalid"
+  assert @attempted_case_program.errors[:program_code].any?,
+         "expected program_code validation error, got: #{@attempted_case_program.errors.full_messages.inspect}"
 end

--- a/features/step_definitions/public_health_case_tracking_steps.rb
+++ b/features/step_definitions/public_health_case_tracking_steps.rb
@@ -46,7 +46,7 @@ When("I request the audit timeline") do
 end
 
 Then("a program case should exist for patient {string} with type {string}") do |patient_id, type|
-  kase = Corvid::Case.find_by(patient_identifier: patient_id, program_type: type)
+  kase = Corvid::Case.for_program(type).find_by(patient_identifier: patient_id)
   refute_nil kase
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,6 +35,7 @@ def clean_corvid_tables!
   Corvid::CommitteeReview.unscoped.delete_all
   Corvid::Task.unscoped.delete_all
   Corvid::PrcReferral.unscoped.delete_all
+  Corvid::CaseProgram.unscoped.delete_all
   Corvid::Case.unscoped.delete_all
   Corvid::CareTeamMember.unscoped.delete_all
   Corvid::CareTeam.unscoped.delete_all

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -127,13 +127,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_000001) do
     t.string "patient_identifier", null: false
     t.string "patient_name_cached"
     t.string "program_data_token"
-    t.string "program_type"
     t.string "status", default: "active", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
-    t.index ["tenant_identifier", "program_type"], name: "index_corvid_cases_on_tenant_identifier_and_program_type"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
     t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"

--- a/test/models/corvid/case_program_test.rb
+++ b/test/models/corvid/case_program_test.rb
@@ -26,7 +26,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
 
   test "requires program_name" do
     with_tenant(TENANT) do
-      cp = Corvid::CaseProgram.new(case: create_case, program_name: nil, program_code: "CHS")
+      cp = Corvid::CaseProgram.new(case: create_case, program_name: nil, program_code: "tb")
       refute cp.valid?
       assert cp.errors[:program_name].any?
     end
@@ -45,7 +45,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
       assert_raises(ArgumentError) do
         Corvid::CaseProgram.new(
           case: create_case, program_name: "IHS CHS",
-          program_code: "CHS", enrollment_status: "bogus"
+          program_code: "tb", enrollment_status: "bogus"
         )
       end
     end
@@ -54,7 +54,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
   test "requires enrollment_date" do
     with_tenant(TENANT) do
       cp = Corvid::CaseProgram.new(
-        case: create_case, program_name: "Medicare", program_code: "MCR",
+        case: create_case, program_name: "Medicare", program_code: "hep_b",
         enrollment_date: nil
       )
       refute cp.valid?
@@ -66,11 +66,11 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
     with_tenant(TENANT) do
       kase = create_case
       Corvid::CaseProgram.create!(
-        case: kase, program_name: "IHS CHS", program_code: "CHS",
+        case: kase, program_name: "IHS CHS", program_code: "tb",
         enrollment_date: Date.current
       )
       dup = Corvid::CaseProgram.new(
-        case: kase, program_name: "IHS CHS", program_code: "CHS",
+        case: kase, program_name: "IHS CHS", program_code: "tb",
         enrollment_date: Date.current
       )
       refute dup.valid?
@@ -82,8 +82,8 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
     with_tenant(TENANT) do
       c1 = create_case
       c2 = create_case
-      Corvid::CaseProgram.create!(case: c1, program_name: "CHS", program_code: "CHS", enrollment_date: Date.current)
-      cp2 = Corvid::CaseProgram.new(case: c2, program_name: "CHS", program_code: "CHS", enrollment_date: Date.current)
+      Corvid::CaseProgram.create!(case: c1, program_name: "CHS", program_code: "tb", enrollment_date: Date.current)
+      cp2 = Corvid::CaseProgram.new(case: c2, program_name: "CHS", program_code: "tb", enrollment_date: Date.current)
       assert cp2.valid?
     end
   end
@@ -91,7 +91,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
   test "disenrollment_date must be on or after enrollment_date" do
     with_tenant(TENANT) do
       cp = Corvid::CaseProgram.new(
-        case: create_case, program_name: "Medicare", program_code: "MCR",
+        case: create_case, program_name: "Medicare", program_code: "hep_b",
         enrollment_date: Date.current, disenrollment_date: 1.day.ago.to_date
       )
       refute cp.valid?
@@ -102,7 +102,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
   test "disenrollment_date on enrollment_date is valid" do
     with_tenant(TENANT) do
       cp = Corvid::CaseProgram.new(
-        case: create_case, program_name: "Medicare", program_code: "MCR",
+        case: create_case, program_name: "Medicare", program_code: "hep_b",
         enrollment_date: Date.current, disenrollment_date: Date.current
       )
       assert cp.valid?
@@ -128,7 +128,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
   test "active_enrollment scope" do
     with_tenant(TENANT) do
       active = create_case_program(enrollment_status: "active")
-      inactive = create_case_program(program_code: "MCR", enrollment_status: "inactive")
+      inactive = create_case_program(program_code: "hep_b", enrollment_status: "inactive")
 
       assert_includes Corvid::CaseProgram.active_enrollment, active
       refute_includes Corvid::CaseProgram.active_enrollment, inactive
@@ -137,10 +137,10 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
 
   test "for_program scope filters by program_code" do
     with_tenant(TENANT) do
-      chs = create_case_program(program_code: "CHS")
-      mcr = create_case_program(program_code: "MCR")
+      chs = create_case_program(program_code: "tb")
+      mcr = create_case_program(program_code: "hep_b")
 
-      results = Corvid::CaseProgram.for_program("CHS")
+      results = Corvid::CaseProgram.for_program("tb")
       assert_includes results, chs
       refute_includes results, mcr
     end
@@ -150,7 +150,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
     with_tenant(TENANT) do
       current = create_case_program(enrollment_status: "active", disenrollment_date: nil)
       disenrolled = create_case_program(
-        program_code: "MCR", enrollment_status: "active",
+        program_code: "hep_b", enrollment_status: "active",
         enrollment_date: 1.month.ago.to_date,
         disenrollment_date: 1.day.ago.to_date
       )
@@ -215,6 +215,48 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
     end
   end
 
+  # -- ProgramRegistry validation --------------------------------------------
+  #
+  # program_code must be registered. This validation moved here from Case
+  # in #260 so program identity lives on the enrollment, not the person.
+
+  test "program_code validates against ProgramRegistry" do
+    with_tenant(TENANT) do
+      cp = Corvid::CaseProgram.new(
+        case: create_case, program_name: "Bogus", program_code: "not_a_program",
+        enrollment_date: Date.current
+      )
+      refute cp.valid?
+      assert cp.errors[:program_code].any?,
+             "expected program_code validation error, got: #{cp.errors.full_messages.inspect}"
+    end
+  end
+
+  test "program_code permits any code registered with ProgramRegistry" do
+    Corvid::ProgramRegistry.register("custom_test_program", display_name: "Custom Test", milestones: [])
+    with_tenant(TENANT) do
+      cp = Corvid::CaseProgram.new(
+        case: create_case, program_name: "Custom Test", program_code: "custom_test_program",
+        enrollment_date: Date.current
+      )
+      assert cp.valid?, "expected case_program with registered program to be valid: #{cp.errors.full_messages.inspect}"
+    end
+  ensure
+    Corvid::ProgramRegistry.reset!
+  end
+
+  test "all built-in IHS programs validate" do
+    %w[immunization sti tb neonatal lead hep_b communicable_disease].each do |code|
+      with_tenant(TENANT) do
+        cp = Corvid::CaseProgram.new(
+          case: create_case, program_name: code.titleize, program_code: code,
+          enrollment_date: Date.current
+        )
+        assert cp.valid?, "expected built-in program #{code} to validate: #{cp.errors.full_messages.inspect}"
+      end
+    end
+  end
+
   # -- TenantScoped ----------------------------------------------------------
 
   test "case programs are scoped to current tenant" do
@@ -247,7 +289,7 @@ class Corvid::CaseProgramTest < ActiveSupport::TestCase
     )
   end
 
-  def create_case_program(program_name: "IHS CHS", program_code: "CHS", enrollment_status: "active", **attrs)
+  def create_case_program(program_name: "IHS CHS", program_code: "tb", enrollment_status: "active", **attrs)
     Corvid::CaseProgram.create!(
       case: attrs.delete(:case) || create_case,
       program_name: program_name,

--- a/test/models/corvid/case_test.rb
+++ b/test/models/corvid/case_test.rb
@@ -177,55 +177,47 @@ class Corvid::CaseTest < ActiveSupport::TestCase
   end
 
   # -- program_case? ---------------------------------------------------------
+  #
+  # Program identity lives on CaseProgram, not on Case. A Case is a person's
+  # workflow record; CaseProgram is the enrollment in a specific program.
 
-  test "program_case? returns true when program_type present" do
+  test "program_case? returns true when a CaseProgram is associated" do
     with_tenant(TEST_TENANT) do
-      kase = Corvid::Case.create!(patient_identifier: "pt_prog", program_type: "hep_b")
+      kase = Corvid::Case.create!(patient_identifier: "pt_prog")
+      Corvid::CaseProgram.create!(
+        case: kase, program_name: "Hepatitis B Perinatal", program_code: "hep_b",
+        enrollment_date: Date.current
+      )
       assert kase.program_case?
     end
   end
 
-  test "program_case? returns false when no program_type" do
+  test "program_case? returns false when no CaseProgram is associated" do
     with_tenant(TEST_TENANT) do
       kase = Corvid::Case.create!(patient_identifier: "pt_no_prog")
       refute kase.program_case?
     end
   end
 
-  # -- program_type validation against registry ------------------------------
-
-  test "program_type validates against ProgramRegistry" do
-    with_tenant(TEST_TENANT) do
-      kase = Corvid::Case.new(patient_identifier: "pt_invalid", program_type: "not_a_program")
-      refute kase.valid?
-      assert kase.errors[:program_type].any?,
-             "expected program_type validation error, got: #{kase.errors.full_messages.inspect}"
-    end
+  test "program_type column has been removed from corvid_cases" do
+    refute_includes Corvid::Case.column_names, "program_type",
+                    "program_type semantics moved to CaseProgram in #260"
   end
 
-  test "program_type permits any code registered with ProgramRegistry" do
-    Corvid::ProgramRegistry.register("custom_test_program", display_name: "Custom Test", milestones: [])
-    with_tenant(TEST_TENANT) do
-      kase = Corvid::Case.new(patient_identifier: "pt_custom", program_type: "custom_test_program")
-      assert kase.valid?, "expected case with registered program to be valid: #{kase.errors.full_messages.inspect}"
-    end
-  ensure
-    Corvid::ProgramRegistry.reset!
-  end
+  # -- for_program scope ------------------------------------------------------
 
-  test "program_type permits nil" do
+  test "for_program scope returns cases enrolled in the given program" do
     with_tenant(TEST_TENANT) do
-      kase = Corvid::Case.new(patient_identifier: "pt_nil_prog")
-      assert kase.valid?
-    end
-  end
+      enrolled = Corvid::Case.create!(patient_identifier: "pt_tb_enrolled")
+      Corvid::CaseProgram.create!(
+        case: enrolled, program_name: "Tuberculosis", program_code: "tb",
+        enrollment_date: Date.current
+      )
+      Corvid::Case.create!(patient_identifier: "pt_unenrolled")
 
-  test "all built-in IHS programs validate" do
-    %w[immunization sti tb neonatal lead hep_b communicable_disease].each do |code|
-      with_tenant(TEST_TENANT) do
-        kase = Corvid::Case.new(patient_identifier: "pt_#{code}", program_type: code)
-        assert kase.valid?, "expected built-in program #{code} to validate: #{kase.errors.full_messages.inspect}"
-      end
+      results = Corvid::Case.for_program("tb")
+      assert_includes results, enrolled
+      assert_equal 1, results.count
     end
   end
 

--- a/test/services/corvid/program_case_audit_service_test.rb
+++ b/test/services/corvid/program_case_audit_service_test.rb
@@ -13,7 +13,7 @@ class Corvid::ProgramCaseAuditServiceTest < ActiveSupport::TestCase
 
   test "case_timeline returns ordered milestone entries" do
     with_tenant(TENANT) do
-      kase = Corvid::Case.create!(patient_identifier: "pt_timeline", program_type: "hep_b", facility_identifier: "fac_test")
+      kase = create_program_case("pt_timeline", "hep_b")
       Corvid::Task.create!(taskable: kase, description: "First dose", milestone_key: "first_dose", milestone_position: 1, due_at: 1.week.from_now)
       completed_task = Corvid::Task.create!(taskable: kase, description: "Intake", milestone_key: "intake", milestone_position: 0, due_at: 1.day.ago)
       completed_task.completed!
@@ -31,10 +31,10 @@ class Corvid::ProgramCaseAuditServiceTest < ActiveSupport::TestCase
 
   test "program_compliance_summary returns completion rates and overdue counts" do
     with_tenant(TENANT) do
-      kase1 = Corvid::Case.create!(patient_identifier: "pt_comp1", program_type: "hep_b", facility_identifier: "fac_test")
+      kase1 = create_program_case("pt_comp1", "hep_b")
       Corvid::Task.create!(taskable: kase1, description: "Dose 1", milestone_key: "dose_1", milestone_position: 1, due_at: 1.year.ago, status: :pending)
 
-      kase2 = Corvid::Case.create!(patient_identifier: "pt_comp2", program_type: "hep_b", facility_identifier: "fac_test")
+      kase2 = create_program_case("pt_comp2", "hep_b")
       t = Corvid::Task.create!(taskable: kase2, description: "Dose 1", milestone_key: "dose_1", milestone_position: 1, due_at: 1.month.from_now)
       t.completed!
 
@@ -65,5 +65,18 @@ class Corvid::ProgramCaseAuditServiceTest < ActiveSupport::TestCase
       assert_equal 0, summary[:total_milestones]
       assert_equal 0.0, summary[:completion_rate]
     end
+  end
+
+  private
+
+  def create_program_case(patient_identifier, program_code)
+    kase = Corvid::Case.create!(
+      patient_identifier: patient_identifier, facility_identifier: "fac_test"
+    )
+    Corvid::CaseProgram.create!(
+      case: kase, program_name: program_code.titleize,
+      program_code: program_code, enrollment_date: Date.current
+    )
+    kase
   end
 end


### PR DESCRIPTION
## Summary

- Removed `program_type` column and registry validation from `Case`
- Moved program identity to `CaseProgram` — registry validation now lives on `program_code`
- `Case#program_case?` and `Case.for_program(code)` join through `case_programs`
- `ProgramTemplateService.create_case` creates Case + CaseProgram atomically
- Migration backfills `CaseProgram` rows from any existing `Case#program_type`, then drops the column and its index

Phase 2 of the registry work started in #266. Per the issue: \`Case is a person; CaseProgram is the enrollment.\`

Closes #260

## Test plan

- [x] All 609 model/service tests pass
- [x] All 342 cucumber scenarios pass (24 pre-existing undefined unchanged)
- [x] Migration applies cleanly to test DB
- [x] Backfill is idempotent (skips existing CaseProgram rows)
- [x] Down-migration restores `program_type` from `CaseProgram.program_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)