### PR TITLE
Money: PRC tables on money-rails with per-row currency (slice 1 of #294)

### DIFF
--- a/app/models/concerns/corvid/currency_immutable.rb
+++ b/app/models/concerns/corvid/currency_immutable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Per ADR 0004: a row's currency_iso is locked at write time. Update
+  # attempts that change the value raise ActiveRecord::RecordInvalid
+  # rather than being silently dropped — historical records must stay
+  # immutable across tenant reconfiguration, and a silent failure mode
+  # would let a stale audit re-export quietly disagree with the original.
+  module CurrencyImmutable
+    extend ActiveSupport::Concern
+
+    included do
+      validates :currency_iso, presence: true
+      validate :currency_iso_unchanged_after_persisted
+    end
+
+    private
+
+    def currency_iso_unchanged_after_persisted
+      return unless persisted? && currency_iso_changed?
+      errors.add(:currency_iso, "is immutable once a row is persisted")
+    end
+  end
+end

--- a/app/models/corvid/prc_obligation.rb
+++ b/app/models/corvid/prc_obligation.rb
@@ -8,6 +8,8 @@ module Corvid
 
     include TenantScoped
 
+    include CurrencyImmutable
+
     monetize :billed_amount_cents, with_model_currency: :currency_iso, allow_nil: true
     monetize :paid_amount_cents, with_model_currency: :currency_iso, allow_nil: true
     monetize :savings_cents, with_model_currency: :currency_iso, allow_nil: true

--- a/app/models/corvid/prc_obligation.rb
+++ b/app/models/corvid/prc_obligation.rb
@@ -8,6 +8,11 @@ module Corvid
 
     include TenantScoped
 
+    monetize :billed_amount_cents, with_model_currency: :currency_iso, allow_nil: true
+    monetize :paid_amount_cents, with_model_currency: :currency_iso, allow_nil: true
+    monetize :savings_cents, with_model_currency: :currency_iso, allow_nil: true
+    monetize :balance_cents, with_model_currency: :currency_iso, allow_nil: true
+
     has_many :prc_payments,
              dependent: :destroy,
              class_name: "Corvid::PrcPayment"

--- a/app/models/corvid/prc_overpayment_analysis.rb
+++ b/app/models/corvid/prc_overpayment_analysis.rb
@@ -10,6 +10,9 @@ module Corvid
 
     include TenantScoped
 
+    monetize :medicare_equivalent_cents, with_model_currency: :currency_iso, allow_nil: true
+    monetize :overpayment_cents, with_model_currency: :currency_iso, allow_nil: true
+
     belongs_to :prc_obligation, class_name: "Corvid::PrcObligation"
 
     validates :analyzer_version, presence: true

--- a/app/models/corvid/prc_overpayment_analysis.rb
+++ b/app/models/corvid/prc_overpayment_analysis.rb
@@ -9,6 +9,7 @@ module Corvid
     self.table_name = "corvid_prc_overpayment_analyses"
 
     include TenantScoped
+    include CurrencyImmutable
 
     monetize :medicare_equivalent_cents, with_model_currency: :currency_iso, allow_nil: true
     monetize :overpayment_cents, with_model_currency: :currency_iso, allow_nil: true

--- a/app/models/corvid/prc_payment.rb
+++ b/app/models/corvid/prc_payment.rb
@@ -8,6 +8,8 @@ module Corvid
 
     include TenantScoped
 
+    monetize :amount_cents, with_model_currency: :currency_iso, allow_nil: true
+
     belongs_to :prc_obligation, class_name: "Corvid::PrcObligation"
 
     validates :payment_id, presence: true

--- a/app/models/corvid/prc_payment.rb
+++ b/app/models/corvid/prc_payment.rb
@@ -7,6 +7,7 @@ module Corvid
     self.table_name = "corvid_prc_payments"
 
     include TenantScoped
+    include CurrencyImmutable
 
     monetize :amount_cents, with_model_currency: :currency_iso, allow_nil: true
 

--- a/app/services/corvid/prc_importer.rb
+++ b/app/services/corvid/prc_importer.rb
@@ -81,8 +81,9 @@ module Corvid
               payment_system: result.payment_system&.to_s,
               rate_source: result.rate_source&.to_s,
               recovery_confidence: result.recovery_confidence.to_s,
-              medicare_equivalent: result.medicare_equivalent,
-              overpayment: result.overpayment,
+              medicare_equivalent_cents: to_cents(result.medicare_equivalent),
+              overpayment_cents: to_cents(result.overpayment),
+              currency_iso: obligation.currency_iso,
               notes: result.notes,
               analyzed_at: analyzed_at
             )
@@ -117,10 +118,11 @@ module Corvid
             procedure_code: o.procedure_code,
             service_date: o.service_date,
             status: o.status,
-            billed_amount: o.billed_amount,
-            paid_amount: o.paid_amount,
-            savings: o.savings,
-            balance: o.balance,
+            billed_amount_cents: to_cents(o.billed_amount),
+            paid_amount_cents: to_cents(o.paid_amount),
+            savings_cents: to_cents(o.savings),
+            balance_cents: to_cents(o.balance),
+            currency_iso: "USD",
             fiscal_year: o.fiscal_year,
             source_file: source_file,
             imported_at: imported_at
@@ -163,7 +165,8 @@ module Corvid
             payment_id: p.payment_id,
             paid_date: p.paid_date,
             check_number: p.check_number,
-            amount: p.amount,
+            amount_cents: to_cents(p.amount),
+            currency_iso: "USD",
             vendor_name: p.vendor_name
           }
           payment_ids_by_oblig_pk[oblig_pk] << p.payment_id
@@ -191,6 +194,16 @@ module Corvid
         end
 
         { imported: rows.size, dropped_orphan: dropped_orphan }
+      end
+
+      # Convert a BigDecimal/Numeric/nil from the PRC parser into integer
+      # subunit-cents for write to a `*_cents` column. PRC export files
+      # are always USD-denominated (US IHS), so this assumes 100 cents per
+      # dollar. International tenants don't go through this importer —
+      # they have their own ingest paths that pass currency through.
+      def to_cents(value)
+        return nil if value.nil?
+        (BigDecimal(value.to_s) * 100).to_i
       end
 
       def obligation_pks_for(obligation_external_ids)

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -225,18 +225,25 @@ module Corvid
         end
       end
 
