### PR TITLE
Money: tenant Payment on money-rails (slice 3 of #294)

### DIFF
--- a/app/models/corvid/payment.rb
+++ b/app/models/corvid/payment.rb
@@ -7,7 +7,10 @@ module Corvid
     self.table_name = "corvid_payments"
 
     include TenantScoped
+    include CurrencyImmutable
     include AASM
+
+    monetize :amount_cents, with_model_currency: :currency_iso
 
     validates :patient_identifier, presence: true
     validates :amount_cents, presence: true, numericality: { greater_than: 0 }
@@ -20,8 +23,13 @@ module Corvid
     scope :succeeded, -> { where(status: "succeeded") }
     scope :for_patient, ->(id) { where(patient_identifier: id) }
 
-    def self.total_collected
-      succeeded.sum(:amount_cents) / 100.0
+    # Per ADR 0004: aggregations partition by currency so a multi-
+    # currency tenant never auto-FXes. Returns { iso => Money }; an
+    # empty scope returns {}.
+    def self.totals_collected_by_currency
+      succeeded.group(:currency_iso).sum(:amount_cents).each_with_object({}) do |(iso, cents), out|
+        out[iso] = Money.new(cents, iso)
+      end
     end
 
     aasm column: :status do
@@ -45,7 +53,13 @@ module Corvid
       end
     end
 
+    # Legacy convenience accessor — returns USD-equivalent dollars as
+    # a Float. Currency-aware callers should use `amount` (a Money)
+    # directly. Kept for backward compatibility with US-only call
+    # sites; raises on non-USD rows so multi-currency callers can't
+    # silently use the wrong unit.
     def amount_dollars
+      raise "amount_dollars is USD-only; use #amount for currency-aware code" unless currency_iso == "USD"
       amount_cents / 100.0
     end
 

--- a/db/migrate/20260415000004_create_corvid_billing_tables.rb
+++ b/db/migrate/20260415000004_create_corvid_billing_tables.rb
@@ -69,7 +69,8 @@ class CreateCorvidBillingTables < ActiveRecord::Migration[8.1]
       t.string :facility_identifier
       t.string :patient_identifier, null: false
       t.string :payment_identifier
-      t.integer :amount_cents, null: false
+      t.bigint :amount_cents, null: false
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.string :status, null: false, default: "pending"
       t.string :description
       t.string :claim_submission_identifier

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -294,9 +294,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
   end
 
   create_table "corvid_payments", force: :cascade do |t|
-    t.integer "amount_cents", null: false
+    t.bigint "amount_cents", null: false
     t.string "claim_submission_identifier"
     t.datetime "created_at", null: false
+    t.string "currency_iso", limit: 3, default: "USD", null: false
     t.string "description"
     t.string "facility_identifier"
     t.string "patient_identifier", null: false

--- a/test/models/corvid/payment_test.rb
+++ b/test/models/corvid/payment_test.rb
@@ -123,12 +123,30 @@ module Corvid
 
     # -- Total collected ------------------------------------------------------
 
-    test "total_collected sums succeeded payments" do
+    test "totals_collected_by_currency sums succeeded payments per currency" do
       Payment.create!(patient_identifier: "pt_tc", amount_cents: 5000, status: "succeeded")
       Payment.create!(patient_identifier: "pt_tc", amount_cents: 3000, status: "succeeded")
       Payment.create!(patient_identifier: "pt_tc", amount_cents: 2000, status: "failed")
 
-      assert_equal 80.0, Payment.total_collected
+      totals = Payment.totals_collected_by_currency
+      assert_equal Money.from_amount(80, "USD"), totals["USD"]
+    end
+
+    test "totals_collected_by_currency splits mixed-currency tenants into buckets" do
+      Payment.create!(patient_identifier: "pt_mc", amount_cents: 5000,
+                      currency_iso: "USD", status: "succeeded")
+      Payment.create!(patient_identifier: "pt_mc", amount_cents: 7000,
+                      currency_iso: "EUR", status: "succeeded")
+
+      totals = Payment.totals_collected_by_currency
+      assert_equal Money.from_amount(50, "USD"), totals["USD"]
+      assert_equal Money.from_amount(70, "EUR"), totals["EUR"]
+    end
+
+    test "currency_iso is immutable once a payment is persisted" do
+      pmt = Payment.create!(patient_identifier: "pt_lock", amount_cents: 1000, status: "pending")
+      pmt.currency_iso = "EUR"
+      assert_raises(ActiveRecord::RecordInvalid) { pmt.save! }
     end
 
     # -- Refundable? edge cases -----------------------------------------------


### PR DESCRIPTION
## Summary

Third slice of [ADR 0004](docs/adr/0004-monetary-values.md). Payment already stored \`amount_cents\` but had no currency awareness — this PR adds:

- \`currency_iso CHAR(3) NOT NULL DEFAULT 'USD'\` column on \`corvid_payments\`.
- \`monetize :amount_cents, with_model_currency: :currency_iso\`.
- \`CurrencyImmutable\` concern (locked at write).
- \`amount_cents\` column type bumped from \`integer\` to \`bigint\` to match the rest of the engine's monetary columns and lift the 2.1M-USD ceiling that 32-bit integers would otherwise impose.

## API changes

- \`Payment.total_collected\` (returned \`Float\`) → \`Payment.totals_collected_by_currency\` (returns \`{ "USD" => Money(...), "EUR" => Money(...) }\`). Multi-currency tenants get one bucket per ISO code rather than a silently-summed total.
- \`Payment#amount_dollars\` stays as a USD-only legacy convenience but now raises on non-USD rows so callers can't silently use the wrong unit. Currency-aware code should use \`#amount\` (the Money virtual accessor).

## Test plan

- [x] Updated \`total_collected\` test to assert per-currency Money buckets.
- [x] New mixed-currency aggregation test (USD + EUR).
- [x] New immutability test (raises \`ActiveRecord::RecordInvalid\` on currency change after persistence).
- [x] 738 minitest assertions / 0 failures, 375 cucumber scenarios / 0 failures locally.

## Out of scope

Case-domain estimates/approvals (\`estimated_cost\`, \`approved_amount\`, \`requested_amount\`) — final monetary slice per the ADR. That's the next PR.

Refs #294