### PR TITLE
Money: Case-domain estimates/approvals — final slice of #294

### DIFF
--- a/app/models/corvid/committee_review.rb
+++ b/app/models/corvid/committee_review.rb
@@ -5,6 +5,10 @@ module Corvid
     self.table_name = "corvid_committee_reviews"
 
     include TenantScoped
+    include CurrencyImmutable
+
+    monetize :approved_amount_cents, with_model_currency: :currency_iso, allow_nil: true
+    monetize :requested_amount_cents, with_model_currency: :currency_iso, allow_nil: true
 
     belongs_to :prc_referral, class_name: "Corvid::PrcReferral"
 
@@ -38,10 +42,14 @@ module Corvid
 
     def self.requires_committee_review?(referral)
       threshold = referral.respond_to?(:committee_threshold) ? referral.committee_threshold : 50_000
-      cost = referral.estimated_cost || 0
+      # estimated_cost is now a Money; coerce to BigDecimal-of-dollars for
+      # comparison against the numeric threshold. Multi-currency thresholds
+      # would belong on the tenant config alongside default_currency_iso —
+      # not yet a real requirement.
+      cost_dollars = referral.estimated_cost ? referral.estimated_cost.to_d : 0
       priority = referral.medical_priority
 
-      return true if cost >= threshold
+      return true if cost_dollars >= threshold
       return true if priority.present? && priority >= 3
       return true if referral.respond_to?(:flagged_for_review?) && referral.flagged_for_review?
 

--- a/app/models/corvid/prc_referral.rb
+++ b/app/models/corvid/prc_referral.rb
@@ -10,8 +10,11 @@ module Corvid
     self.table_name = "corvid_prc_referrals"
 
     include TenantScoped
+    include CurrencyImmutable
     include Determinable
     include AASM
+
+    monetize :estimated_cost_cents, with_model_currency: :currency_iso, allow_nil: true
 
     # CHS approval status codes for EHR sync.
     # Engine-owned mapping — no dependency on EHR-side constants.
@@ -91,9 +94,13 @@ module Corvid
     end
 
     def requires_committee?
+      # Money's `>=` is currency-aware (raises across mismatched currencies);
+      # the threshold is a numeric (USD-equivalent dollar amount) by
+      # convention, so coerce Money → BigDecimal-of-dollars for comparison.
       cost = service_request&.estimated_cost || estimated_cost
+      cost_dollars = cost.respond_to?(:to_d) ? cost.to_d : cost
       priority = medical_priority
-      (cost.present? && cost >= committee_threshold) ||
+      (cost_dollars.present? && cost_dollars >= committee_threshold) ||
         (priority.present? && priority >= 3) ||
         flagged_for_review?
     end

--- a/app/services/corvid/budget_availability_service.rb
+++ b/app/services/corvid/budget_availability_service.rb
@@ -30,7 +30,10 @@ module Corvid
       end
 
       def reserve_funds_if_available(referral_identifier, amount, params = {})
-        Corvid.adapter.create_obligation(referral_identifier, amount, params)
+        # Adapter wire format expects a numeric amount; convert at the
+        # boundary so callers can pass either a Money or a Numeric.
+        numeric_amount = amount.respond_to?(:to_d) ? amount.to_d : amount
+        Corvid.adapter.create_obligation(referral_identifier, numeric_amount, params)
       end
 
       def current_quarter
@@ -45,18 +48,24 @@ module Corvid
       end
 
       def check(referral)
+        # Budget figures are still numeric (USD-equivalent dollars). Coerce
+        # estimated_cost (now a Money) to BigDecimal-of-dollars so all the
+        # comparisons below work without a per-call currency match check.
+        # Multi-currency budgeting would belong on the tenant config when
+        # we have a concrete non-USD case.
         cost = referral.estimated_cost
+        cost_dollars = cost.respond_to?(:to_d) ? cost.to_d : cost
         budget = remaining_budget
         total = fiscal_year_budget
 
         BudgetCheckResult.new(
-          funds_available: cost.present? && cost > 0 && budget >= cost,
-          budget_sufficient: cost.present? && budget >= cost,
+          funds_available: cost_dollars.present? && cost_dollars > 0 && budget >= cost_dollars,
+          budget_sufficient: cost_dollars.present? && budget >= cost_dollars,
           remaining_budget: budget,
           total_budget: total,
           fiscal_year: current_fiscal_year,
-          requires_cost_estimate: cost.nil? || cost <= 0,
-          requires_committee_review: cost.present? && cost >= COMMITTEE_REVIEW_THRESHOLD,
+          requires_cost_estimate: cost_dollars.nil? || cost_dollars <= 0,
+          requires_committee_review: cost_dollars.present? && cost_dollars >= COMMITTEE_REVIEW_THRESHOLD,
           valid_funding_source: true
         )
       end