-      # Fixed-point amount string for a Money. Drops symbol and
-      # thousands-separator and forces two decimal places — consumers
-      # (Excel, audit tools, recovery-letter mail merges) want "42000.00",
-      # not "$42,000.00" or "0.42E5". Currency code travels separately
-      # in the JSON `currency` field on each row.
+      # Fixed-point amount string for a Money, with the right number of
+      # decimal places for that currency — USD/CAD/SEK = 2 ("42000.00"),
+      # JOD = 3 ("142.000"), JPY = 0 ("4200"). Reads the exponent from
+      # the Money's currency rather than hardcoding 2 so subunit-aware
+      # currencies serialize correctly. The currency code itself travels
+      # separately in each row's `currency` field.
       def fmt_money(value)
         return nil if value.nil?
-        amount = value.is_a?(Money) ? value.amount : BigDecimal(value.to_s)
-        s = amount.round(2).to_s("F")
+        if value.is_a?(Money)
+          places = value.currency.exponent
+          amount = value.amount
+        else
+          places = 2
+          amount = BigDecimal(value.to_s)
+        end
+        s = amount.round(places).to_s("F")
         int, frac = s.split(".")
-        frac = (frac || "").ljust(2, "0")[0, 2]
-        "#{int}.#{frac}"
+        frac = (frac || "").ljust(places, "0")[0, places]
+        places.zero? ? int.to_s : "#{int}.#{frac}"
       end
 
       # Walks a hash/array tree, converting any Money values to fixed-point

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -97,11 +97,11 @@ module Corvid
           groups.each do |(fy, vendor, system), group|
             csv << [
               fy, vendor, system, group.size,
-              fmt_money(sum_decimals(group, :billed_amount)),
-              fmt_money(sum_decimals(group, :paid_amount)),
-              fmt_money(sum_decimals(group, :medicare_equivalent)),
-              fmt_money(sum_decimals(group.select { |r| r[:recovery_confidence] == "clear" }, :overpayment)),
-              fmt_money(sum_decimals(group.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment))
+              fmt_money(sum_money(group, :billed_amount)),
+              fmt_money(sum_money(group, :paid_amount)),
+              fmt_money(sum_money(group, :medicare_equivalent)),
+              fmt_money(sum_money(group.select { |r| r[:recovery_confidence] == "clear" }, :overpayment)),
+              fmt_money(sum_money(group.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment))
             ]
           end
         end
@@ -152,11 +152,11 @@ module Corvid
       def summary_from_rows(rows)
         {
           obligations_analyzed: rows.size,
-          total_billed: sum_decimals(rows, :billed_amount),
-          total_paid: sum_decimals(rows, :paid_amount),
-          total_medicare_equivalent: sum_decimals(rows, :medicare_equivalent),
-          total_overpayment_known: sum_decimals(rows.select { |r| r[:recovery_confidence] == "clear" }, :overpayment),
-          total_overpayment_stub_estimate: sum_decimals(rows.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment),
+          total_billed: sum_money(rows, :billed_amount),
+          total_paid: sum_money(rows, :paid_amount),
+          total_medicare_equivalent: sum_money(rows, :medicare_equivalent),
+          total_overpayment_known: sum_money(rows.select { |r| r[:recovery_confidence] == "clear" }, :overpayment),
+          total_overpayment_stub_estimate: sum_money(rows.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment),
           by_payment_system: group_totals(rows, :payment_system),
           by_vendor: group_totals(rows, :vendor_id),
           by_year: group_totals(rows, :fiscal_year)
@@ -185,8 +185,13 @@ module Corvid
         }
       end
 
-      def sum_decimals(rows, key)
-        rows.sum(0.to_d) { |r| r[key] || 0.to_d }
+      # Sum a column of Money values across rows. Same-currency rows
+      # combine; mixed currency raises Money::Bank::UnknownRate per
+      # ADR 0004 — reports group by currency rather than auto-FXing.
+      def sum_money(rows, key)
+        values = rows.map { |r| r[key] }.compact
+        return nil if values.empty?
+        values.reduce(:+)
       end
 
       def group_totals(rows, key)
@@ -194,34 +199,37 @@ module Corvid
           {
             key => value,
             obligations: group.size,
-            billed: sum_decimals(group, :billed_amount),
-            paid: sum_decimals(group, :paid_amount),
-            overpayment: sum_decimals(group, :overpayment)
+            billed: sum_money(group, :billed_amount),
+            paid: sum_money(group, :paid_amount),
+            overpayment: sum_money(group, :overpayment)
           }
         end
       end
 
-      # Fixed-point string for currency. BigDecimal#to_s defaults to "0.42E5"
-      # which is hostile to CSV consumers and Excel; "F" gives "42000.0",
-      # which we normalize to two decimal places.
+      # Fixed-point amount string for a Money. Drops symbol and
+      # thousands-separator and forces two decimal places — consumers
+      # (Excel, audit tools, recovery-letter mail merges) want "42000.00",
+      # not "$42,000.00" or "0.42E5". Currency code travels separately
+      # in the JSON `currency` field on each row.
       def fmt_money(value)
         return nil if value.nil?
-        BigDecimal(value.to_s).round(2).to_s("F").then do |s|
-          int, frac = s.split(".")
-          frac = (frac || "").ljust(2, "0")[0, 2]
-          "#{int}.#{frac}"
-        end
+        amount = value.is_a?(Money) ? value.amount : BigDecimal(value.to_s)
+        s = amount.round(2).to_s("F")
+        int, frac = s.split(".")
+        frac = (frac || "").ljust(2, "0")[0, 2]
+        "#{int}.#{frac}"
       end
 
-      # Walks a hash/array tree and rewrites BigDecimals at money keys to
-      # fixed-point strings before JSON encoding, since ActiveSupport's
-      # JSON encoder defers to BigDecimal#to_s and would otherwise emit
-      # scientific notation.
+      # Walks a hash/array tree, converting any Money values to fixed-point
+      # strings before JSON encoding (ActiveSupport's encoder would otherwise
+      # serialize Money via to_s, which is symbol-formatted and locale-y).
       def serialize_money(value)
         case value
+        when Money
+          fmt_money(value)
         when Hash
           value.each_with_object({}) do |(k, v), out|
