### PR TITLE
Tighten stub docstrings and rate_source for no-rate path (follow-up to #288)

### DIFF
--- a/app/services/corvid/ipps_stub_rate_provider.rb
+++ b/app/services/corvid/ipps_stub_rate_provider.rb
@@ -10,9 +10,10 @@ module Corvid
   # `IppsRateProvider` facade once #276 lands.
   #
   # Methodology: hardcoded national-average per-discharge IPPS payment by
-  # year (from public CMS aggregate IPPS data) multiplied by a per-DRG
-  # relative-weight factor. Locality wage index is intentionally not
-  # applied — that level of accuracy waits for #276.
+  # **federal fiscal year** (Oct 1 – Sep 30; from public CMS aggregate IPPS
+  # data) multiplied by a per-DRG relative-weight factor. Service dates
+  # are converted to FY before lookup. Locality wage index is intentionally
+  # not applied — that level of accuracy waits for #276.
   module IppsStubRateProvider
     # National-average per-discharge IPPS payment by federal fiscal year.
     # Approximated from CMS aggregate published statistics.

--- a/app/services/corvid/opps_stub_rate_provider.rb
+++ b/app/services/corvid/opps_stub_rate_provider.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module Corvid
-  # Phase 1.5 placeholder for hospital outpatient MLR repricing. Returns
-  # rough national-average OPPS payment estimates by year, optionally
-  # adjusted by APC if known. Replace at the `OppsRateProvider` facade
-  # once #277 lands.
+  # Phase 1.5 placeholder for hospital outpatient MLR repricing. Returns a
+  # rough per-year national-average OPPS payment per outpatient encounter.
+  # Does **not** adjust by APC, locality, or any other factor — those wait
+  # for the real OPPS rate provider when #277 lands.
   #
-  # Methodology: per-year national-average OPPS payment per claim line.
-  # Outpatient encounters bundle multiple lines, so a stub for a single
-  # OPPS-paid encounter is a per-encounter approximation, not per-APC.
+  # Use this for directional reporting and pipeline validation only. Do
+  # not rely on per-APC differentiation; the stub returns the same year
+  # average regardless of the APC code passed in.
   module OppsStubRateProvider
     # Approximate national-average OPPS payment per outpatient encounter
     # by year. Wide variance in reality — this is rough.

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -82,7 +82,7 @@ module Corvid
           return Result.new(
             base_fields(obligation, proc_info, facility).merge(
               payment_system: :pfs,
-              rate_source: :real,
+              rate_source: nil, # no rate looked up successfully
               recovery_confidence: :no_rate_for_year,
               notes: "No PFS rate found for CPT #{proc_info.hcpcs} in locality " \
                      "#{facility.locality} on #{obligation.service_date}"

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -129,6 +129,8 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
 
     assert_equal :no_rate_for_year, result.recovery_confidence
     assert_nil result.medicare_equivalent
+    assert_nil result.rate_source,
+              "rate_source must be nil when no Medicare rate was actually computed"
   end
 
   # -- Helpers ---------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #288 addressing the remaining review threads:

- **OPPS module docstring** — rewritten to explicitly say the stub does not adjust by APC, locality, or anything else; earlier wording ("optionally adjusted by APC if known") suggested more sophistication than the stub delivers.
- **Analyzer `:no_rate_for_year` branch** — now sets `rate_source: nil` rather than `:real`, so downstream reports don't misinterpret a no-rate result as having used real CMS data. New test locks the behavior in.
- **IPPS module docstring** — clarifies that the per-year averages are keyed by federal fiscal year (Oct 1 boundary), matching the implementation already shipped in #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)