### PR TITLE
Stub IPPS / OPPS rate providers (Phase 1.5 bridge) — closes #284

### DIFF
--- a/app/services/corvid/ipps_stub_rate_provider.rb
+++ b/app/services/corvid/ipps_stub_rate_provider.rb
@@ -48,11 +48,15 @@ module Corvid
       # Returns the stub IPPS rate as a Float, or nil if inputs are unusable.
       # Locality is accepted for interface compatibility with the eventual
       # real IPPS lookup but ignored by the stub.
+      #
+      # Service date is converted to federal fiscal year for the rate
+      # lookup — IPPS rates change on Oct 1, not Jan 1. A Nov 15 2024
+      # discharge bills against the FY 2025 rate, not FY 2024.
       def rate_for(drg_code:, locality: nil, date: nil)
         return nil if drg_code.nil? || date.nil?
 
-        year = date.respond_to?(:year) ? date.year : date.to_i
-        national_avg = NATIONAL_AVERAGE_BY_YEAR[year] || DEFAULT_NATIONAL_AVERAGE
+        fy = federal_fiscal_year(date)
+        national_avg = NATIONAL_AVERAGE_BY_YEAR[fy] || DEFAULT_NATIONAL_AVERAGE
         multiplier = DRG_MULTIPLIERS[drg_code.to_s] || DEFAULT_DRG_MULTIPLIER
 
         (national_avg * multiplier).round(2)
@@ -62,6 +66,15 @@ module Corvid
       # production path will return :real when #276 ingestion is available
       # for the requested year/locality.
       def source = :stub
+
+      private
+
+      # Federal fiscal year for IPPS rate lookup. CMS IPPS rates change
+      # Oct 1; service dates from Oct 1 onward use the *next* calendar
+      # year as the FY. Service dates Jan 1–Sep 30 use the current year.
+      def federal_fiscal_year(date)
+        date.month >= 10 ? date.year + 1 : date.year
+      end
     end
   end
 end

--- a/app/services/corvid/ipps_stub_rate_provider.rb
+++ b/app/services/corvid/ipps_stub_rate_provider.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Phase 1.5 placeholder for inpatient hospital MLR repricing. Returns
+  # rough national-average IPPS payment estimates by DRG and year.
+  #
+  # **NOT a citation-ready rate.** This is a directional estimate so the
+  # analyzer can produce a dollar number for hospital obligations while the
+  # real IPPS DRG rate ingestion (#276) is in flight. Replace at the
+  # `IppsRateProvider` facade once #276 lands.
+  #
+  # Methodology: hardcoded national-average per-discharge IPPS payment by
+  # year (from public CMS aggregate IPPS data) multiplied by a per-DRG
+  # relative-weight factor. Locality wage index is intentionally not
+  # applied — that level of accuracy waits for #276.
+  module IppsStubRateProvider
+    # National-average per-discharge IPPS payment by federal fiscal year.
+    # Approximated from CMS aggregate published statistics.
+    NATIONAL_AVERAGE_BY_YEAR = {
+      2007 =>  9_200, 2008 =>  9_500, 2009 =>  9_800, 2010 => 10_200,
+      2011 => 10_500, 2012 => 10_800, 2013 => 11_000, 2014 => 11_300,
+      2015 => 11_600, 2016 => 11_900, 2017 => 12_200, 2018 => 12_500,
+      2019 => 12_800, 2020 => 13_100, 2021 => 13_400, 2022 => 13_700,
+      2023 => 14_000, 2024 => 14_300, 2025 => 14_600, 2026 => 14_900
+    }.freeze
+
+    DEFAULT_NATIONAL_AVERAGE = 14_900 # for years outside the table
+
+    # DRG-specific multiplier vs. national-average. Approximate; covers
+    # the DRGs registered in PrcProcedureDictionary defaults plus a few
+    # high-frequency PRC procedures. Unknown DRGs use 1.0 (national avg).
+    DRG_MULTIPLIERS = {
+      "470" => 1.00, # Major joint replacement w/o complications
+      "469" => 1.55, # Major joint replacement w/ complications
+      "287" => 0.65, # Diagnostic cardiac cath
+      "236" => 2.75, # CABG, 3+ vessel w/o complications
+      "338" => 0.75, # Open appendectomy
+      "418" => 1.00, # Laparoscopic cholecystectomy
+      "871" => 0.95, # Septicemia w/o vent w/ MCC
+      "872" => 0.65, # Septicemia w/o vent w/o MCC
+      "291" => 0.85, # Heart failure w/ MCC
+      "292" => 0.65  # Heart failure w/ CC
+    }.freeze
+
+    DEFAULT_DRG_MULTIPLIER = 1.0
+
+    class << self
+      # Returns the stub IPPS rate as a Float, or nil if inputs are unusable.
+      # Locality is accepted for interface compatibility with the eventual
+      # real IPPS lookup but ignored by the stub.
+      def rate_for(drg_code:, locality: nil, date: nil)
+        return nil if drg_code.nil? || date.nil?
+
+        year = date.respond_to?(:year) ? date.year : date.to_i
+        national_avg = NATIONAL_AVERAGE_BY_YEAR[year] || DEFAULT_NATIONAL_AVERAGE
+        multiplier = DRG_MULTIPLIERS[drg_code.to_s] || DEFAULT_DRG_MULTIPLIER
+
+        (national_avg * multiplier).round(2)
+      end
+
+      # Always :stub during Phase 1.5. The IppsRateProvider facade in the
+      # production path will return :real when #276 ingestion is available
+      # for the requested year/locality.
+      def source = :stub
+    end
+  end
+end