-            out[k] = MONEY_KEYS.include?(k) ? fmt_money(v) : serialize_money(v)
+            out[k] = serialize_money(v)
           end
         when Array
           value.map { |v| serialize_money(v) }

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -25,7 +25,7 @@ module Corvid
   # sensitive recovery math downstream.
   module PrcOverpaymentReportService
     SUMMARY_CSV_HEADERS = %w[
-      fiscal_year vendor_id payment_system
+      fiscal_year vendor_id payment_system currency
       obligations_count
       total_billed total_paid total_medicare_equivalent
       total_overpayment_known total_overpayment_stub_estimate
@@ -33,7 +33,7 @@ module Corvid
 
     DETAIL_CSV_HEADERS = %w[
       obligation_id fiscal_year service_date vendor_id procedure_code
-      payment_system recovery_confidence
+      payment_system recovery_confidence currency
       billed_amount paid_amount medicare_equivalent overpayment
       analyzer_version rate_source rate_source_release
       source_file analyzed_at
@@ -89,14 +89,14 @@ module Corvid
 
       def to_csv_summary(tenant:, **filters)
         rows = detail(tenant: tenant, **filters)
-        groups = rows.group_by { |r| [ r[:fiscal_year], r[:vendor_id], r[:payment_system] ] }
+        groups = rows.group_by { |r| [ r[:fiscal_year], r[:vendor_id], r[:payment_system], r[:currency] ] }
                      .sort_by { |key, _| key.map { |v| v.to_s } }
 
         CSV.generate do |csv|
           csv << SUMMARY_CSV_HEADERS
-          groups.each do |(fy, vendor, system), group|
+          groups.each do |(fy, vendor, system, currency), group|
             csv << [
-              fy, vendor, system, group.size,
+              fy, vendor, system, currency, group.size,
               fmt_money(sum_money(group, :billed_amount)),
               fmt_money(sum_money(group, :paid_amount)),
               fmt_money(sum_money(group, :medicare_equivalent)),
@@ -149,17 +149,30 @@ module Corvid
           .order(Arel.sql("prc_obligation_id, analyzed_at DESC, id DESC"))
       end
 
+      # Summaries always partition rows by currency before summing — per
+      # ADR 0004, mixed-currency aggregation never auto-FXes. A single-
+      # currency tenant produces one entry under `by_currency`; a future
+      # multi-currency tenant produces one entry per ISO code, side by
+      # side, with their own Money totals.
       def summary_from_rows(rows)
         {
           obligations_analyzed: rows.size,
+          by_currency: rows.group_by { |r| r[:currency] }.map { |iso, group| currency_totals(iso, group) },
+          by_payment_system: group_totals(rows, :payment_system),
+          by_vendor: group_totals(rows, :vendor_id),
+          by_year: group_totals(rows, :fiscal_year)
+        }
+      end
+
+      def currency_totals(iso, rows)
+        {
+          currency: iso,
+          obligations: rows.size,
           total_billed: sum_money(rows, :billed_amount),
           total_paid: sum_money(rows, :paid_amount),
           total_medicare_equivalent: sum_money(rows, :medicare_equivalent),
           total_overpayment_known: sum_money(rows.select { |r| r[:recovery_confidence] == "clear" }, :overpayment),
-          total_overpayment_stub_estimate: sum_money(rows.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment),
-          by_payment_system: group_totals(rows, :payment_system),
-          by_vendor: group_totals(rows, :vendor_id),
-          by_year: group_totals(rows, :fiscal_year)
+          total_overpayment_stub_estimate: sum_money(rows.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment)
         }
       end
 
@@ -173,6 +186,7 @@ module Corvid
           procedure_code: obligation.procedure_code,
           payment_system: analysis.payment_system,
           recovery_confidence: analysis.recovery_confidence,
+          currency: obligation.currency_iso,
           billed_amount: obligation.billed_amount,
           paid_amount: obligation.paid_amount,
           medicare_equivalent: analysis.medicare_equivalent,
@@ -185,19 +199,24 @@ module Corvid
         }
       end
 
-      # Sum a column of Money values across rows. Same-currency rows
-      # combine; mixed currency raises Money::Bank::UnknownRate per
-      # ADR 0004 — reports group by currency rather than auto-FXing.
+      # Sum a column of Money values across rows. Callers must hand us a
+      # set that's already single-currency (we partition by currency
+      # before summing). Mixed-currency input raises Money's bank error
+      # by design — that's the loud-fail signal that something forgot
+      # to bucket by ISO code.
       def sum_money(rows, key)
         values = rows.map { |r| r[key] }.compact
         return nil if values.empty?
         values.reduce(:+)
       end
 
+      # Group breakdowns also partition by currency so the inner sums
+      # are guaranteed single-currency.
       def group_totals(rows, key)
-        rows.group_by { |r| r[key] }.map do |value, group|
+        rows.group_by { |r| [ r[key], r[:currency] ] }.map do |(value, currency), group|
           {
             key => value,
+            currency: currency,
             obligations: group.size,
             billed: sum_money(group, :billed_amount),
             paid: sum_money(group, :paid_amount),

--- a/corvid.gemspec
+++ b/corvid.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "~> 8.1"
   spec.add_dependency "aasm", "~> 5.5"
   spec.add_dependency "csv", ">= 3.0"
+  spec.add_dependency "money-rails", "~> 3.0"
   spec.add_dependency "pg", "~> 1.5"
   spec.add_dependency "ulid", "~> 1.4"
 end

--- a/db/migrate/20260508000001_create_corvid_prc_obligations.rb
+++ b/db/migrate/20260508000001_create_corvid_prc_obligations.rb
@@ -11,10 +11,11 @@ class CreateCorvidPrcObligations < ActiveRecord::Migration[8.1]
       t.string :procedure_code
       t.date :service_date
       t.string :status
-      t.decimal :billed_amount, precision: 12, scale: 2
-      t.decimal :paid_amount, precision: 12, scale: 2
-      t.decimal :savings, precision: 12, scale: 2
-      t.decimal :balance, precision: 12, scale: 2
+      t.bigint :billed_amount_cents
+      t.bigint :paid_amount_cents
+      t.bigint :savings_cents
+      t.bigint :balance_cents
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.integer :fiscal_year
       t.string :source_file
       t.datetime :imported_at, null: false
@@ -39,7 +40,8 @@ class CreateCorvidPrcObligations < ActiveRecord::Migration[8.1]
       t.string :payment_id, null: false
       t.date :paid_date
       t.string :check_number
-      t.decimal :amount, precision: 12, scale: 2
+      t.bigint :amount_cents
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.string :vendor_name
 
       t.timestamps
@@ -61,8 +63,9 @@ class CreateCorvidPrcObligations < ActiveRecord::Migration[8.1]
       t.string :payment_system
       t.string :rate_source
       t.string :recovery_confidence, null: false
-      t.decimal :medicare_equivalent, precision: 12, scale: 2
-      t.decimal :overpayment, precision: 12, scale: 2
+      t.bigint :medicare_equivalent_cents
+      t.bigint :overpayment_cents
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.text :notes
       t.datetime :analyzed_at, null: false
 

--- a/features/prc/multi_currency.feature
+++ b/features/prc/multi_currency.feature
@@ -1,0 +1,46 @@
+Feature: PRC obligations across international currencies
+  As corvid expanding beyond US tribal IHS
+  I need each tenant's monetary values stored in their own currency
+  So that USD + JOD never silently sum, JOD's 1000 fils stays correct,
+  and historical records are immutable across tenant reconfiguration
+
+  # Per ADR 0004:
+  # - Storage is integer subunit-cents (USD: 100/dollar, JOD: 1000/dinar,
+  #   SEK: 100/krona, CAD: 100/dollar). The gem looks up the divisor by
+  #   ISO 4217 code; nothing in corvid hardcodes "100".
+  # - Cross-currency arithmetic raises by default, forcing reports to
+  #   handle multi-currency explicitly.
+
+  Scenario: Yakama Nation PRC obligation stores in USD cents
+    Given a tenant "tnt_yakama" denominated in "USD"
+    When I record a PRC obligation billed at 65000.00
+    Then the obligation's billed_amount_cents is 6500000
+    And the obligation's currency_iso is "USD"
+    And reading the obligation back yields Money of 65000 USD
+
+  Scenario: Inera Sweden tenant stores in SEK öre
+    Given a tenant "tnt_inera" denominated in "SEK"
+    When I record a PRC obligation billed at 1200.00
+    Then the obligation's billed_amount_cents is 120000
+    And the obligation's currency_iso is "SEK"
+    And reading the obligation back yields Money of 1200 SEK
+
+  Scenario: Jordan Hakeem tenant stores in JOD fils — 1000 per dinar, not 100
+    Given a tenant "tnt_hakeem" denominated in "JOD"
+    When I record a PRC obligation billed at 142.00
+    Then the obligation's billed_amount_cents is 142000
+    And the obligation's currency_iso is "JOD"
+    And reading the obligation back yields Money of 142 JOD
+
+  Scenario: FNDHO Ontario tenant stores in CAD cents
+    Given a tenant "tnt_fndho" denominated in "CAD"
+    When I record a PRC obligation billed at 350.50
+    Then the obligation's billed_amount_cents is 35050
+    And the obligation's currency_iso is "CAD"
+    And reading the obligation back yields Money of 350.50 CAD
+
+  Scenario: Cross-currency arithmetic raises rather than silently summing
+    Given a tenant "tnt_yakama" denominated in "USD"
+    And a tenant "tnt_hakeem" denominated in "JOD"
+    When I try to add the USD obligation and the JOD obligation
+    Then the engine raises a cross-currency error

--- a/features/step_definitions/multi_currency_steps.rb
+++ b/features/step_definitions/multi_currency_steps.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# State carried between steps: { tenant_id => Money instance }
-@multi_currency_billed ||= {}
-
 Given("a tenant {string} denominated in {string}") do |tenant_id, iso|
   @tenants ||= {}
   @tenants[tenant_id] = iso

--- a/features/step_definitions/multi_currency_steps.rb
+++ b/features/step_definitions/multi_currency_steps.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# State carried between steps: { tenant_id => Money instance }
+@multi_currency_billed ||= {}
+
+Given("a tenant {string} denominated in {string}") do |tenant_id, iso|
+  @tenants ||= {}
+  @tenants[tenant_id] = iso
+end
+
+When("I record a PRC obligation billed at {float}") do |amount|
+  raise "no tenant set" if @tenants.nil? || @tenants.empty?
+  tenant_id, iso = @tenants.first
+  Corvid::TenantContext.with_tenant(tenant_id) do
+    @obligation = Corvid::PrcObligation.create!(
+      facility_identifier: "FAC",
+      obligation_id: "OBL-#{iso}-#{SecureRandom.hex(4)}",
+      billed_amount: Money.from_amount(amount, iso),
+      currency_iso: iso,
+      fiscal_year: 2026,
+      imported_at: Time.current
+    )
+  end
+end
+
+Then("the obligation's billed_amount_cents is {int}") do |cents|
+  assert_equal cents, @obligation.billed_amount_cents
+end
+
+Then("the obligation's currency_iso is {string}") do |iso|
+  assert_equal iso, @obligation.currency_iso
+end
+
+Then("reading the obligation back yields Money of {float} {word}") do |amount, iso|
+  Corvid::TenantContext.with_tenant(@tenants.keys.first) do
+    reloaded = Corvid::PrcObligation.find(@obligation.id)
+    assert_equal Money.from_amount(amount, iso), reloaded.billed_amount
+  end
+end
+
+When("I try to add the USD obligation and the JOD obligation") do
+  Corvid::TenantContext.with_tenant("tnt_yakama") do
+    @usd_ob = Corvid::PrcObligation.create!(
+      facility_identifier: "SEA",
+      obligation_id: "OBL-USD-#{SecureRandom.hex(4)}",
+      billed_amount: Money.from_amount(100, "USD"),
+      currency_iso: "USD",
+      fiscal_year: 2026,
+      imported_at: Time.current
+    )
+  end
+  Corvid::TenantContext.with_tenant("tnt_hakeem") do
+    @jod_ob = Corvid::PrcObligation.create!(
+      facility_identifier: "AMM",
+      obligation_id: "OBL-JOD-#{SecureRandom.hex(4)}",
+      billed_amount: Money.from_amount(100, "JOD"),
+      currency_iso: "JOD",
+      fiscal_year: 2026,
+      imported_at: Time.current
+    )
+  end
+end
+
+Then("the engine raises a cross-currency error") do
+  assert_raises(Money::Bank::UnknownRate) do
+    @usd_ob.billed_amount + @jod_ob.billed_amount
+  end
+end

--- a/lib/corvid/engine.rb
+++ b/lib/corvid/engine.rb
@@ -2,6 +2,7 @@
 
 require "rails/engine"
 require "aasm"
+require "money-rails"
 require "ostruct"
 
 module Corvid
@@ -14,6 +15,19 @@ module Corvid
         unless app.config.paths["db/migrate"].include?(expanded_path)
           app.config.paths["db/migrate"] << expanded_path
         end
+      end
+    end
+
+    # Money-rails defaults per ADR 0004. Every monetized model declares
+    # `monetize ..., with_model_currency: :currency_iso` so cross-currency
+    # arithmetic raises by default. Global default is USD; international
+    # tenants set per-row currency_iso when those onboardings happen.
+    initializer "corvid.money_rails" do
+      MoneyRails.configure do |config|
+        config.default_currency = :usd
+        config.no_cents_if_whole = false
+        config.symbol = false
+        config.locale_backend = :i18n
       end
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -43,10 +43,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.string "patient_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["tenant_identifier", "api_name", "app_identifier"], name: "idx_corvid_api_calls_tenant_app"
-    t.index ["tenant_identifier", "api_name", "called_at"], name: "idx_corvid_api_calls_tenant_api_time"
-    t.index ["tenant_identifier", "api_name", "patient_identifier"], name: "idx_corvid_api_calls_tenant_patient"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
+    t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
+    t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
+    t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -64,9 +64,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
   end
 
   create_table "corvid_care_team_members", force: :cascade do |t|
@@ -92,7 +92,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -110,7 +110,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -133,8 +133,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -167,8 +167,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -203,7 +203,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -223,8 +223,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -307,21 +307,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
-    t.decimal "balance", precision: 12, scale: 2
-    t.decimal "billed_amount", precision: 12, scale: 2
+    t.bigint "balance_cents"
+    t.bigint "billed_amount_cents"
     t.datetime "created_at", null: false
+    t.string "currency_iso", limit: 3, default: "USD", null: false
     t.string "facility_identifier", null: false
     t.integer "fiscal_year"
     t.datetime "imported_at", null: false
     t.string "obligation_id", null: false
-    t.decimal "paid_amount", precision: 12, scale: 2
+    t.bigint "paid_amount_cents"
     t.string "patient_dfn"
     t.string "procedure_code"
-    t.decimal "savings", precision: 12, scale: 2
+    t.bigint "savings_cents"
     t.date "service_date"
     t.string "source_file"
     t.string "status"
@@ -338,9 +339,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.datetime "analyzed_at", null: false
     t.string "analyzer_version", null: false
     t.datetime "created_at", null: false
-    t.decimal "medicare_equivalent", precision: 12, scale: 2
+    t.string "currency_iso", limit: 3, default: "USD", null: false
+    t.bigint "medicare_equivalent_cents"
     t.text "notes"
-    t.decimal "overpayment", precision: 12, scale: 2
+    t.bigint "overpayment_cents"
     t.string "payment_system"
     t.bigint "prc_obligation_id", null: false
     t.string "rate_source"
@@ -354,9 +356,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
   end
 
   create_table "corvid_prc_payments", force: :cascade do |t|
-    t.decimal "amount", precision: 12, scale: 2
+    t.bigint "amount_cents"
     t.string "check_number"
     t.datetime "created_at", null: false
+    t.string "currency_iso", limit: 3, default: "USD", null: false
     t.date "paid_date"
     t.string "payment_id", null: false
     t.bigint "prc_obligation_id", null: false
@@ -396,7 +399,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -422,8 +425,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/models/corvid/prc_money_test.rb
+++ b/test/models/corvid/prc_money_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Multi-currency tests for the PRC tables.
+#
+# Per ADR 0004:
+# - Storage is integer subunit-cents (USD: cents, JOD: fils, SEK: öre, CAD: cents).
+# - currency_iso is locked at write time and never updated.
+# - Cross-currency arithmetic raises Money::Bank::UnknownRate / IncompatibleCurrencyError.
+# - Reads return Money objects; the gem looks up subunit_to_unit from the ISO code.
+class Corvid::PrcMoneyTest < ActiveSupport::TestCase
+  TENANT_US     = "tnt_yakama"
+  TENANT_SE     = "tnt_inera"
+  TENANT_JO     = "tnt_hakeem"
+  TENANT_CA     = "tnt_fndho"
+
+  # -- Storage roundtrip across four currencies -------------------------------
+
+  test "USD obligation stores cents and reads back as Money" do
+    Corvid::TenantContext.with_tenant(TENANT_US) do
+      ob = create_obligation("USD", billed: 65_000.00)
+      assert_equal 6_500_000, ob.billed_amount_cents
+      assert_equal "USD", ob.currency_iso
+      assert_equal Money.from_amount(65_000, "USD"), ob.billed_amount
+      assert_kind_of Money, ob.billed_amount
+    end
+  end
+
+  test "SEK obligation stores öre (100 per krona) and reads back as Money" do
+    Corvid::TenantContext.with_tenant(TENANT_SE) do
+      ob = create_obligation("SEK", billed: 1_200.00)
+      assert_equal 120_000, ob.billed_amount_cents
+      assert_equal "SEK", ob.billed_amount.currency.iso_code
+      assert_equal Money.from_amount(1_200, "SEK"), ob.billed_amount
+    end
+  end
+
+  test "JOD obligation stores fils (1000 per dinar), not 100" do
+    # Critical subunit assertion — hardcoding 100 anywhere would yield 142000 fils
+    # for 142 JOD instead of the correct 142000.
+    Corvid::TenantContext.with_tenant(TENANT_JO) do
+      ob = create_obligation("JOD", billed: 142.00)
+      assert_equal 142_000, ob.billed_amount_cents,
+                   "JOD's subunit_to_unit is 1000, not 100 — money-rails must look it up by ISO code"
+      assert_equal "JOD", ob.billed_amount.currency.iso_code
+      assert_equal Money.from_amount(142, "JOD"), ob.billed_amount
+    end
+  end
+
+  test "CAD obligation stores cents (100 per dollar) and reads back as Money" do
+    Corvid::TenantContext.with_tenant(TENANT_CA) do
+      ob = create_obligation("CAD", billed: 350.50)
+      assert_equal 35_050, ob.billed_amount_cents
+      assert_equal "CAD", ob.billed_amount.currency.iso_code
+    end
+  end
+
+  # -- Currency immutability --------------------------------------------------
+
+  test "currency_iso defaults to USD on rows created without an explicit value" do
+    Corvid::TenantContext.with_tenant(TENANT_US) do
+      ob = Corvid::PrcObligation.create!(
+        facility_identifier: "SEA",
+        obligation_id: "OBL-DEFAULT",
+        imported_at: Time.current,
+        billed_amount_cents: 100
+      )
+      assert_equal "USD", ob.currency_iso
+    end
+  end
+
+  # -- Cross-currency safety --------------------------------------------------
+
+  test "cross-currency arithmetic raises so apples-and-oranges sums fail loudly" do
+    Corvid::TenantContext.with_tenant(TENANT_US) do
+      usd_ob = create_obligation("USD", billed: 100)
+      Corvid::TenantContext.with_tenant(TENANT_JO) do
+        jod_ob = create_obligation("JOD", billed: 100, obligation_id: "OBL-JO-1")
+        assert_raises(Money::Bank::UnknownRate) do
+          usd_ob.billed_amount + jod_ob.billed_amount
+        end
+      end
+    end
+  end
+
+  test "same-currency arithmetic across rows yields a Money in that currency" do
+    Corvid::TenantContext.with_tenant(TENANT_SE) do
+      a = create_obligation("SEK", billed: 100, obligation_id: "OBL-SE-A")
+      b = create_obligation("SEK", billed: 250, obligation_id: "OBL-SE-B")
+      total = a.billed_amount + b.billed_amount
+      assert_equal Money.from_amount(350, "SEK"), total
+      assert_equal "SEK", total.currency.iso_code
+    end
+  end
+
+  # -- Payment + Analysis money fields ---------------------------------------
+
+  test "PrcPayment monetizes amount with the row's currency" do
+    Corvid::TenantContext.with_tenant(TENANT_JO) do
+      ob = create_obligation("JOD", billed: 1000, obligation_id: "OBL-JO-PMT")
+      pmt = Corvid::PrcPayment.create!(
+        prc_obligation: ob,
+        payment_id: "PMT-JO-1",
+        amount_cents: 500_000, # 500 JOD = 500_000 fils
+        currency_iso: "JOD"
+      )
+      assert_equal Money.from_amount(500, "JOD"), pmt.amount
+    end
+  end
+
+  test "PrcOverpaymentAnalysis monetizes medicare_equivalent and overpayment" do
+    Corvid::TenantContext.with_tenant(TENANT_CA) do
+      ob = create_obligation("CAD", billed: 800, obligation_id: "OBL-CA-1")
+      anl = Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        recovery_confidence: "clear",
+        medicare_equivalent_cents: 50_000, # 500 CAD
+        overpayment_cents: 30_000, # 300 CAD
+        currency_iso: "CAD",
+        analyzed_at: Time.current
+      )
+      assert_equal Money.from_amount(500, "CAD"), anl.medicare_equivalent
+      assert_equal Money.from_amount(300, "CAD"), anl.overpayment
+    end
+  end
+
+  private
+
+  def create_obligation(currency, billed:, obligation_id: "OBL-#{currency}-#{SecureRandom.hex(4)}")
+    Corvid::PrcObligation.create!(
+      facility_identifier: "FAC-#{currency}",
+      obligation_id: obligation_id,
+      billed_amount: Money.from_amount(billed, currency),
+      currency_iso: currency,
+      fiscal_year: 2026,
+      imported_at: Time.current
+    )
+  end
+end

--- a/test/models/corvid/prc_money_test.rb
+++ b/test/models/corvid/prc_money_test.rb
@@ -37,8 +37,9 @@ class Corvid::PrcMoneyTest < ActiveSupport::TestCase
   end
 
   test "JOD obligation stores fils (1000 per dinar), not 100" do
-    # Critical subunit assertion — hardcoding 100 anywhere would yield 142000 fils
-    # for 142 JOD instead of the correct 142000.
+    # Critical subunit assertion — hardcoding 100 anywhere would yield
+    # 14_200 fils for 142 JOD (interpreting it as 142 cents) instead of
+    # the correct 142_000 fils. The gem looks up the divisor by ISO code.
     Corvid::TenantContext.with_tenant(TENANT_JO) do
       ob = create_obligation("JOD", billed: 142.00)
       assert_equal 142_000, ob.billed_amount_cents,

--- a/test/models/corvid/prc_money_test.rb
+++ b/test/models/corvid/prc_money_test.rb
@@ -94,6 +94,47 @@ class Corvid::PrcMoneyTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Currency immutability --------------------------------------------------
+
+  test "currency_iso cannot be changed after a row is persisted" do
+    Corvid::TenantContext.with_tenant(TENANT_US) do
+      ob = create_obligation("USD", billed: 100, obligation_id: "OBL-LOCK-1")
+      ob.currency_iso = "EUR"
+      assert_raises(ActiveRecord::RecordInvalid) { ob.save! }
+      ob.reload
+      assert_equal "USD", ob.currency_iso, "the persisted value did not change"
+    end
+  end
+
+  test "currency_iso immutability is enforced on PrcPayment too" do
+    Corvid::TenantContext.with_tenant(TENANT_JO) do
+      ob = create_obligation("JOD", billed: 1000, obligation_id: "OBL-LOCK-PMT")
+      pmt = Corvid::PrcPayment.create!(
+        prc_obligation: ob,
+        payment_id: "PMT-LOCK-1",
+        amount_cents: 100_000,
+        currency_iso: "JOD"
+      )
+      pmt.currency_iso = "USD"
+      assert_raises(ActiveRecord::RecordInvalid) { pmt.save! }
+    end
+  end
+
+  test "currency_iso immutability is enforced on PrcOverpaymentAnalysis too" do
+    Corvid::TenantContext.with_tenant(TENANT_CA) do
+      ob = create_obligation("CAD", billed: 500, obligation_id: "OBL-LOCK-ANL")
+      anl = Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        recovery_confidence: "clear",
+        currency_iso: "CAD",
+        analyzed_at: Time.current
+      )
+      anl.currency_iso = "USD"
+      assert_raises(ActiveRecord::RecordInvalid) { anl.save! }
+    end
+  end
+
   # -- Payment + Analysis money fields ---------------------------------------
 
   test "PrcPayment monetizes amount with the row's currency" do

--- a/test/services/corvid/prc_importer_test.rb
+++ b/test/services/corvid/prc_importer_test.rb
@@ -91,14 +91,14 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
     with_tenant(TENANT) do
       Corvid::PrcImporter.import(SAMPLE, source_file: "test.prc")
       original_paid = Corvid::PrcObligation.find_by(obligation_id: "OBL-2009-000123").paid_amount
-      assert_equal 42_000.to_d, original_paid
+      assert_equal Money.from_amount(42_000, "USD"), original_paid
 
       # Same obligation_id but paid amount has been corrected to a new value
       updated = SAMPLE.sub("42000.00", "45000.00")
       Corvid::PrcImporter.import(updated, source_file: "test_corrected.prc")
 
       reloaded = Corvid::PrcObligation.find_by(obligation_id: "OBL-2009-000123")
-      assert_equal 45_000.to_d, reloaded.paid_amount,
+      assert_equal Money.from_amount(45_000, "USD"), reloaded.paid_amount,
                    "obligation row reflects the latest export's values"
       assert_equal "test_corrected.prc", reloaded.source_file,
                    "source_file updates to the most recent import"

--- a/test/services/corvid/prc_overpayment_report_service_test.rb
+++ b/test/services/corvid/prc_overpayment_report_service_test.rb
@@ -60,12 +60,12 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT)
 
     assert_equal 2, summary[:obligations_analyzed]
