### PR TITLE
Adapter injection for BudgetAvailabilityService (slice 2 of #222)

### DIFF
--- a/app/services/corvid/budget_availability_service.rb
+++ b/app/services/corvid/budget_availability_service.rb
@@ -3,79 +3,116 @@
 module Corvid
   # Adapter-backed budget facade. Real budget data lives in the EHR/CHS
   # system; this service translates Case-domain queries to adapter calls.
+  #
+  # Per #222 / ADR 0005: the adapter is injected per-instance rather
+  # than reached via the `Corvid.adapter` global. The class-method form
+  # accepts an `adapter:` kwarg (defaulting to `Corvid.adapter`) so
+  # existing call sites keep working while tests and per-tenant code
+  # paths can swap in their own adapters without mutating global state.
   class BudgetAvailabilityService
     DEFAULT_FISCAL_YEAR_BUDGET = 1_000_000.00
     COMMITTEE_REVIEW_THRESHOLD = 50_000.00
 
+    def initialize(adapter: Corvid.adapter)
+      @adapter = adapter
+    end
+
+    def fiscal_year_budget
+      summary = @adapter.get_budget_summary
+      return DEFAULT_FISCAL_YEAR_BUDGET unless summary
+
+      (summary[:total_budget] || summary[:total]).to_f.nonzero? || DEFAULT_FISCAL_YEAR_BUDGET
+    end
+
+    def reserved_funds
+      summary = @adapter.get_budget_summary
+      return 0.0 unless summary
+
+      summary[:obligated]&.to_f || 0.0
+    end
+
+    def remaining_budget
+      summary = @adapter.get_budget_summary
+      return 0.0 unless summary
+
+      summary[:remaining]&.to_f || 0.0
+    end
+
+    def reserve_funds_if_available(referral_identifier, amount, params = {})
+      # Adapter wire format expects a numeric amount; convert at the
+      # boundary so callers can pass either a Money or a Numeric.
+      numeric_amount = amount.respond_to?(:to_d) ? amount.to_d : amount
+      @adapter.create_obligation(referral_identifier, numeric_amount, params)
+    end
+
+    def current_quarter
+      month = Date.current.month
+      year = Date.current.year
+      case month
+      when 10, 11, 12 then "FY#{year + 1}-Q1"
+      when 1, 2, 3 then "FY#{year}-Q2"
+      when 4, 5, 6 then "FY#{year}-Q3"
+      when 7, 8, 9 then "FY#{year}-Q4"
+      end
+    end
+
+    def check(referral)
+      # Budget figures are still numeric (USD-equivalent dollars). Coerce
+      # estimated_cost (now a Money) to BigDecimal-of-dollars so all the
+      # comparisons below work without a per-call currency match check.
+      # Multi-currency budgeting would belong on the tenant config when
+      # we have a concrete non-USD case.
+      cost = referral.estimated_cost
+      cost_dollars = cost.respond_to?(:to_d) ? cost.to_d : cost
+      budget = remaining_budget
+      total = fiscal_year_budget
+
+      BudgetCheckResult.new(
+        funds_available: cost_dollars.present? && cost_dollars > 0 && budget >= cost_dollars,
+        budget_sufficient: cost_dollars.present? && budget >= cost_dollars,
+        remaining_budget: budget,
+        total_budget: total,
+        fiscal_year: current_fiscal_year,
+        requires_cost_estimate: cost_dollars.nil? || cost_dollars <= 0,
+        requires_committee_review: cost_dollars.present? && cost_dollars >= COMMITTEE_REVIEW_THRESHOLD,
+        valid_funding_source: true
+      )
+    end
+
+    # Class-method shims for backward compatibility. Existing callers
+    # `Corvid::BudgetAvailabilityService.remaining_budget` keep working;
+    # new callers pass `adapter:` to inject.
     class << self
-      def fiscal_year_budget
-        summary = Corvid.adapter.get_budget_summary
-        return DEFAULT_FISCAL_YEAR_BUDGET unless summary
-
-        (summary[:total_budget] || summary[:total]).to_f.nonzero? || DEFAULT_FISCAL_YEAR_BUDGET
+      def fiscal_year_budget(adapter: Corvid.adapter)
+        new(adapter: adapter).fiscal_year_budget
       end
 
-      def reserved_funds
-        summary = Corvid.adapter.get_budget_summary
-        return 0.0 unless summary
-
-        summary[:obligated]&.to_f || 0.0
+      def reserved_funds(adapter: Corvid.adapter)
+        new(adapter: adapter).reserved_funds
       end
 
-      def remaining_budget
-        summary = Corvid.adapter.get_budget_summary
-        return 0.0 unless summary
-
-        summary[:remaining]&.to_f || 0.0
+      def remaining_budget(adapter: Corvid.adapter)
+        new(adapter: adapter).remaining_budget
       end
 
-      def reserve_funds_if_available(referral_identifier, amount, params = {})
-        # Adapter wire format expects a numeric amount; convert at the
-        # boundary so callers can pass either a Money or a Numeric.
-        numeric_amount = amount.respond_to?(:to_d) ? amount.to_d : amount
-        Corvid.adapter.create_obligation(referral_identifier, numeric_amount, params)
+      def reserve_funds_if_available(referral_identifier, amount, params = {}, adapter: Corvid.adapter)
+        new(adapter: adapter).reserve_funds_if_available(referral_identifier, amount, params)
       end
 
-      def current_quarter
-        month = Date.current.month
-        year = Date.current.year
-        case month
-        when 10, 11, 12 then "FY#{year + 1}-Q1"
-        when 1, 2, 3 then "FY#{year}-Q2"
-        when 4, 5, 6 then "FY#{year}-Q3"
-        when 7, 8, 9 then "FY#{year}-Q4"
-        end
+      def current_quarter(adapter: Corvid.adapter)
+        new(adapter: adapter).current_quarter
       end
 
-      def check(referral)
-        # Budget figures are still numeric (USD-equivalent dollars). Coerce
-        # estimated_cost (now a Money) to BigDecimal-of-dollars so all the
-        # comparisons below work without a per-call currency match check.
-        # Multi-currency budgeting would belong on the tenant config when
-        # we have a concrete non-USD case.
-        cost = referral.estimated_cost
-        cost_dollars = cost.respond_to?(:to_d) ? cost.to_d : cost
-        budget = remaining_budget
-        total = fiscal_year_budget
-
-        BudgetCheckResult.new(
-          funds_available: cost_dollars.present? && cost_dollars > 0 && budget >= cost_dollars,
-          budget_sufficient: cost_dollars.present? && budget >= cost_dollars,
-          remaining_budget: budget,
-          total_budget: total,
-          fiscal_year: current_fiscal_year,
-          requires_cost_estimate: cost_dollars.nil? || cost_dollars <= 0,
-          requires_committee_review: cost_dollars.present? && cost_dollars >= COMMITTEE_REVIEW_THRESHOLD,
-          valid_funding_source: true
-        )
+      def check(referral, adapter: Corvid.adapter)
+        new(adapter: adapter).check(referral)
       end
+    end
 
-      private
+    private
 
-      def current_fiscal_year
-        year = Date.current.year
-        Date.current.month >= 10 ? "FY#{year + 1}" : "FY#{year}"
-      end
+    def current_fiscal_year
+      year = Date.current.year
+      Date.current.month >= 10 ? "FY#{year + 1}" : "FY#{year}"
     end
 
     BudgetCheckResult = Struct.new(

--- a/test/services/corvid/budget_availability_service_injection_test.rb
+++ b/test/services/corvid/budget_availability_service_injection_test.rb
@@ -95,6 +95,55 @@ class Corvid::BudgetAvailabilityServiceInjectionTest < ActiveSupport::TestCase
     end
   end
 
+  test "class .check(referral, adapter:) routes through the injected adapter via shim" do
+    Corvid.configure { |c| c.adapter = poison_adapter }
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ref = Corvid::PrcReferral.create!(
+        case: Corvid::Case.create!(patient_identifier: "p_cs", facility_identifier: "fac_cs"),
+        referral_identifier: "rf_classcheck_#{SecureRandom.hex(4)}",
+        estimated_cost_cents: 50_000_00, # 50_000 USD — at the committee threshold
+        currency_iso: "USD"
+      )
+
+      result = Corvid::BudgetAvailabilityService.check(ref, adapter: @fake)
+
+      assert_equal 900_000.0, result.remaining_budget
+      assert result.requires_committee_review,
+             "50_000 USD is at COMMITTEE_REVIEW_THRESHOLD"
+      assert_includes @fake.calls.map(&:first), :get_budget_summary
+    end
+  end
+
+  # -- Edge cases: degraded adapter responses --------------------------------
+
+  class NilSummaryAdapter
+    def get_budget_summary; nil; end
+  end
+
+  class EmptySummaryAdapter
+    def get_budget_summary; {}; end
+  end
+
+  test "remaining_budget falls back to 0.0 when adapter returns nil" do
+    service = Corvid::BudgetAvailabilityService.new(adapter: NilSummaryAdapter.new)
+    assert_equal 0.0, service.remaining_budget
+    assert_equal 0.0, service.reserved_funds
+  end
+
+  test "fiscal_year_budget falls back to default when adapter returns nil" do
+    service = Corvid::BudgetAvailabilityService.new(adapter: NilSummaryAdapter.new)
+    assert_equal Corvid::BudgetAvailabilityService::DEFAULT_FISCAL_YEAR_BUDGET,
+                 service.fiscal_year_budget
+  end
+
+  test "fiscal_year_budget falls back to default when adapter returns an empty payload" do
+    service = Corvid::BudgetAvailabilityService.new(adapter: EmptySummaryAdapter.new)
+    assert_equal Corvid::BudgetAvailabilityService::DEFAULT_FISCAL_YEAR_BUDGET,
+                 service.fiscal_year_budget
+    assert_equal 0.0, service.remaining_budget
+    assert_equal 0.0, service.reserved_funds
+  end
+
   private
 
   def poison_adapter

--- a/test/services/corvid/budget_availability_service_injection_test.rb
+++ b/test/services/corvid/budget_availability_service_injection_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Per #222 / ADR 0005: BudgetAvailabilityService accepts an `adapter:`
+# kwarg so per-tenant budget routing and per-test fakes can be
+# injected without mutating the global Corvid.adapter.
+class Corvid::BudgetAvailabilityServiceInjectionTest < ActiveSupport::TestCase
+  TENANT = "tnt_budget_inject"
+
+  # Minimal recording fake — every adapter call lands here so we can
+  # assert routing went through the injected adapter rather than the
+  # global.
+  class RecordingAdapter
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def get_budget_summary
+      @calls << [ :get_budget_summary ]
+      { total_budget: 1_000_000.0, obligated: 100_000.0, remaining: 900_000.0 }
+    end
+
+    def create_obligation(referral_identifier, amount, params = {})
+      @calls << [ :create_obligation, referral_identifier, amount, params ]
+      Object.new.tap do |o|
+        def o.success?; true; end
+        def o.failure?; false; end
+        def o.id; "obl_inj"; end
+      end
+    end
+  end
+
+  setup do
+    @fake = RecordingAdapter.new
+    @original_adapter = Corvid.adapter
+  end
+
+  teardown do
+    Corvid.configure { |c| c.adapter = @original_adapter }
+  end
+
+  test "instance routes get_budget_summary through the injected adapter" do
+    Corvid.configure { |c| c.adapter = poison_adapter }
+    service = Corvid::BudgetAvailabilityService.new(adapter: @fake)
+
+    assert_equal 900_000.0, service.remaining_budget
+    assert_equal 100_000.0, service.reserved_funds
+    assert_equal 1_000_000.0, service.fiscal_year_budget
+    assert_includes @fake.calls.map(&:first), :get_budget_summary
+  end
+
+  test "instance routes create_obligation through the injected adapter" do
+    Corvid.configure { |c| c.adapter = poison_adapter }
+    service = Corvid::BudgetAvailabilityService.new(adapter: @fake)
+
+    service.reserve_funds_if_available("rf_inj", 5_000)
+
+    assert_equal :create_obligation, @fake.calls.last[0]
+    assert_equal "rf_inj", @fake.calls.last[1]
+  end
+
+  test "class method accepts adapter: kwarg without touching the global" do
+    Corvid.configure { |c| c.adapter = poison_adapter }
+
+    Corvid::BudgetAvailabilityService.reserve_funds_if_available("rf_cls", 1_000, {}, adapter: @fake)
+
+    assert_equal :create_obligation, @fake.calls.last[0]
+  end
+
+  test "class .remaining_budget without kwarg falls back to Corvid.adapter (backward-compat)" do
+    Corvid.configure { |c| c.adapter = @fake }
+
+    Corvid::BudgetAvailabilityService.remaining_budget
+
+    assert_includes @fake.calls.map(&:first), :get_budget_summary
+  end
+
+  test "check(referral) routes through the injected adapter for budget figures" do
+    Corvid.configure { |c| c.adapter = poison_adapter }
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ref = Corvid::PrcReferral.create!(
+        case: Corvid::Case.create!(patient_identifier: "p_b", facility_identifier: "fac_b"),
+        referral_identifier: "rf_check_#{SecureRandom.hex(4)}",
+        estimated_cost_cents: 10_000,
+        currency_iso: "USD"
+      )
+
+      result = Corvid::BudgetAvailabilityService.new(adapter: @fake).check(ref)
+
+      assert_equal 900_000.0, result.remaining_budget
+      assert_includes @fake.calls.map(&:first), :get_budget_summary
+    end
+  end
+
+  private
+
+  def poison_adapter
+    Object.new.tap do |o|
+      def o.method_missing(name, *_a, **_kw)
+        raise "Corvid.adapter (the global) was used unexpectedly: ##{name}"
+      end
+
+      def o.respond_to_missing?(_n, _p = false); true; end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Second slice of #222. Converts \`BudgetAvailabilityService\` to the per-instance DI pattern established in [ADR 0005](docs/adr/0005-adapter-injection.md). Pure refactor — no behavior change.

## Pattern recap

\`\`\`ruby
service = Corvid::BudgetAvailabilityService.new(adapter: my_adapter)
service.remaining_budget   # routes through my_adapter

# Class-method shims keep existing callers working
Corvid::BudgetAvailabilityService.remaining_budget                  # falls back to Corvid.adapter
Corvid::BudgetAvailabilityService.remaining_budget(adapter: my_adapter)
\`\`\`

## Methods routed through @adapter

- \`fiscal_year_budget\`, \`reserved_funds\`, \`remaining_budget\` → \`get_budget_summary\`
- \`reserve_funds_if_available\` → \`create_obligation\`
- \`check(referral)\` drives the others

## Test plan

- [x] 5 injection tests: instance path, class+kwarg, class+global default, \`create_obligation\` routing, \`check(referral)\` end-to-end.
- [x] Existing \`BudgetAvailabilityServiceTest\` (no changes needed) still green via class-method shims.
- [x] 748 minitest assertions / 0 failures, 375 cucumber scenarios / 0 failures.

## Slices remaining under #222

\`EligibilityChecklistService\`, \`PriorAuthorizationApiService\`, \`ProgramTemplateService\`, \`ChsReportingService\`, \`AuthorizationWizard\`, \`CaseDashboardService\`. Same pattern, one PR per cluster.

Refs #222