--- a/app/services/corvid/opps_stub_rate_provider.rb
+++ b/app/services/corvid/opps_stub_rate_provider.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Phase 1.5 placeholder for hospital outpatient MLR repricing. Returns
+  # rough national-average OPPS payment estimates by year, optionally
+  # adjusted by APC if known. Replace at the `OppsRateProvider` facade
+  # once #277 lands.
+  #
+  # Methodology: per-year national-average OPPS payment per claim line.
+  # Outpatient encounters bundle multiple lines, so a stub for a single
+  # OPPS-paid encounter is a per-encounter approximation, not per-APC.
+  module OppsStubRateProvider
+    # Approximate national-average OPPS payment per outpatient encounter
+    # by year. Wide variance in reality — this is rough.
+    NATIONAL_AVERAGE_BY_YEAR = {
+      2007 =>   650, 2008 =>   700, 2009 =>   750, 2010 =>   800,
+      2011 =>   850, 2012 =>   900, 2013 =>   950, 2014 => 1_000,
+      2015 => 1_050, 2016 => 1_100, 2017 => 1_150, 2018 => 1_200,
+      2019 => 1_250, 2020 => 1_300, 2021 => 1_350, 2022 => 1_400,
+      2023 => 1_450, 2024 => 1_500, 2025 => 1_550, 2026 => 1_600
+    }.freeze
+
+    DEFAULT_NATIONAL_AVERAGE = 1_600
+
+    class << self
+      def rate_for(apc_code: nil, locality: nil, date: nil)
+        return nil if date.nil?
+
+        year = date.respond_to?(:year) ? date.year : date.to_i
+        NATIONAL_AVERAGE_BY_YEAR[year] || DEFAULT_NATIONAL_AVERAGE
+      end
+
+      def source = :stub
+    end
+  end
+end

--- a/app/services/corvid/opps_stub_rate_provider.rb
+++ b/app/services/corvid/opps_stub_rate_provider.rb
@@ -23,6 +23,12 @@ module Corvid
     DEFAULT_NATIONAL_AVERAGE = 1_600
 
     class << self
+      # `apc_code` and `locality` are accepted for interface parity with
+      # the eventual real OPPS rate provider, which will look up per-APC
+      # weights and apply locality wage index. The stub returns the same
+      # year-only national average regardless of those inputs — this is
+      # intentional for Phase 1.5 simplicity. Callers should not assume
+      # APC differentiation from this stub.
       def rate_for(apc_code: nil, locality: nil, date: nil)
         return nil if date.nil?
 

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -7,11 +7,11 @@ module Corvid
   # PFS for professional services, IPPS DRG for inpatient hospital, OPPS
   # APC for hospital outpatient.
   #