-    assert_equal 65_200.to_d, summary[:total_billed]
-    assert_equal 42_180.to_d, summary[:total_paid]
-    assert_equal 18_100.to_d, summary[:total_medicare_equivalent]
-    assert_equal 80.to_d, summary[:total_overpayment_known],
+    assert_equal Money.from_amount(65_200, "USD"), summary[:total_billed]
+    assert_equal Money.from_amount(42_180, "USD"), summary[:total_paid]
+    assert_equal Money.from_amount(18_100, "USD"), summary[:total_medicare_equivalent]
+    assert_equal Money.from_amount(80, "USD"), summary[:total_overpayment_known],
                  "clear-confidence overpayment is the recoverable-now total"
-    assert_equal 24_000.to_d, summary[:total_overpayment_stub_estimate],
+    assert_equal Money.from_amount(24_000, "USD"), summary[:total_overpayment_stub_estimate],
                  "stub-confidence overpayment is directional, not yet recoverable"
   end
 
@@ -75,7 +75,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     assert_equal 2, summary[:by_payment_system].size
     ipps_row = summary[:by_payment_system].find { |r| r[:payment_system] == "ipps" }
     assert_equal 1, ipps_row[:obligations]
-    assert_equal 24_000.to_d, ipps_row[:overpayment]
+    assert_equal Money.from_amount(24_000, "USD"), ipps_row[:overpayment]
 
     assert_equal 2, summary[:by_vendor].size
     assert_equal 2, summary[:by_year].size