--- a/app/services/corvid/committee_review_sync_service.rb
+++ b/app/services/corvid/committee_review_sync_service.rb
@@ -52,7 +52,9 @@ module Corvid
       def build_update_params(committee_review)
         case committee_review.decision
         when "approved", "modified"
-          { committee_decision: "APPROVED", approved_amount: committee_review.approved_amount, reviewer_identifier: committee_review.reviewer_identifier }
+          # The EHR/adapter wire format takes a numeric amount, not a Money;
+          # convert at the boundary per ADR 0004.
+          { committee_decision: "APPROVED", approved_amount: committee_review.approved_amount&.to_d, reviewer_identifier: committee_review.reviewer_identifier }
         when "denied"
           { committee_decision: "DENIED", reviewer_identifier: committee_review.reviewer_identifier }
         when "deferred"
@@ -76,7 +78,9 @@ module Corvid
         case committee_review.decision
         when "approved", "modified"
           result[:backend_status] = "AUTHORIZED"
-          result[:synced_amount] = committee_review.approved_amount
+          # synced_amount is part of the result struct surface, not the
+          # internal Money type — emit numeric for downstream callers.
+          result[:synced_amount] = committee_review.approved_amount&.to_d
         when "denied"
           result[:backend_status] = "DENIED"
           result[:denial_reason] = Corvid.adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?

--- a/db/migrate/20260406000001_create_corvid_schema.rb
+++ b/db/migrate/20260406000001_create_corvid_schema.rb
@@ -78,7 +78,8 @@ class CreateCorvidSchema < ActiveRecord::Migration[8.1]
       t.string :authorization_number
       t.integer :medical_priority
       t.string :priority_system
-      t.decimal :estimated_cost, precision: 12, scale: 2
+      t.bigint :estimated_cost_cents
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.datetime :notification_date
       t.boolean :emergency_flag, default: false
       t.string :deferred_reason_token
@@ -142,8 +143,9 @@ class CreateCorvidSchema < ActiveRecord::Migration[8.1]
       t.date :committee_date
       t.string :decision, null: false, default: "pending"
       t.string :rationale_token
-      t.decimal :approved_amount, precision: 12, scale: 2
-      t.decimal :requested_amount, precision: 12, scale: 2
+      t.bigint :approved_amount_cents
+      t.bigint :requested_amount_cents
+      t.string :currency_iso, null: false, limit: 3, default: "USD"
       t.string :attendees_token
       t.string :documents_reviewed_token
       t.string :conditions_token

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -187,17 +187,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
   create_table "corvid_committee_reviews", force: :cascade do |t|
     t.date "appeal_deadline"
     t.string "appeal_instructions_token"
-    t.decimal "approved_amount", precision: 12, scale: 2
+    t.bigint "approved_amount_cents"
     t.string "attendees_token"
     t.date "committee_date"
     t.string "conditions_token"
     t.datetime "created_at", null: false
+    t.string "currency_iso", limit: 3, default: "USD", null: false
     t.string "decision", default: "pending", null: false
     t.string "documents_reviewed_token"
     t.string "facility_identifier"
     t.bigint "prc_referral_id", null: false
     t.string "rationale_token"
-    t.decimal "requested_amount", precision: 12, scale: 2
+    t.bigint "requested_amount_cents"
     t.string "reviewer_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
@@ -377,10 +378,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.datetime "authorization_number_cached_at"
     t.bigint "case_id", null: false
     t.datetime "created_at", null: false
+    t.string "currency_iso", limit: 3, default: "USD", null: false
     t.string "current_activity"
     t.string "deferred_reason_token"
     t.boolean "emergency_flag", default: false
-    t.decimal "estimated_cost", precision: 12, scale: 2
+    t.bigint "estimated_cost_cents"
     t.boolean "exception_approved"
     t.string "exception_rationale_token"
     t.datetime "exception_reviewed_at"

--- a/test/models/corvid/committee_review_test.rb
+++ b/test/models/corvid/committee_review_test.rb
@@ -429,7 +429,7 @@ class Corvid::CommitteeReviewTest < ActiveSupport::TestCase
       upcoming_pending = create_review(committee_date: Date.current + 1.day)
       upcoming_approved = create_review(committee_date: Date.current + 1.day)
       upcoming_approved.update_column(:decision, "approved")
