### PR TITLE
Adapter injection pattern + first exemplar (slice 1 of #222)

### DIFF
--- a/app/services/corvid/committee_review_sync_service.rb
+++ b/app/services/corvid/committee_review_sync_service.rb
@@ -2,107 +2,128 @@
 
 module Corvid
   # Syncs committee review decisions to the EHR via adapter.
+  #
+  # Per #222 / ADR 0005: the adapter is injected per-instance rather
+  # than reached via the `Corvid.adapter` global. The class-method form
+  # accepts an `adapter:` kwarg (defaulting to `Corvid.adapter`) so
+  # existing call sites keep working while tests and per-tenant code
+  # paths can swap in their own adapters without mutating global state.
   class CommitteeReviewSyncService
-    class << self
-      def sync_decision(committee_review)
-        return { success: false, error: "Cannot sync pending decision" } if committee_review.pending?
-        return { success: false, error: "Missing referral IEN" } if missing_referral_identifier?(committee_review)
+    def initialize(adapter: Corvid.adapter)
+      @adapter = adapter
+    end
 
-        prc_referral = committee_review.prc_referral
-        identifier = prc_referral.referral_identifier
-        params = build_update_params(committee_review)
+    def sync_decision(committee_review)
+      return { success: false, error: "Cannot sync pending decision" } if committee_review.pending?
+      return { success: false, error: "Missing referral IEN" } if missing_referral_identifier?(committee_review)
 
-        success = update_ehr(identifier, params)
+      prc_referral = committee_review.prc_referral
+      identifier = prc_referral.referral_identifier
+      params = build_update_params(committee_review)
 
-        if success
-          build_success_result(committee_review)
-        else
-          { success: false, error: "Backend update failed" }
-        end
+      success = update_ehr(identifier, params)
+
+      if success
+        build_success_result(committee_review)
+      else
+        { success: false, error: "Backend update failed" }
+      end
+    rescue => e
+      { success: false, error: Corvid.sanitize_phi(e.message) }
+    end
+
+    def sync_and_apply!(committee_review)
+      sync_result = sync_decision(committee_review)
+      backend_synced = sync_result[:success]
+
+      referral_updated = false
+      begin
+        committee_review.apply_to_referral!
+        referral_updated = true
       rescue => e
-        { success: false, error: Corvid.sanitize_phi(e.message) }
+        Rails.logger.warn("CommitteeReviewSyncService: apply_to_referral! failed: #{e.message}")
       end
 
-      def sync_and_apply!(committee_review)
-        sync_result = sync_decision(committee_review)
-        backend_synced = sync_result[:success]
+      {
+        success: backend_synced && referral_updated,
+        backend_synced: backend_synced,
+        referral_updated: referral_updated,
+        sync_pending: !backend_synced
+      }
+    end
 
-        referral_updated = false
-        begin
-          committee_review.apply_to_referral!
-          referral_updated = true
-        rescue => e
-          Rails.logger.warn("CommitteeReviewSyncService: apply_to_referral! failed: #{e.message}")
-        end
-
-        {
-          success: backend_synced && referral_updated,
-          backend_synced: backend_synced,
-          referral_updated: referral_updated,
-          sync_pending: !backend_synced
-        }
+    # Class-method shims for backward compatibility. Existing callers
+    # `Corvid::CommitteeReviewSyncService.sync_decision(review)` keep
+    # working unchanged; new callers can pass `adapter:` to inject.
+    class << self
+      def sync_decision(committee_review, adapter: Corvid.adapter)
+        new(adapter: adapter).sync_decision(committee_review)
       end
 
-      private
+      def sync_and_apply!(committee_review, adapter: Corvid.adapter)
+        new(adapter: adapter).sync_and_apply!(committee_review)
+      end
+    end
 
-      def missing_referral_identifier?(committee_review)
-        committee_review.prc_referral&.referral_identifier.blank?
+    private
+
+    def missing_referral_identifier?(committee_review)
+      committee_review.prc_referral&.referral_identifier.blank?
+    end
+
+    def build_update_params(committee_review)
+      case committee_review.decision
+      when "approved", "modified"
+        # The EHR/adapter wire format takes a numeric amount, not a Money;
+        # convert at the boundary per ADR 0004.
+        { committee_decision: "APPROVED", approved_amount: committee_review.approved_amount&.to_d, reviewer_identifier: committee_review.reviewer_identifier }
+      when "denied"
+        { committee_decision: "DENIED", reviewer_identifier: committee_review.reviewer_identifier }
+      when "deferred"
+        { committee_decision: "DEFERRED", reviewer_identifier: committee_review.reviewer_identifier }
+      else
+        {}
+      end
+    end
+
+    def update_ehr(identifier, params)
+      @adapter.update_referral(identifier, params)
+    end
+
+    def build_success_result(committee_review)
+      result = {
+        success: true,
+        synced_at: Time.current,
+        committee_date: committee_review.committee_date
+      }
+
+      case committee_review.decision
+      when "approved", "modified"
+        result[:backend_status] = "AUTHORIZED"
+        # synced_amount is part of the result struct surface, not the
+        # internal Money type — emit numeric for downstream callers.
+        result[:synced_amount] = committee_review.approved_amount&.to_d
+      when "denied"
+        result[:backend_status] = "DENIED"
+        result[:denial_reason] = @adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
+      when "deferred"
+        result[:backend_status] = "PENDING"
+        result[:defer_reason] = @adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
       end
 
-      def build_update_params(committee_review)
-        case committee_review.decision
-        when "approved", "modified"
-          # The EHR/adapter wire format takes a numeric amount, not a Money;
-          # convert at the boundary per ADR 0004.
-          { committee_decision: "APPROVED", approved_amount: committee_review.approved_amount&.to_d, reviewer_identifier: committee_review.reviewer_identifier }
-        when "denied"
-          { committee_decision: "DENIED", reviewer_identifier: committee_review.reviewer_identifier }
-        when "deferred"
-          { committee_decision: "DEFERRED", reviewer_identifier: committee_review.reviewer_identifier }
-        else
-          {}
-        end
-      end
+      # Count synced items
+      result[:conditions_synced] = count_token_items(committee_review.conditions_token)
+      result[:attendees_synced] = count_token_items(committee_review.attendees_token)
 
-      def update_ehr(identifier, params)
-        Corvid.adapter.update_referral(identifier, params)
-      end
+      result
+    end
 
-      def build_success_result(committee_review)
-        result = {
-          success: true,
-          synced_at: Time.current,
-          committee_date: committee_review.committee_date
-        }
-
-        case committee_review.decision
-        when "approved", "modified"
-          result[:backend_status] = "AUTHORIZED"
-          # synced_amount is part of the result struct surface, not the
-          # internal Money type — emit numeric for downstream callers.
-          result[:synced_amount] = committee_review.approved_amount&.to_d
-        when "denied"
-          result[:backend_status] = "DENIED"
-          result[:denial_reason] = Corvid.adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
-        when "deferred"
-          result[:backend_status] = "PENDING"
-          result[:defer_reason] = Corvid.adapter.fetch_text(committee_review.rationale_token) if committee_review.rationale_token.present?
-        end
-
-        # Count synced items
-        result[:conditions_synced] = count_token_items(committee_review.conditions_token)
-        result[:attendees_synced] = count_token_items(committee_review.attendees_token)
-
-        result
-      end
-
-      def count_token_items(token)
-        return 0 unless token.present?
-        data = Corvid.adapter.fetch_text(token)
-        data.is_a?(Array) ? data.size : 0
-      rescue
-        0
-      end
+    def count_token_items(token)
+      return 0 unless token.present?
+      data = @adapter.fetch_text(token)
+      data.is_a?(Array) ? data.size : 0
+    rescue
+      0
     end
   end
 end

--- a/app/services/corvid/committee_review_sync_service.rb
+++ b/app/services/corvid/committee_review_sync_service.rb
@@ -32,6 +32,12 @@ module Corvid
       { success: false, error: Corvid.sanitize_phi(e.message) }
     end
 
+    # KNOWN LIMITATION (#264): the `apply_to_referral!` half drives AASM
+    # state transitions on PrcReferral whose `after:` callbacks call
+    # `Corvid.adapter.update_referral` directly. Until #264 lands the
+    # apply half is NOT routed through the injected `@adapter` — the
+    # `sync_decision` half is. Per-tenant adapter routing for the
+    # combined flow isn't safe yet; see ADR 0005 §"Known limitation".
     def sync_and_apply!(committee_review)
       sync_result = sync_decision(committee_review)
       backend_synced = sync_result[:success]

--- a/app/services/corvid/committee_review_sync_service.rb
+++ b/app/services/corvid/committee_review_sync_service.rb
@@ -47,7 +47,7 @@ module Corvid
         committee_review.apply_to_referral!
         referral_updated = true
       rescue => e
-        Rails.logger.warn("CommitteeReviewSyncService: apply_to_referral! failed: #{e.message}")
+        Rails.logger.warn("CommitteeReviewSyncService: apply_to_referral! failed: #{Corvid.sanitize_phi(e.message)}")
       end
 
       {

--- a/docs/adr/0005-adapter-injection.md
+++ b/docs/adr/0005-adapter-injection.md
@@ -1,0 +1,81 @@
+# ADR 0005: Adapter dependency injection in services
+
+**Status:** Proposed
+**Date:** 2026-05-09
+
+## Context
+
+Today every service in corvid reaches for `Corvid.adapter` directly — a global accessor backed by `Corvid.configuration.adapter`. That global made sense when the engine was single-tenant and single-backend, but it has accumulated three concrete costs:
+
+1. **Per-tenant adapter routing is impossible.** A US tribal tenant on RPMS-via-rpc and a Swedish Inera tenant on a FHIR adapter cannot coexist in one process — there is one global adapter, and rebinding it during request handling is racy.
+2. **Tests mutate global state.** Every test that needs a different adapter calls `Corvid.configure { |c| c.adapter = ... }`, which mutates the singleton for the duration of the test. Parallelizing the suite, or running adapter-contract tests against multiple backends, requires per-test isolation that the global precludes.
+3. **Adapter contract testing (#233) is awkward.** Asserting parity across mock / RPC / FHIR adapters wants instance-based DI: instantiate the service with each adapter in turn and run the same scenarios.
+
+Twenty source files touch `Corvid.adapter` directly today — eight services and twelve models. This ADR scopes the services half (#222); the model half is tracked separately under #264.
+
+## Decision
+
+1. **Services accept `adapter:` via the constructor.** The pattern is:
+
+   ```ruby
+   class FooService
+     def initialize(adapter: Corvid.adapter)
+       @adapter = adapter
+     end
+
+     def do_something(arg)
+       @adapter.some_call(arg)
+     end
+   end
+   ```
+
+   Default to `Corvid.adapter` so existing call sites and one-off scripts that don't care about DI keep working. Tests and per-tenant code paths inject explicitly.
+
+2. **Class-method form preserves backward compatibility.** Services that today expose static methods (`Corvid::FooService.do_something(arg)`) gain class-method shims that take `adapter:` and delegate to `new(adapter: adapter).do_something(arg)`:
+
+   ```ruby
+   class << self
+     def do_something(arg, adapter: Corvid.adapter)
+       new(adapter: adapter).do_something(arg)
+     end
+   end
+   ```
+
+   This keeps every existing caller in the engine, host apps, and step definitions working without touching them. A future PR can deprecate the class-method shims if no internal callers remain.
+
+3. **Models stay on the global for now.** Per #264, models also reach for `Corvid.adapter` (via concerns like `Determinable`, and directly in `PrcReferral#service_request`, `CommitteeReview#reviewer`, etc.). Refactoring models is meaningfully harder — they're often constructed implicitly by ActiveRecord and don't have a constructor we control. That's a separate ADR / issue.
+
+4. **Module-style services convert to class-style.** Some existing services are pure modules with `class << self` (e.g., `PrcImporter`, `OverpaymentRecovery::*`). When they need adapter injection, they become classes following the pattern above. Pure-function services that don't touch the adapter (e.g., `Timeline`, `PayoutCalculator`) stay as modules.
+
+5. **Rollout is staged across PRs.** This ADR ships with one exemplar (`CommitteeReviewSyncService`). Subsequent PRs convert the remaining seven adapter-touching services in `app/services/corvid/`, one cluster per PR, with the same pattern. Each PR adds an `_injection_test.rb` asserting the service routes through the injected adapter rather than the global.
+
+## Consequences
+
+### Positive
+
+- Per-tenant adapter routing becomes possible — a service instance carries its own adapter, so a job processing a Swedish tenant's records can use a SEK-aware adapter while a job processing a Yakama tenant's records uses RPMS.
+- Tests inject adapters per-instance; no more `Corvid.configure { |c| c.adapter = ... }` mutation pattern.
+- Adapter contract tests (#233) become straightforward: instantiate the service with each adapter implementation, run the same scenario, assert parity.
+- Migration to per-instance state is forward-compatible with the cross-product event bus (#261) and the future model decoupling (#264).
+
+### Negative
+
+- Eight services to refactor; each PR is mechanical but touches multiple methods.
+- The class-method shim layer is technical debt — it exists to keep callers working during the rollout. We'll need to revisit whether to keep it long-term once internal callers all use instances.
+- New `_injection_test.rb` files add test surface; parity checks are valuable but slow CI down a bit.
+
+### Alternatives considered
+
+- **Thread-local adapter override.** `Corvid.with_adapter(x) { ... }` Thread.current-based swap. Less invasive than DI, but: thread-local state is fragile under concurrent jobs/Sidekiq, doesn't help with parallel test runs, and doesn't compose with multi-tenant routing (one thread might handle requests for two tenants).
+- **Dependency container.** A container that resolves adapters by tenant key. Heavier than DI for the marginal benefit; can be layered on top of DI later if we ever need it.
+- **Leave the global; add documentation.** Cheap today, but every blocking-labeled architecture issue (#264, #233, #261) gets harder. Punting forward compounds the cost.
+- **Partial migration: only the services that need per-tenant routing.** Two-class system invites confusion. Better to migrate all services to one pattern even if not all of them have a near-term per-tenant story.
+
+## References
+
+- #222 Services should use instance-based injection instead of Corvid.adapter global
+- #264 Decouple models from Corvid.adapter global (deeper than #222)
+- #233 Add shared adapter contract tests for adapter parity
+- #261 Cross-product event bus abstraction
+- ADR 0002 Architectural foundations
+- ADR 0004 Monetary values (the trust-boundary pattern this ADR extends to adapter calls)

--- a/docs/adr/0005-adapter-injection.md
+++ b/docs/adr/0005-adapter-injection.md
@@ -49,6 +49,27 @@ Twenty source files touch `Corvid.adapter` directly today — eight services and
 
 5. **Rollout is staged across PRs.** This ADR ships with one exemplar (`CommitteeReviewSyncService`). Subsequent PRs convert the remaining seven adapter-touching services in `app/services/corvid/`, one cluster per PR, with the same pattern. Each PR adds an `_injection_test.rb` asserting the service routes through the injected adapter rather than the global.
 
+## Known limitation: model callback paths
+
+A service can be DI-clean and still leak through the global if any
+method on the service triggers an ActiveRecord callback that itself
+reads `Corvid.adapter` — the AASM `after:` hooks on `PrcReferral`
+(`sync_status_to_ehr`, etc.) are the canonical example. When
+`CommitteeReviewSyncService#sync_and_apply!` calls
+`committee_review.apply_to_referral!`, the apply half goes through
+those callbacks and routes through the global adapter regardless of
+what was injected at the service.
+
+This gap is **explicitly out of scope** for #222 and gated on #264
+(model decoupling). Services that touch model callback paths should:
+1. Document the partial routing in a code comment.
+2. Add an injection test that pins down which half is DI-clean and
+   which still goes through the global, so when #264 lands the test
+   tightens automatically rather than relying on memory.
+
+Until #264 lands, per-tenant adapter routing for any flow that
+crosses a model callback boundary is not safe.
+
 ## Consequences
 
 ### Positive

--- a/test/services/corvid/committee_review_sync_service_injection_test.rb
+++ b/test/services/corvid/committee_review_sync_service_injection_test.rb
@@ -32,6 +32,15 @@ class Corvid::CommitteeReviewSyncServiceInjectionTest < ActiveSupport::TestCase
 
   setup do
     @fake = RecordingAdapter.new
+    @original_adapter = Corvid.adapter
+  end
+
+  teardown do
+    # Each test below mutates Corvid.adapter (to poison it or replace
+    # it with a recording fake). test_helper.rb's setup re-resets the
+    # adapter for the next test, but explicit teardown here keeps this
+    # file self-contained and survives test_helper reorganizations.
+    Corvid.configure { |c| c.adapter = @original_adapter }
   end
 
   test "instance.sync_decision routes through the injected adapter, not Corvid.adapter" do

--- a/test/services/corvid/committee_review_sync_service_injection_test.rb
+++ b/test/services/corvid/committee_review_sync_service_injection_test.rb
@@ -56,6 +56,45 @@ class Corvid::CommitteeReviewSyncServiceInjectionTest < ActiveSupport::TestCase
     assert_includes @fake.calls.map(&:first), :update_referral
   end
 
+  test "sync_and_apply! routes the SYNC half through the injected adapter" do
+    # Half-pin: assert that the sync_decision portion of sync_and_apply!
+    # uses the injected adapter. The apply portion goes through model
+    # callbacks (PrcReferral AASM after-hooks → Corvid.adapter directly)
+    # — that's the documented #264 gap. We don't poison the global here
+    # because the apply half legitimately needs it until #264 lands.
+    review = build_approved_review
+    Corvid.configure { |c| c.adapter = Corvid::Adapters::MockAdapter.new }
+    service = Corvid::CommitteeReviewSyncService.new(adapter: @fake)
+
+    service.sync_and_apply!(review)
+
+    assert_includes @fake.calls.map(&:first), :update_referral,
+                    "the injected adapter must receive the sync_decision call"
+  end
+
+  test "sync_and_apply! apply half currently routes through Corvid.adapter (gated on #264)" do
+    # Boundary-pin: documents the limitation so when #264 lands and the
+    # model callbacks become DI-aware, this test will fail and prompt
+    # us to flip it into a stricter assertion ("apply half also routes
+    # through @adapter"). Until then, this is the fact on the ground.
+    review = build_approved_review
+    global = Corvid::Adapters::MockAdapter.new
+    spy_global = []
+    global.define_singleton_method(:update_referral) do |id, params|
+      spy_global << [ :update_referral, id, params ]
+      true
+    end
+    Corvid.configure { |c| c.adapter = global }
+
+    Corvid::CommitteeReviewSyncService.new(adapter: @fake).sync_and_apply!(review)
+
+    # When the model layer is decoupled in #264, this assertion should
+    # be inverted to `assert_empty spy_global` and the apply half should
+    # also land in @fake.calls.
+    assert spy_global.any?,
+           "apply_to_referral! is expected to route through the global until #264; if this test now reports @fake received the call instead, tighten the assertion"
+  end
+
   test "class .sync_decision still works with no kwarg, falling back to Corvid.adapter" do
     # Backward-compat path — existing callers that didn't know about DI
     # keep working. The global is the default, not the only option.
@@ -77,7 +116,11 @@ class Corvid::CommitteeReviewSyncServiceInjectionTest < ActiveSupport::TestCase
           patient_identifier: "p_inj", facility_identifier: "fac_inj"
         ),
         referral_identifier: "rf_inject_#{SecureRandom.hex(4)}",
-        status: "submitted"
+        # Must be in committee_review for `authorize!` to fire its
+        # after-callback; whiny_transitions=false would otherwise swallow
+        # the transition silently and the model-callback path we're
+        # trying to exercise would never run.
+        status: "committee_review"
       )
       Corvid::CommitteeReview.create!(
         prc_referral: ref,

--- a/test/services/corvid/committee_review_sync_service_injection_test.rb
+++ b/test/services/corvid/committee_review_sync_service_injection_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Per #222 / ADR 0005: services accept an `adapter:` kwarg so per-tenant
+# adapters and per-test fakes can be injected without mutating the
+# global Corvid.adapter. The class method form preserves backward
+# compatibility for existing callers.
+class Corvid::CommitteeReviewSyncServiceInjectionTest < ActiveSupport::TestCase
+  TENANT = "tnt_inject"
+
+  # Minimal fake adapter that records every call it receives — lets us
+  # assert that the service routed through the injected adapter rather
+  # than the global Corvid.adapter.
+  class RecordingAdapter
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def update_referral(identifier, params)
+      @calls << [ :update_referral, identifier, params ]
+      true
+    end
+
+    def fetch_text(token)
+      @calls << [ :fetch_text, token ]
+      "text-for-#{token}"
+    end
+  end
+
+  setup do
+    @fake = RecordingAdapter.new
+  end
+
+  test "instance.sync_decision routes through the injected adapter, not Corvid.adapter" do
+    review = build_approved_review
+    Corvid.configure { |c| c.adapter = poison_adapter } # blow up if global is used
+    service = Corvid::CommitteeReviewSyncService.new(adapter: @fake)
+
+    result = service.sync_decision(review)
+
+    assert result[:success], "expected success but got #{result.inspect}"
+    assert_includes @fake.calls.map(&:first), :update_referral,
+                    "the fake adapter must have received update_referral; got #{@fake.calls.inspect}"
+  end
+
+  test "class .sync_decision accepts adapter: kwarg without touching the global" do
+    review = build_approved_review
+    Corvid.configure { |c| c.adapter = poison_adapter }
+
+    result = Corvid::CommitteeReviewSyncService.sync_decision(review, adapter: @fake)
+
+    assert result[:success]
+    assert_includes @fake.calls.map(&:first), :update_referral
+  end
+
+  test "class .sync_decision still works with no kwarg, falling back to Corvid.adapter" do
+    # Backward-compat path — existing callers that didn't know about DI
+    # keep working. The global is the default, not the only option.
+    review = build_approved_review
+    Corvid.configure { |c| c.adapter = @fake }
+
+    result = Corvid::CommitteeReviewSyncService.sync_decision(review)
+
+    assert result[:success]
+    assert_includes @fake.calls.map(&:first), :update_referral
+  end
+
+  private
+
+  def build_approved_review
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ref = Corvid::PrcReferral.create!(
+        case: Corvid::Case.create!(
+          patient_identifier: "p_inj", facility_identifier: "fac_inj"
+        ),
+        referral_identifier: "rf_inject_#{SecureRandom.hex(4)}",
+        status: "submitted"
+      )
+      Corvid::CommitteeReview.create!(
+        prc_referral: ref,
+        committee_date: Date.current,
+        decision: "approved",
+        approved_amount_cents: 5_000_000,
+        currency_iso: "USD",
+        reviewer_identifier: "rv_inj"
+      )
+    end
+  end
+
+  def poison_adapter
+    Object.new.tap do |o|
+      def o.method_missing(name, *_a, **_kw)
+        raise "Corvid.adapter (the global) was used unexpectedly: ##{name}"
+      end
+
+      def o.respond_to_missing?(_n, _p = false); true; end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Establishes the DI pattern for #222 with [ADR 0005](docs/adr/0005-adapter-injection.md) and converts the first exemplar service. Subsequent PRs roll the same pattern to the remaining seven adapter-touching services.

## Pattern

\`\`\`ruby
class FooService
  def initialize(adapter: Corvid.adapter)
    @adapter = adapter
  end

  def do_something(arg)
    @adapter.some_call(arg)
  end

  class << self
    # Backward-compat shim — existing callers keep working.
    def do_something(arg, adapter: Corvid.adapter)
      new(adapter: adapter).do_something(arg)
    end
  end
end
\`\`\`

## What changed

- **ADR 0005** documents the pattern, alternatives considered, and rollout plan.
- **\`Corvid::CommitteeReviewSyncService\`** converted to instance form with a class-method shim.
- **3 injection tests** assert: instance routes through injected adapter; class method accepts \`adapter:\` kwarg; class method without kwarg still uses \`Corvid.adapter\` (backward compat).

## What's next per #222

Seven more services to convert (one PR per cluster, same pattern):
\`BudgetAvailabilityService\`, \`EligibilityChecklistService\`, \`PriorAuthorizationApiService\`, \`ProgramTemplateService\`, \`ChsReportingService\`, \`AuthorizationWizard\`, \`CaseDashboardService\`.

Twelve models also reach for \`Corvid.adapter\` directly — that's #264, deliberately separate scope.

## Test plan

- [x] 3 injection tests cover the new pattern (instance, class+kwarg, class+global default).
- [x] Existing \`CommitteeReviewSyncServiceTest\` (no changes needed) still green — backward-compat shim works.
- [x] 741 minitest assertions / 0 failures, 375 cucumber scenarios / 0 failures locally on Ruby 4.0.2.

Refs #222