@@ -84,8 +84,8 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
   test "summary filters by fiscal_year" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT, year: 2009)
     assert_equal 1, summary[:obligations_analyzed]
-    assert_equal 0.to_d, summary[:total_overpayment_known]
-    assert_equal 24_000.to_d, summary[:total_overpayment_stub_estimate]
+    assert_nil summary[:total_overpayment_known], "no clear-confidence rows in 2009"
+    assert_equal Money.from_amount(24_000, "USD"), summary[:total_overpayment_stub_estimate]
   end
 
   test "summary filters by recovery_confidence" do
@@ -93,7 +93,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       tenant: TENANT, recovery_confidence: "clear"
     )
     assert_equal 1, summary[:obligations_analyzed]
-    assert_equal 80.to_d, summary[:total_overpayment_known]
+    assert_equal Money.from_amount(80, "USD"), summary[:total_overpayment_known]
   end
 
   test "summary filters by payment_system and vendor_id" do
@@ -116,7 +116,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     assert_equal "phase_1.5", hip_row[:analyzer_version]
     assert_equal "fy09.prc", hip_row[:source_file]
     assert_equal "stub_estimate", hip_row[:recovery_confidence]
-    assert_equal 24_000.to_d, hip_row[:overpayment]
+    assert_equal Money.from_amount(24_000, "USD"), hip_row[:overpayment]
   end
 
   test "detail uses each obligation's most recent analysis when history exists" do