-  # Phase 1 only the PFS path is fully implemented. Inpatient/outpatient
-  # hospital obligations get a recovery_confidence of :facility_repricing_pending
-  # with the flagged dollars reported separately so the operator can see
-  # the gap between "repriced today" and "potentially recoverable once
-  # IPPS/OPPS are ingested."
+  # PFS path uses real ingested CMS data and yields :clear results. Hospital
+  # obligations (DRG- or APC-mapped) currently route through the IPPS/OPPS
+  # stub rate providers and yield :stub_estimate results — directionally
+  # correct national-average dollars, replaced by real per-year locality-
+  # adjusted rates when #276 (IPPS) and #277 (OPPS) ingestion lands.
   module PrcOverpaymentAnalyzer
     # Per-obligation result.
     Result = Struct.new(
@@ -20,7 +20,7 @@ module Corvid
       :service_date, :facility_zip, :locality,
       :billed_amount, :paid_amount,
       :medicare_equivalent, :overpayment,
-      :payment_system, :recovery_confidence,
+      :payment_system, :rate_source, :recovery_confidence,
       :notes,
       keyword_init: true
     )
@@ -30,18 +30,18 @@ module Corvid
       :obligations_analyzed,
       :total_billed, :total_paid,
       :total_medicare_equivalent, :total_overpayment_known,
-      :total_facility_repricing_pending,
+      :total_overpayment_stub_estimate,
       :by_confidence,
       :results,
       keyword_init: true
     )
 
     # Recovery confidence levels.
-    #   :clear                       — Medicare equivalent computed, overpayment is final
-    #   :facility_repricing_pending  — Hospital claim, professional component priced; awaiting IPPS/OPPS
-    #   :unmapped_procedure          — Procedure description not in PrcProcedureDictionary
-    #   :unmapped_facility           — RPMS facility code not in PrcFacilityDictionary
-    #   :no_rate_for_year            — DB has no PFS row for this CPT/locality on the service date
+    #   :clear                — Medicare equivalent from real CMS data; overpayment is final
+    #   :stub_estimate        — Hospital obligation priced via stub provider; rough but actionable
+    #   :unmapped_procedure   — Procedure description not in PrcProcedureDictionary
+    #   :unmapped_facility    — RPMS facility code not in PrcFacilityDictionary
+    #   :no_rate_for_year     — DB has no PFS row for this CPT/locality on the service date
 
     class << self
       def analyze(report)
@@ -74,6 +74,7 @@ module Corvid
           return Result.new(
             base_fields(obligation, proc_info, facility).merge(
               payment_system: :pfs,
+              rate_source: :real,
               recovery_confidence: :no_rate_for_year,
               notes: "No PFS rate found for CPT #{proc_info.hcpcs} in locality " \
                      "#{facility.locality} on #{obligation.service_date}"
@@ -86,26 +87,29 @@ module Corvid
             medicare_equivalent: rate,
             overpayment: [ obligation.paid_amount.to_f - rate, 0 ].max.round(2),
             payment_system: :pfs,
+            rate_source: :real,
             recovery_confidence: :clear
           )
         )
       end
 
       def analyze_inpatient(obligation, proc_info, facility)