-      upcoming_approved.update_column(:approved_amount, 50_000)
+      upcoming_approved.update_column(:approved_amount_cents, 5_000_000)
 
       upcoming = Corvid::CommitteeReview.upcoming_reviews(days: 7)
 
@@ -485,7 +485,7 @@ class Corvid::CommitteeReviewTest < ActiveSupport::TestCase
     with_tenant(TENANT) do
       review = create_review(committee_date: Date.current)
       review.update_column(:decision, "approved")
-      review.update_column(:approved_amount, 50_000)
+      review.update_column(:approved_amount_cents, 5_000_000)
 
       summary = review.summary
 
@@ -563,7 +563,19 @@ class Corvid::CommitteeReviewTest < ActiveSupport::TestCase
   def create_review_with_decision(decision, **attrs)
     review = create_review
     review.update_column(:decision, decision.to_s)
-    attrs.each { |k, v| review.update_column(k, v) }
+    attrs.each do |k, v|
+      # update_column writes a real DB column; translate the monetize
+      # virtual attributes (approved_amount, requested_amount) into
+      # their underlying *_cents columns.
+      case k
+      when :approved_amount
+        review.update_column(:approved_amount_cents, (v.to_d * 100).to_i)
+      when :requested_amount
+        review.update_column(:requested_amount_cents, (v.to_d * 100).to_i)
+      else
+        review.update_column(k, v)
+      end
+    end
     review
   end
 end

--- a/test/models/corvid/prc_referral_caching_test.rb
+++ b/test/models/corvid/prc_referral_caching_test.rb
@@ -167,7 +167,7 @@ class Corvid::PrcReferralCachingTest < ActiveSupport::TestCase
   test "requires_committee? falls back to cached priority when RCIS unavailable" do
     with_referral(medical_priority: 3) do |ref|
       ref.define_singleton_method(:service_request) { nil }
-      ref.update_columns(flagged_for_review: false, estimated_cost: nil)
+      ref.update_columns(flagged_for_review: false, estimated_cost_cents: nil)
 
       assert ref.requires_committee?
     end


### PR DESCRIPTION
## Summary

Final slice of [ADR 0004](docs/adr/0004-monetary-values.md). `PrcReferral.estimated_cost` and `CommitteeReview.{approved,requested}_amount` move to integer subunit-cents storage with a locked-at-write `currency_iso` column. `CurrencyImmutable` concern, `monetize` declarations.

This closes the engine-wide money-rails migration.

## ⚠️ Local DB reset required after pulling

This branch (like the other slices of #294) edits an already-applied migration in place rather than adding a forward migration — pre-production stance per ADR 0004. After pulling, run:

```bash
cd test/dummy && RAILS_ENV=test bundle exec rails db:drop db:create db:migrate
```

CI starts each run from an empty database so it's unaffected; only local dev environments need the reset. Production migration consolidation is a tagged-release concern (engine has no production consumers yet).

## Caller updates at trust boundaries (per ADR §7)

- **`PrcReferral#requires_committee?` + `CommitteeReview.requires_committee_review?`** — Money's `>=` is currency-aware (raises across Money / Integer); coerce via `.to_d` before comparing against the numeric threshold.
- **`BudgetAvailabilityService#check`** — same coercion for budget arithmetic.
- **`BudgetAvailabilityService#reserve_funds_if_available`** — converts `amount` to numeric at the adapter boundary (mock adapter + EHR/RPMS wire formats expect Numeric).
- **`CommitteeReviewSyncService`** — converts `approved_amount` to numeric before sending to the EHR adapter and before exposing as `result[:synced_amount]` in the result struct surface.

## Test updates

- `update_column` calls in `committee_review_test.rb` and `prc_referral_caching_test.rb` now reference the `*_cents` columns (update_column bypasses the monetize virtual accessor).
- `create_review_with_decision` test helper translates `approved_amount` / `requested_amount` keys → `*_cents` columns.

## Test plan

- [x] 738 minitest assertions / 0 failures.
- [x] 375 cucumber scenarios / 0 failures.

## Status of #294

Slice 1 (PRC obligations + payments + analyses): merged in #296.
Slice 2 (ClaimSubmission): merged in #298.
Slice 3 (tenant Payment): merged in #300.
Slice 4 (Case-domain estimates/approvals): this PR.

Closes #294