@@ -137,7 +137,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     hip_row = rows.find { |r| r[:obligation_id] == "OBL-A" }
     assert_equal "phase_2.0", hip_row[:analyzer_version]
     assert_equal "clear", hip_row[:recovery_confidence]
-    assert_equal 20_000.to_d, hip_row[:overpayment]
+    assert_equal Money.from_amount(20_000, "USD"), hip_row[:overpayment]
   end
 
   # -- CSV outputs ------------------------------------------------------------

--- a/test/services/corvid/prc_overpayment_report_service_test.rb
+++ b/test/services/corvid/prc_overpayment_report_service_test.rb
@@ -289,6 +289,40 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Currency-aware decimal places -----------------------------------------
+
+  test "JOD CSV money fields use 3 decimal places (fils), not 2" do
+    tenant = "tnt_jod_csv"
+    Corvid::TenantContext.with_tenant(tenant) do
+      ob = Corvid::PrcObligation.create!(
+        facility_identifier: "AMM",
+        obligation_id: "OBL-JOD-FMT",
+        billed_amount_cents: 142_000, # 142 JOD
+        paid_amount_cents: 100_000,
+        currency_iso: "JOD",
+        fiscal_year: 2026,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        recovery_confidence: "clear",
+        currency_iso: "JOD",
+        medicare_equivalent_cents: 80_000,
+        overpayment_cents: 20_000,
+        analyzed_at: Time.current
+      )
+    end
+
+    csv = Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: tenant)
+    table = CSV.parse(csv, headers: true)
+    row = table.first
+    assert_equal "JOD", row["currency"]
+    assert_match(/\A\d+\.\d{3}\z/, row["billed_amount"],
+                 "JOD billed_amount=#{row['billed_amount'].inspect} should have 3 decimals (fils)")
+    assert_equal "142.000", row["billed_amount"]
+  end
+
   # -- Filter naming (fiscal_year vs year alias) ------------------------------
 
   test "fiscal_year: filter selects the federal-fiscal-year column" do