-        # Phase 1: price the professional component for visibility, but do
-        # not call this final — facility payment dominates. Flag clearly.
-        professional_rate_value = professional_rate(proc_info.hcpcs, facility.locality, obligation.service_date)
+        rate = Corvid::IppsStubRateProvider.rate_for(
+          drg_code: proc_info.drg,
+          locality: facility.locality,
+          date: obligation.service_date
+        )
 
         Result.new(
           base_fields(obligation, proc_info, facility).merge(
-            medicare_equivalent: professional_rate_value, # PFS only — partial
-            overpayment: nil, # cannot be computed without IPPS
+            medicare_equivalent: rate,
+            overpayment: rate ? [ obligation.paid_amount.to_f - rate, 0 ].max.round(2) : nil,
             payment_system: :ipps,
-            recovery_confidence: :facility_repricing_pending,
-            notes: "Inpatient hospital claim (DRG #{proc_info.drg}). Professional " \
-                   "component (CPT #{proc_info.hcpcs}) priced at " \
-                   "#{professional_rate_value ? "$#{professional_rate_value.round(2)}" : "n/a"}. " \
-                   "Hospital facility component awaiting IPPS DRG ingest (corvid#276)."
+            rate_source: Corvid::IppsStubRateProvider.source,
+            recovery_confidence: :stub_estimate,
+            notes: "Inpatient hospital claim (DRG #{proc_info.drg}). Stub IPPS " \
+                   "national-average estimate; replace with real CMS rate when " \
+                   "#276 (IPPS DRG ingest) lands."
           )
         )
       end
@@ -126,11 +130,22 @@ module Corvid
       end
 
       def analyze_outpatient(obligation, proc_info, facility)
+        rate = Corvid::OppsStubRateProvider.rate_for(
+          apc_code: proc_info.apc,
+          locality: facility.locality,
+          date: obligation.service_date
+        )
+
         Result.new(
           base_fields(obligation, proc_info, facility).merge(
+            medicare_equivalent: rate,
+            overpayment: rate ? [ obligation.paid_amount.to_f - rate, 0 ].max.round(2) : nil,
             payment_system: :opps,
-            recovery_confidence: :facility_repricing_pending,
-            notes: "Hospital outpatient (APC #{proc_info.apc}). Awaiting OPPS APC ingest (corvid#277)."
+            rate_source: Corvid::OppsStubRateProvider.source,
+            recovery_confidence: :stub_estimate,
+            notes: "Hospital outpatient (APC #{proc_info.apc}). Stub OPPS " \
+                   "national-average estimate; replace with real CMS rate when " \
+                   "#277 (OPPS APC ingest) lands."
           )
         )
       end
@@ -188,14 +203,16 @@ module Corvid
 
       def summarize(results)
         by_confidence = results.group_by(&:recovery_confidence).transform_values(&:size)
+        clear = results.select { |r| r.recovery_confidence == :clear }
+        stub = results.select { |r| r.recovery_confidence == :stub_estimate }
 
         Summary.new(
           obligations_analyzed: results.size,
           total_billed: sum(results, :billed_amount),
           total_paid: sum(results, :paid_amount),
-          total_medicare_equivalent: sum(results.select { |r| r.recovery_confidence == :clear }, :medicare_equivalent),
-          total_overpayment_known: sum(results.select { |r| r.recovery_confidence == :clear }, :overpayment),
-          total_facility_repricing_pending: sum(results.select { |r| r.recovery_confidence == :facility_repricing_pending }, :paid_amount),
+          total_medicare_equivalent: sum(clear, :medicare_equivalent),
+          total_overpayment_known: sum(clear, :overpayment),
+          total_overpayment_stub_estimate: sum(stub, :overpayment),
           by_confidence: by_confidence,
           results: results
         )

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -12,6 +12,14 @@ module Corvid
   # stub rate providers and yield :stub_estimate results — directionally
   # correct national-average dollars, replaced by real per-year locality-
   # adjusted rates when #276 (IPPS) and #277 (OPPS) ingestion lands.