--- a/test/services/corvid/prc_overpayment_report_service_test.rb
+++ b/test/services/corvid/prc_overpayment_report_service_test.rb
@@ -56,17 +56,17 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
 
   # -- Summary ----------------------------------------------------------------
 
-  test "summary aggregates totals across all obligations" do
+  test "summary aggregates totals across all obligations, partitioned by currency" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT)
 
     assert_equal 2, summary[:obligations_analyzed]
-    assert_equal Money.from_amount(65_200, "USD"), summary[:total_billed]
-    assert_equal Money.from_amount(42_180, "USD"), summary[:total_paid]
-    assert_equal Money.from_amount(18_100, "USD"), summary[:total_medicare_equivalent]
-    assert_equal Money.from_amount(80, "USD"), summary[:total_overpayment_known],
-                 "clear-confidence overpayment is the recoverable-now total"
-    assert_equal Money.from_amount(24_000, "USD"), summary[:total_overpayment_stub_estimate],
-                 "stub-confidence overpayment is directional, not yet recoverable"
+    assert_equal 1, summary[:by_currency].size, "single-currency tenant has one bucket"
+    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
+    assert_equal Money.from_amount(65_200, "USD"), usd[:total_billed]
+    assert_equal Money.from_amount(42_180, "USD"), usd[:total_paid]
+    assert_equal Money.from_amount(18_100, "USD"), usd[:total_medicare_equivalent]
+    assert_equal Money.from_amount(80, "USD"), usd[:total_overpayment_known]
+    assert_equal Money.from_amount(24_000, "USD"), usd[:total_overpayment_stub_estimate]
   end
 
   test "summary breaks down by payment_system, vendor, and fiscal_year" do
@@ -84,8 +84,9 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
   test "summary filters by fiscal_year" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT, year: 2009)
     assert_equal 1, summary[:obligations_analyzed]
-    assert_nil summary[:total_overpayment_known], "no clear-confidence rows in 2009"
-    assert_equal Money.from_amount(24_000, "USD"), summary[:total_overpayment_stub_estimate]
+    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
+    assert_nil usd[:total_overpayment_known], "no clear-confidence rows in 2009"
+    assert_equal Money.from_amount(24_000, "USD"), usd[:total_overpayment_stub_estimate]
   end
 
   test "summary filters by recovery_confidence" do
@@ -93,7 +94,8 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       tenant: TENANT, recovery_confidence: "clear"
     )
     assert_equal 1, summary[:obligations_analyzed]
-    assert_equal Money.from_amount(80, "USD"), summary[:total_overpayment_known]
+    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
+    assert_equal Money.from_amount(80, "USD"), usd[:total_overpayment_known]
   end
 
   test "summary filters by payment_system and vendor_id" do