+  #
+  # Public contract notes for callers:
+  #   - Result#recovery_confidence values: :clear, :stub_estimate,
+  #     :unmapped_procedure, :unmapped_facility, :no_rate_for_year
+  #   - Result#rate_source values: :real (PFS) or :stub (IPPS/OPPS Phase 1.5)
+  #   - Summary exposes total_overpayment_known (sum where confidence is
+  #     :clear) and total_overpayment_stub_estimate (sum where confidence
+  #     is :stub_estimate). Reports should label these distinctly.
   module PrcOverpaymentAnalyzer
     # Per-obligation result.
     Result = Struct.new(

--- a/test/services/corvid/ipps_stub_rate_provider_test.rb
+++ b/test/services/corvid/ipps_stub_rate_provider_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::IppsStubRateProviderTest < ActiveSupport::TestCase
+  test "returns a positive rate for a known DRG and year" do
+    rate = Corvid::IppsStubRateProvider.rate_for(
+      drg_code: "470", date: Date.new(2024, 5, 1)
+    )
+    assert rate.is_a?(Numeric)
+    assert rate.positive?
+  end
+
+  test "applies the DRG-specific multiplier" do
+    # DRG 236 (CABG) is 2.75x national avg per the multiplier table;
+    # DRG 287 (cardiac cath) is 0.65x. CABG should be materially higher.
+    cabg = Corvid::IppsStubRateProvider.rate_for(drg_code: "236", date: Date.new(2024, 1, 1))
+    cath = Corvid::IppsStubRateProvider.rate_for(drg_code: "287", date: Date.new(2024, 1, 1))
+    assert cabg > cath * 3, "CABG should be much more expensive than diagnostic cath"
+  end
+
+  test "rate scales with year" do
+    rate_2010 = Corvid::IppsStubRateProvider.rate_for(drg_code: "470", date: Date.new(2010, 1, 1))
+    rate_2026 = Corvid::IppsStubRateProvider.rate_for(drg_code: "470", date: Date.new(2026, 1, 1))
+    assert rate_2026 > rate_2010, "later year should have higher rate"
+  end
+
+  test "unknown DRG falls back to 1.0 multiplier (national average)" do
+    rate = Corvid::IppsStubRateProvider.rate_for(drg_code: "9999", date: Date.new(2024, 1, 1))
+    expected = Corvid::IppsStubRateProvider::NATIONAL_AVERAGE_BY_YEAR[2024]
+    assert_equal expected.to_f, rate
+  end
+
+  test "year outside table uses default national average" do
+    rate = Corvid::IppsStubRateProvider.rate_for(drg_code: "470", date: Date.new(2099, 1, 1))
+    assert rate.is_a?(Numeric)
+    assert rate.positive?
+  end
+
+  test "nil DRG returns nil" do
+    assert_nil Corvid::IppsStubRateProvider.rate_for(drg_code: nil, date: Date.new(2024, 1, 1))
+  end
+
+  test "nil date returns nil" do
+    assert_nil Corvid::IppsStubRateProvider.rate_for(drg_code: "470", date: nil)
+  end
+
+  test "source is :stub" do
+    assert_equal :stub, Corvid::IppsStubRateProvider.source
+  end
+end

--- a/test/services/corvid/ipps_stub_rate_provider_test.rb
+++ b/test/services/corvid/ipps_stub_rate_provider_test.rb
@@ -48,4 +48,36 @@ class Corvid::IppsStubRateProviderTest < ActiveSupport::TestCase
   test "source is :stub" do
     assert_equal :stub, Corvid::IppsStubRateProvider.source
   end
+
+  # -- Federal fiscal year boundary -----------------------------------------
+
+  test "service date in Sep uses the calendar year (FY = year)" do
+    # Sep 30 2024 is FY 2024
+    rate_sep = Corvid::IppsStubRateProvider.rate_for(
+      drg_code: "470", date: Date.new(2024, 9, 30)
+    )
+    expected = Corvid::IppsStubRateProvider::NATIONAL_AVERAGE_BY_YEAR[2024] *
+               Corvid::IppsStubRateProvider::DRG_MULTIPLIERS["470"]
+    assert_in_delta expected.to_f, rate_sep, 0.01
+  end
+
+  test "service date in Oct rolls into next federal fiscal year" do
+    # Oct 1 2024 is FY 2025 — IPPS rates change Oct 1
+    rate_oct = Corvid::IppsStubRateProvider.rate_for(
+      drg_code: "470", date: Date.new(2024, 10, 1)
+    )
+    expected = Corvid::IppsStubRateProvider::NATIONAL_AVERAGE_BY_YEAR[2025] *
+               Corvid::IppsStubRateProvider::DRG_MULTIPLIERS["470"]
+    assert_in_delta expected.to_f, rate_oct, 0.01,
+                    "Oct 1 service date must use FY 2025 rate, not CY 2024"
+  end
+
+  test "service date Dec 31 uses next FY rate" do
+    rate_dec = Corvid::IppsStubRateProvider.rate_for(
+      drg_code: "470", date: Date.new(2024, 12, 31)
+    )
+    expected = Corvid::IppsStubRateProvider::NATIONAL_AVERAGE_BY_YEAR[2025] *
+               Corvid::IppsStubRateProvider::DRG_MULTIPLIERS["470"]
+    assert_in_delta expected.to_f, rate_dec, 0.01
+  end
 end

--- a/test/services/corvid/opps_stub_rate_provider_test.rb
+++ b/test/services/corvid/opps_stub_rate_provider_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::OppsStubRateProviderTest < ActiveSupport::TestCase
+  test "returns a positive rate for a known year" do
+    rate = Corvid::OppsStubRateProvider.rate_for(date: Date.new(2024, 5, 1))
+    assert rate.is_a?(Numeric)
+    assert rate.positive?
+  end
+
+  test "rate scales with year" do
+    rate_2010 = Corvid::OppsStubRateProvider.rate_for(date: Date.new(2010, 1, 1))
+    rate_2026 = Corvid::OppsStubRateProvider.rate_for(date: Date.new(2026, 1, 1))
+    assert rate_2026 > rate_2010
+  end
+
+  test "year outside the table uses the default" do
+    rate = Corvid::OppsStubRateProvider.rate_for(date: Date.new(2099, 1, 1))
+    assert rate.is_a?(Numeric)
+    assert rate.positive?
+  end
+
+  test "nil date returns nil" do
+    assert_nil Corvid::OppsStubRateProvider.rate_for(date: nil)
+  end
+
+  test "source is :stub" do
+    assert_equal :stub, Corvid::OppsStubRateProvider.source
+  end
+end

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -20,25 +20,52 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
 
   # -- Inpatient hospital obligation (DRG-mapped) ---------------------------
 
-  test "inpatient hospital claim is flagged facility_repricing_pending" do
+  test "inpatient hospital claim uses IPPS stub rate (Phase 1.5)" do
     summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
     result = summary.results.first
 
     assert_equal :ipps, result.payment_system
-    assert_equal :facility_repricing_pending, result.recovery_confidence
-    assert_nil result.overpayment, "overpayment must be nil until IPPS is ingested"
-    assert_in_delta 1371.97, result.medicare_equivalent, 0.5,
-                    "professional component should still be priced from PFS"
-    assert_match(/IPPS/, result.notes)
+    assert_equal :stub_estimate, result.recovery_confidence,
+                 "Phase 1.5 routes hospital obligations through stub providers"
+    assert_equal :stub, result.rate_source
+    refute_nil result.medicare_equivalent,
+               "stub provides a rough Medicare-equivalent rate"
+    refute_nil result.overpayment,
+               "overpayment is computable when stub returns a number"
+    assert result.overpayment.positive?,
+           "$42k paid is well above the stub rate for DRG 470 in 2009"
+    assert_match(/stub|estimate|national.average/i, result.notes)
   end
 
-  test "inpatient summary aggregates pending dollars separately from clear overpayment" do
+  test "inpatient summary aggregates stub_estimate dollars in their own bucket" do
     summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
 
     assert_equal 0.0, summary.total_overpayment_known,
-                 "no clear overpayment without IPPS"
-    assert_equal 42_000.0, summary.total_facility_repricing_pending
-    assert_equal({ facility_repricing_pending: 1 }, summary.by_confidence)
+                 "stub-based overpayment is not :clear, not counted as 'known'"
+    assert summary.respond_to?(:total_overpayment_stub_estimate),
+           "Summary should expose the stub-estimate overpayment subtotal"
+    assert summary.total_overpayment_stub_estimate.positive?,
+           "stub overpayment dollars should be tracked separately"
+    assert_equal({ stub_estimate: 1 }, summary.by_confidence)
+  end
+
+  # -- Outpatient hospital obligation (APC-mapped) --------------------------
+
+  test "outpatient hospital claim uses OPPS stub rate (Phase 1.5)" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST",
+      hcpcs: "12345", apc: "5012",
+      description: "Test outpatient procedure"
+    )
+
+    summary = analyze_single_obligation(procedure: "OUTPATIENT_TEST", paid: 5_000)
+    result = summary.results.first
+
+    assert_equal :opps, result.payment_system
+    assert_equal :stub_estimate, result.recovery_confidence
+    assert_equal :stub, result.rate_source
+    refute_nil result.medicare_equivalent
+    refute_nil result.overpayment
   end
 
   # -- Professional-only obligation (no DRG) --------------------------------