@@ -277,10 +279,13 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       end
     end
 
+    usd_bucket = parsed["summary"]["by_currency"].find { |b| b["currency"] == "USD" }
+    refute_nil usd_bucket
     %w[total_billed total_paid total_medicare_equivalent
        total_overpayment_known total_overpayment_stub_estimate].each do |col|
-      assert_kind_of String, parsed["summary"][col]
-      refute_match(/E/i, parsed["summary"][col])
+      next if usd_bucket[col].nil? # not all confidence buckets always populate
+      assert_kind_of String, usd_bucket[col]
+      refute_match(/E/i, usd_bucket[col])
     end
   end
 
@@ -295,6 +300,97 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     by_alias = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT, year: 2009)
     by_canon = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT, fiscal_year: 2009)
     assert_equal by_canon[:obligations_analyzed], by_alias[:obligations_analyzed]
+  end
+
+  # -- Mixed-currency tenant --------------------------------------------------
+
+  test "mixed-currency tenant produces per-currency summary buckets, never auto-FX" do
+    # Hypothetical: a tenant has historical USD records (locked at write)
+    # and a recent reconfiguration that started recording new rows in EUR.
+    # Per ADR 0004, the report shows them in separate currency buckets
+    # rather than summing across — the gem's loud-fail at this seam is the
+    # whole point.
+    tenant = "tnt_mixed"
+    Corvid::TenantContext.with_tenant(tenant) do
+      eur_ob = Corvid::PrcObligation.create!(
+        facility_identifier: "EU",
+        obligation_id: "OBL-EUR-1",
+        billed_amount_cents: 50_000, # 500 EUR
+        paid_amount_cents: 50_000,
+        currency_iso: "EUR",
+        fiscal_year: 2026,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: eur_ob,
+        analyzer_version: "phase_1.5",
+        recovery_confidence: "clear",
+        currency_iso: "EUR",
+        medicare_equivalent_cents: 30_000,
+        overpayment_cents: 20_000,
+        analyzed_at: Time.current
+      )
+
+      usd_ob = Corvid::PrcObligation.create!(
+        facility_identifier: "US",
+        obligation_id: "OBL-USD-1",
+        billed_amount_cents: 100_00, # 100 USD
+        paid_amount_cents: 100_00,
+        currency_iso: "USD",
+        fiscal_year: 2026,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: usd_ob,
+        analyzer_version: "phase_1.5",
+        recovery_confidence: "clear",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 50_00,
+        overpayment_cents: 50_00,
+        analyzed_at: Time.current
+      )
+    end
+
+    summary = Corvid::PrcOverpaymentReportService.summary(tenant: tenant)
+    assert_equal 2, summary[:obligations_analyzed]
+    assert_equal 2, summary[:by_currency].size, "two currency buckets, no merger"
+    assert_equal Money.from_amount(500, "EUR"),
+                 summary[:by_currency].find { |b| b[:currency] == "EUR" }[:total_billed]
+    assert_equal Money.from_amount(100, "USD"),
+                 summary[:by_currency].find { |b| b[:currency] == "USD" }[:total_billed]
+  end
+
+  test "mixed-currency CSV summary emits one row per (year, vendor, system, currency)" do
+    tenant = "tnt_mixed_csv"
+    Corvid::TenantContext.with_tenant(tenant) do
+      [ "USD", "EUR" ].each_with_index do |iso, i|
+        ob = Corvid::PrcObligation.create!(
+          facility_identifier: "F",
+          obligation_id: "OBL-#{iso}-#{i}",
+          vendor_id: "V1",
+          billed_amount_cents: 1000,
+          currency_iso: iso,
+          fiscal_year: 2026,
+          imported_at: Time.current
+        )
+        Corvid::PrcOverpaymentAnalysis.create!(
+          prc_obligation: ob,
+          analyzer_version: "phase_1.5",
+          recovery_confidence: "clear",
+          payment_system: "pfs",
+          currency_iso: iso,
+          overpayment_cents: 100,
+          analyzed_at: Time.current
+        )
+      end
+    end
+
+    csv = Corvid::PrcOverpaymentReportService.to_csv_summary(tenant: tenant)
+    table = CSV.parse(csv, headers: true)
+    assert_includes table.headers, "currency"
+    currencies = table.map { |r| r["currency"] }.sort
+    assert_equal [ "EUR", "USD" ], currencies,
+                 "mixed-currency rows split rather than summing across ISO codes"
   end
 
   # -- Tenant scoping ---------------------------------------------------------


### PR DESCRIPTION
## Summary

First implementation slice of [ADR 0004](docs/adr/0004-monetary-values.md). PRC obligations, payments, and overpayment analyses now store integer subunit-cents alongside an ISO 4217 \`currency_iso\` column locked at write time. Multi-currency tested across **USD** (Yakama / IHS), **SEK** (Inera Sweden), **JOD** (Jordan Hakeem — 1000 fils per dinar, exercised explicitly so the gem's subunit lookup is verified), and **CAD** (FNDHO Ontario).

## Trust boundaries (per ADR §7)

- Money objects flow inside services and models.
- The PRC importer is a wire-side boundary — it parses US-only RPMS exports and writes \`*_cents\` + \`currency_iso = "USD"\` via a \`to_cents\` helper.
- The overpayment report service consumes Money internally; CSV/JSON serializers convert to fixed-point string at the output edge via Money-aware \`fmt_money\`.
- Cross-currency arithmetic raises \`Money::Bank::UnknownRate\` so reports group by currency rather than auto-FXing.

## Pre-production note

Migration \`20260508000001\` is edited in place rather than adding a backfill — pre-production tables don't yet hold real data. Future slices follow the same recipe.

## Dependencies

- \`money-rails ~> 3.0\` (latest), pulls \`money 7.0.2\` and \`monetize 2.0.0\`.

## Test plan

- [x] 9 model tests in \`test/models/corvid/prc_money_test.rb\`: USD/SEK/JOD/CAD storage roundtrips, currency_iso default, cross-currency arithmetic raises, same-currency arithmetic works, payment + analysis accessor monetization.
- [x] 5 cucumber scenarios in \`features/prc/multi_currency.feature\` covering all four currencies + cross-currency error.
- [x] Existing report/importer tests updated to assert against \`Money\` objects.
- [x] Full minitest suite (722 runs / 1595 assertions / 0 failures) and cucumber (351 passing) green.

## Next slices (under #294)

Billing transactions → claim submissions → tenant payments → Case-domain estimates/approvals. Each follows the same recipe: edit migration in place, add monetize declarations, update wire-side adapters, update tests.

Refs #294