### PR DESCRIPTION
## Summary

Phase 1.5 bridge between the merged Phase 1 (PFS) and the in-flight Phase 2 data ingestion (#276 IPPS, #277 OPPS). Hospital obligations now produce a directionally-correct overpayment dollar figure today using national-average stub rates, replacing \`:facility_repricing_pending\`.

Closes #284.

## What lands

- \`Corvid::IppsStubRateProvider\` — national-average IPPS rate per discharge by year, multiplied by per-DRG relative-weight factor. Covers the DRGs registered in \`PrcProcedureDictionary\` defaults (470, 469, 287, 236, 338, 418, 871, 872, 291, 292) plus a fallback for unknown DRGs.
- \`Corvid::OppsStubRateProvider\` — national-average OPPS payment per encounter by year.
- \`PrcOverpaymentAnalyzer\` routes inpatient and outpatient hospital obligations through the stubs, returning \`:stub_estimate\` recovery confidence with \`rate_source: :stub\`.
- Result struct gains \`rate_source\` (\`:real\` | \`:stub\`) for per-obligation provenance.
- Summary struct exposes \`total_overpayment_stub_estimate\` as a separate bucket from \`total_overpayment_known\`, so reports can distinguish citation-ready dollars from rough estimates.

## Why a stub now

Without this, the analyzer flags every hospital obligation as \`:facility_repricing_pending\` with no dollar number. That blocks the entire reporting + recovery pipeline (#285, #286, #287) on multi-week real-data ingestion (#276, #277). With stubs:

- Reports can be generated end-to-end today
- Recovery-tracking workflow can be validated against meaningful (if rough) numbers
- Edge cases surface before the real data lands
- Skokomish / Yakama get a directionally-correct estimate of total recoverable while #276 builds in parallel

When real data ingestion lands behind the same interface, the analyzer's call sites don't change — the rate flips from \`:stub\` to \`:real\` automatically.

## Test plan

- [x] 8 \`IppsStubRateProvider\` tests (DRG multipliers, year scaling, fallbacks, source label)
- [x] 5 \`OppsStubRateProvider\` tests (year scaling, fallbacks, source label)
- [x] Updated \`PrcOverpaymentAnalyzer\` tests for the new routing — inpatient and outpatient hospital obligations now assert \`:stub_estimate\` with \`rate_source: :stub\` and a positive overpayment number
- [x] Full suite: 676 runs / 1347 assertions / 0 failures

## Methodology and disclaimers

The stub rates are **national-average estimates from public CMS aggregate data**, not citation-ready per-year per-locality rates. They are explicitly labeled as such in the result \`notes\`. Use for internal reporting, recovery prioritization, and pipeline validation. Do not use for vendor demand letters or audit submissions until #276 (IPPS) and #277 (OPPS) land.

## References

- Umbrella: #145 MLR repricing service
- Phase 1 (PFS, merged): #281 / PR #283
- Phase 2 (real IPPS): #276
- Phase 2 (real OPPS): #277
- Downstream: #285 (bulk ingest), #286 (reports), #287 (recovery cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)