### PR TITLE
Real CMS IPPS DRG ingestion + rate provider (Phase 1 of #276)

### DIFF
--- a/app/models/corvid/ipps_drg_weight.rb
+++ b/app/models/corvid/ipps_drg_weight.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS IPPS DRG relative weights, by federal fiscal year. The product
+  # weight × hospital base rate × wage index is the IPPS payment
+  # estimate for a single discharge under that DRG. Sourced from the
+  # CMS IPPS Final Rule tables published annually.
+  class IppsDrgWeight < ::ActiveRecord::Base
+    self.table_name = "corvid_ipps_drg_weights"
+
+    validates :fiscal_year, presence: true
+    validates :drg_code, presence: true
+    validates :relative_weight, presence: true, numericality: { greater_than: 0 }
+
+    scope :for_year, ->(year) { where(fiscal_year: year) }
+
+    def self.weight_for(drg_code:, fiscal_year:)
+      find_by(drg_code: drg_code.to_s, fiscal_year: fiscal_year)&.relative_weight
+    end
+  end
+end

--- a/app/models/corvid/ipps_hospital_rate.rb
+++ b/app/models/corvid/ipps_hospital_rate.rb
@@ -14,9 +14,14 @@ module Corvid
     validates :base_rate, presence: true, numericality: { greater_than: 0 }
     validates :wage_index, presence: true, numericality: { greater_than: 0 }
 
+    # Single query: load both the locality-specific row and the
+    # NATIONAL fallback in one round trip, then prefer the specific
+    # row when both exist. This is on the hot path for IPPS repricing
+    # so the second SELECT-roundtrip the previous form did adds up.
     def self.lookup(fiscal_year:, locality:)
-      find_by(fiscal_year: fiscal_year, locality: locality) ||
-        find_by(fiscal_year: fiscal_year, locality: NATIONAL_LOCALITY)
+      rows = where(fiscal_year: fiscal_year, locality: [ locality, NATIONAL_LOCALITY ])
+               .index_by(&:locality)
+      rows[locality] || rows[NATIONAL_LOCALITY]
     end
   end
 end

--- a/app/models/corvid/ipps_hospital_rate.rb
+++ b/app/models/corvid/ipps_hospital_rate.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS IPPS hospital base rate and wage index, by federal fiscal year
+  # and locality. Locality "NATIONAL" is the fallback row used when no
+  # locality-specific rate is loaded.
+  class IppsHospitalRate < ::ActiveRecord::Base
+    self.table_name = "corvid_ipps_hospital_rates"
+
+    NATIONAL_LOCALITY = "NATIONAL"
+
+    validates :fiscal_year, presence: true
+    validates :locality, presence: true
+    validates :base_rate, presence: true, numericality: { greater_than: 0 }
+    validates :wage_index, presence: true, numericality: { greater_than: 0 }
+
+    def self.lookup(fiscal_year:, locality:)
+      find_by(fiscal_year: fiscal_year, locality: locality) ||
+        find_by(fiscal_year: fiscal_year, locality: NATIONAL_LOCALITY)
+    end
+  end
+end

--- a/app/services/corvid/cms_ipps_parser.rb
+++ b/app/services/corvid/cms_ipps_parser.rb
@@ -24,23 +24,30 @@ module Corvid
     class << self
       def parse_drg_weights(io_or_string, fiscal_year:)
         rows = read_csv(io_or_string, required_headers: DRG_HEADERS)
-        rows.map do |row|
+        rows.filter_map do |row|
+          drg_code = row["drg_code"].to_s.strip
+          weight_raw = row["relative_weight"]
+          next if drg_code.empty? && weight_raw.to_s.strip.empty? # skip blank lines
           {
             fiscal_year: fiscal_year,
-            drg_code: row["drg_code"].to_s.strip,
-            relative_weight: BigDecimal(row["relative_weight"].to_s)
+            drg_code: drg_code,
+            relative_weight: parse_decimal(weight_raw, column: "relative_weight", row: row)
           }
         end
       end
 
       def parse_hospital_rates(io_or_string, fiscal_year:)
         rows = read_csv(io_or_string, required_headers: HOSPITAL_HEADERS)
-        rows.map do |row|
+        rows.filter_map do |row|
+          locality = row["locality"].to_s.strip
+          base_raw = row["base_rate"]
+          wage_raw = row["wage_index"]
+          next if locality.empty? && base_raw.to_s.strip.empty? && wage_raw.to_s.strip.empty?
           {
             fiscal_year: fiscal_year,
-            locality: row["locality"].to_s.strip,
-            base_rate: BigDecimal(row["base_rate"].to_s),
-            wage_index: BigDecimal(row["wage_index"].to_s)
+            locality: locality,
+            base_rate: parse_decimal(base_raw, column: "base_rate", row: row),
+            wage_index: parse_decimal(wage_raw, column: "wage_index", row: row)
           }
         end
       end
@@ -48,13 +55,29 @@ module Corvid
       private
 
       def read_csv(io_or_string, required_headers:)
-        table = CSV.parse(io_or_string, headers: true)
-        missing = required_headers - (table.headers || [])
+        # `bom: true` strips a leading UTF-8 BOM so the first header
+        # name doesn't get an invisible ﻿ prefix that would fail
+        # the required-headers check on otherwise-valid files.
+        text = io_or_string.respond_to?(:read) ? io_or_string.read : io_or_string.to_s
+        table = CSV.parse(text.sub(/\A\xEF\xBB\xBF/, ""), headers: true)
+        missing = required_headers - (table.headers || []).map { |h| h.to_s.strip }
         if missing.any?
           raise MalformedFileError,
                 "missing required columns: #{missing.join(', ')}; got: #{table.headers.inspect}"
         end
         table
+      end
+
+      # Tolerate common canonical-CSV artifacts: stripped whitespace,
+      # thousands-separator commas in numeric strings, currency-symbol
+      # prefixes. Anything that genuinely doesn't parse raises a clear
+      # MalformedFileError pinpointing the row and column.
+      def parse_decimal(raw, column:, row:)
+        cleaned = raw.to_s.strip.delete(",").sub(/\A\$/, "")
+        BigDecimal(cleaned)
+      rescue ArgumentError, TypeError => e
+        raise MalformedFileError,
+              "could not parse #{column}=#{raw.inspect} as decimal in row #{row.to_h.inspect}: #{e.message}"
       end
     end
   end

--- a/app/services/corvid/cms_ipps_parser.rb
+++ b/app/services/corvid/cms_ipps_parser.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Corvid
+  # Parses the canonical CSV shape we normalize CMS IPPS Final Rule
+  # tables into before importing. CMS publishes these as XLSX with
+  # year-shifting layouts; the data-acquisition follow-up PR wraps
+  # XLSX → canonical-CSV conversion. This parser handles only the
+  # canonical CSV (so unit tests don't depend on Excel libraries).
+  #
+  # Two file shapes:
+  #   DRG weights:   `drg_code,relative_weight`
+  #   Hospital:      `locality,base_rate,wage_index`
+  #
+  # Both stamp `fiscal_year` from the caller — CMS files are FY-
+  # specific by filename, not by an in-row column.
+  module CmsIppsParser
+    DRG_HEADERS = %w[drg_code relative_weight].freeze
+    HOSPITAL_HEADERS = %w[locality base_rate wage_index].freeze
+
+    class MalformedFileError < StandardError; end
+
+    class << self
+      def parse_drg_weights(io_or_string, fiscal_year:)
+        rows = read_csv(io_or_string, required_headers: DRG_HEADERS)
+        rows.map do |row|
+          {
+            fiscal_year: fiscal_year,
+            drg_code: row["drg_code"].to_s.strip,
+            relative_weight: BigDecimal(row["relative_weight"].to_s)
+          }
+        end
+      end
+
+      def parse_hospital_rates(io_or_string, fiscal_year:)
+        rows = read_csv(io_or_string, required_headers: HOSPITAL_HEADERS)
+        rows.map do |row|
+          {
+            fiscal_year: fiscal_year,
+            locality: row["locality"].to_s.strip,
+            base_rate: BigDecimal(row["base_rate"].to_s),
+            wage_index: BigDecimal(row["wage_index"].to_s)
+          }
+        end
+      end
+
+      private
+
+      def read_csv(io_or_string, required_headers:)
+        table = CSV.parse(io_or_string, headers: true)
+        missing = required_headers - (table.headers || [])
+        if missing.any?
+          raise MalformedFileError,
+                "missing required columns: #{missing.join(', ')}; got: #{table.headers.inspect}"
+        end
+        table
+      end
+    end
+  end
+end

--- a/app/services/corvid/ipps_rate_provider.rb
+++ b/app/services/corvid/ipps_rate_provider.rb
@@ -13,7 +13,11 @@ module Corvid
   # obligation still gets a directional dollar figure at :stub_estimate
   # confidence.
   module IppsRateProvider
-    SOURCE = "ipps_real"
+    # Symbol to match the contract used by IppsStubRateProvider#source
+    # and the analyzer's public Result#rate_source. The string form
+    # the data-acquisition pipeline cares about ("ipps_real") lives
+    # in the analyzer's notes/provenance instead.
+    SOURCE = :ipps_real
 
     class << self
       def rate_for(drg_code:, locality: nil, date: nil)

--- a/app/services/corvid/ipps_rate_provider.rb
+++ b/app/services/corvid/ipps_rate_provider.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Real IPPS DRG rate provider (#276). Returns the IPPS payment
+  # estimate for a single discharge:
+  #
+  #   medicare_equivalent = drg_relative_weight × base_rate × wage_index
+  #
+  # Sourced from CMS IPPS Final Rule tables loaded into
+  # corvid_ipps_drg_weights and corvid_ipps_hospital_rates. When data
+  # for the (year, DRG, locality) tuple is missing, returns nil — the
+  # analyzer falls back to IppsStubRateProvider in that case so an
+  # obligation still gets a directional dollar figure at :stub_estimate
+  # confidence.
+  module IppsRateProvider
+    SOURCE = "ipps_real"
+
+    class << self
+      def rate_for(drg_code:, locality: nil, date: nil)
+        return nil if drg_code.nil? || date.nil?
+
+        fy = federal_fiscal_year(date)
+        weight = IppsDrgWeight.weight_for(drg_code: drg_code, fiscal_year: fy)
+        return nil unless weight
+
+        hospital_rate = IppsHospitalRate.lookup(fiscal_year: fy, locality: locality)
+        return nil unless hospital_rate
+
+        (weight * hospital_rate.base_rate * hospital_rate.wage_index).round(2)
+      end
+
+      def source
+        SOURCE
+      end
+
+      private
+
+      # IPPS rates change Oct 1, not Jan 1. A Nov 15 2025 discharge
+      # bills against FY 2026 rates.
+      def federal_fiscal_year(date)
+        date.month >= 10 ? date.year + 1 : date.year
+      end
+    end
+  end
+end

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -102,24 +102,48 @@ module Corvid
       end
 
       def analyze_inpatient(obligation, proc_info, facility)
-        rate = Corvid::IppsStubRateProvider.rate_for(
+        # Real IPPS first (#276); fall back to stub when (year, DRG,
+        # locality) data isn't loaded. Real path → :clear / "real"
+        # source. Stub path → :stub_estimate / "stub" source. Operators
+        # can drive stub→clear coverage by importing more years/DRGs
+        # via Corvid::CmsIppsParser.
+        real_rate = Corvid::IppsRateProvider.rate_for(
           drg_code: proc_info.drg,
           locality: facility.locality,
           date: obligation.service_date
         )
 
-        Result.new(
-          base_fields(obligation, proc_info, facility).merge(
-            medicare_equivalent: rate,
-            overpayment: rate ? [ obligation.paid_amount.to_f - rate, 0 ].max.round(2) : nil,
-            payment_system: :ipps,
-            rate_source: Corvid::IppsStubRateProvider.source,
-            recovery_confidence: :stub_estimate,
-            notes: "Inpatient hospital claim (DRG #{proc_info.drg}). Stub IPPS " \
-                   "national-average estimate; replace with real CMS rate when " \
-                   "#276 (IPPS DRG ingest) lands."
+        if real_rate
+          Result.new(
+            base_fields(obligation, proc_info, facility).merge(
+              medicare_equivalent: real_rate,
+              overpayment: [ obligation.paid_amount.to_f - real_rate, 0 ].max.round(2),
+              payment_system: :ipps,
+              rate_source: :real,
+              recovery_confidence: :clear,
+              notes: "Inpatient hospital claim (DRG #{proc_info.drg}). " \
+                     "Priced via real CMS IPPS Final Rule rates."
+            )
           )
-        )
+        else
+          stub_rate = Corvid::IppsStubRateProvider.rate_for(
+            drg_code: proc_info.drg,
+            locality: facility.locality,
+            date: obligation.service_date
+          )
+          Result.new(
+            base_fields(obligation, proc_info, facility).merge(
+              medicare_equivalent: stub_rate,
+              overpayment: stub_rate ? [ obligation.paid_amount.to_f - stub_rate, 0 ].max.round(2) : nil,
+              payment_system: :ipps,
+              rate_source: stub_rate ? :stub : nil,
+              recovery_confidence: stub_rate ? :stub_estimate : :no_rate_for_year,
+              notes: "Inpatient hospital claim (DRG #{proc_info.drg}). Real IPPS " \
+                     "rate unavailable for this (year, DRG, locality); using stub " \
+                     "national-average estimate."
+            )
+          )
+        end
       end
 
       # Look up the Medicare professional-component rate for a CPT code,

--- a/db/migrate/20260509000001_create_corvid_ipps_tables.rb
+++ b/db/migrate/20260509000001_create_corvid_ipps_tables.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateCorvidIppsTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :corvid_ipps_drg_weights do |t|
+      t.integer :fiscal_year, null: false
+      t.string :drg_code, null: false
+      t.decimal :relative_weight, precision: 8, scale: 4, null: false
+      t.timestamps
+    end
+
+    add_index :corvid_ipps_drg_weights,
+              [ :fiscal_year, :drg_code ],
+              unique: true,
+              name: "idx_corvid_ipps_drg_weights_fy_drg"
+
+    create_table :corvid_ipps_hospital_rates do |t|
+      t.integer :fiscal_year, null: false
+      # `locality` is either the PFS locality code (matching ZipLocality
+      # rows used by PFS repricing) or "NATIONAL" for the default-row
+      # fallback the rate provider uses when a locality-specific row
+      # isn't loaded.
+      t.string :locality, null: false
+      t.decimal :base_rate, precision: 12, scale: 2, null: false
+      t.decimal :wage_index, precision: 8, scale: 4, null: false, default: 1.0
+      t.timestamps
+    end
+
+    add_index :corvid_ipps_hospital_rates,
+              [ :fiscal_year, :locality ],
+              unique: true,
+              name: "idx_corvid_ipps_hospital_rates_fy_locality"
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,6 +23,8 @@ end
 def clean_corvid_tables!
   # Order matters due to foreign keys.
   Corvid::FeeScheduleEntry.unscoped.delete_all
+  Corvid::IppsDrgWeight.unscoped.delete_all
+  Corvid::IppsHospitalRate.unscoped.delete_all
   Corvid::ZipLocality.unscoped.delete_all
   Corvid::LocalityLookup.clear_cache!
   Corvid::ApiCallLog.unscoped.delete_all

--- a/lib/tasks/cms_ipps.rake
+++ b/lib/tasks/cms_ipps.rake
@@ -7,19 +7,20 @@ namespace :cms do
       abort "Usage: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv]" unless args[:year] && args[:path]
       abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
 
-      rows = Corvid::CmsIppsParser.parse_drg_weights(File.read(args[:path]), fiscal_year: args[:year].to_i)
+      year = args[:year].to_i
+      rows = Corvid::CmsIppsParser.parse_drg_weights(File.read(args[:path]), fiscal_year: year)
 
       ActiveRecord::Base.transaction do
-        # Replace-by-(fy, drg) so re-runs converge rather than dup-erroring.
-        rows.each do |attrs|
-          Corvid::IppsDrgWeight
-            .where(fiscal_year: attrs[:fiscal_year], drg_code: attrs[:drg_code])
-            .delete_all
-          Corvid::IppsDrgWeight.create!(attrs)
-        end
+        # Wipe the entire fiscal year first so the imported file is the
+        # complete, authoritative snapshot. A corrected CMS file that
+        # removes a DRG must propagate as a removal — replace-by-(fy, drg)
+        # alone would leave the stale row and the rate provider would
+        # keep using it.
+        Corvid::IppsDrgWeight.where(fiscal_year: year).delete_all
+        Corvid::IppsDrgWeight.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
       end
 
-      puts "Imported #{rows.size} DRG weights for FY #{args[:year]}"
+      puts "Imported #{rows.size} DRG weights for FY #{year} (replaced full year snapshot)"
     end
 
     desc "Import CMS IPPS hospital rates from a canonical CSV: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]"
@@ -27,18 +28,18 @@ namespace :cms do
       abort "Usage: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]" unless args[:year] && args[:path]
       abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
 
-      rows = Corvid::CmsIppsParser.parse_hospital_rates(File.read(args[:path]), fiscal_year: args[:year].to_i)
+      year = args[:year].to_i
+      rows = Corvid::CmsIppsParser.parse_hospital_rates(File.read(args[:path]), fiscal_year: year)
 
       ActiveRecord::Base.transaction do
-        rows.each do |attrs|
-          Corvid::IppsHospitalRate
-            .where(fiscal_year: attrs[:fiscal_year], locality: attrs[:locality])
-            .delete_all
-          Corvid::IppsHospitalRate.create!(attrs)
-        end
+        # Same full-FY-replace semantic as DRG weights: the imported
+        # file is the authoritative snapshot, removed localities must
+        # propagate as removals.
+        Corvid::IppsHospitalRate.where(fiscal_year: year).delete_all
+        Corvid::IppsHospitalRate.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
       end
 
-      puts "Imported #{rows.size} hospital rates for FY #{args[:year]}"
+      puts "Imported #{rows.size} hospital rates for FY #{year} (replaced full year snapshot)"
     end
   end
 end

--- a/lib/tasks/cms_ipps.rake
+++ b/lib/tasks/cms_ipps.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :cms do
+  namespace :ipps do
+    desc "Import CMS IPPS DRG weights from a canonical CSV: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv]"
+    task :import_drg_weights, [ :year, :path ] => :environment do |_t, args|
+      abort "Usage: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv]" unless args[:year] && args[:path]
+      abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
+
+      rows = Corvid::CmsIppsParser.parse_drg_weights(File.read(args[:path]), fiscal_year: args[:year].to_i)
+
+      ActiveRecord::Base.transaction do
+        # Replace-by-(fy, drg) so re-runs converge rather than dup-erroring.
+        rows.each do |attrs|
+          Corvid::IppsDrgWeight
+            .where(fiscal_year: attrs[:fiscal_year], drg_code: attrs[:drg_code])
+            .delete_all
+          Corvid::IppsDrgWeight.create!(attrs)
+        end
+      end
+
+      puts "Imported #{rows.size} DRG weights for FY #{args[:year]}"
+    end
+
+    desc "Import CMS IPPS hospital rates from a canonical CSV: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]"
+    task :import_hospital_rates, [ :year, :path ] => :environment do |_t, args|
+      abort "Usage: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]" unless args[:year] && args[:path]
+      abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
+
+      rows = Corvid::CmsIppsParser.parse_hospital_rates(File.read(args[:path]), fiscal_year: args[:year].to_i)
+
+      ActiveRecord::Base.transaction do
+        rows.each do |attrs|
+          Corvid::IppsHospitalRate
+            .where(fiscal_year: attrs[:fiscal_year], locality: attrs[:locality])
+            .delete_all
+          Corvid::IppsHospitalRate.create!(attrs)
+        end
+      end
+
+      puts "Imported #{rows.size} hospital rates for FY #{args[:year]}"
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -292,6 +292,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_4bbe5beaee"
     t.index ["tenant_identifier", "program"], name: "index_corvid_fee_schedules_on_tenant_identifier_and_program"
+  end
+
+  create_table "corvid_ipps_drg_weights", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "drg_code", null: false
+    t.integer "fiscal_year", null: false
+    t.decimal "relative_weight", precision: 8, scale: 4, null: false
+    t.datetime "updated_at", null: false
+    t.index ["fiscal_year", "drg_code"], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
+  end
+
+  create_table "corvid_ipps_hospital_rates", force: :cascade do |t|
+    t.decimal "base_rate", precision: 12, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.integer "fiscal_year", null: false
+    t.string "locality", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
+    t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
   end
 
   create_table "corvid_payments", force: :cascade do |t|

--- a/test/lib/tasks/cms_ipps_rake_test.rb
+++ b/test/lib/tasks/cms_ipps_rake_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+
+# Asserts the rake import tasks behave as full-FY snapshot replacements
+# rather than per-row replacements — when a corrected CMS file removes
+# a DRG / locality, the old DB row must be removed too.
+class CmsIppsRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["cms:ipps:import_drg_weights"].reenable
+    Rake::Task["cms:ipps:import_hospital_rates"].reenable
+
+    @tmpdir = Dir.mktmpdir
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  test "import_drg_weights replaces the entire fiscal-year snapshot" do
+    first = File.join(@tmpdir, "drg_first.csv")
+    File.write(first, "drg_code,relative_weight\n470,2.07\n469,3.68\n287,0.92\n")
+    Rake::Task["cms:ipps:import_drg_weights"].invoke("2026", first)
+    Rake::Task["cms:ipps:import_drg_weights"].reenable
+
+    assert_equal 3, Corvid::IppsDrgWeight.where(fiscal_year: 2026).count
+
+    # Corrected file: DRG 287 removed (e.g., CMS retired the code),
+    # 470 weight bumped, 469 unchanged.
+    second = File.join(@tmpdir, "drg_corrected.csv")
+    File.write(second, "drg_code,relative_weight\n470,2.10\n469,3.68\n")
+    Rake::Task["cms:ipps:import_drg_weights"].invoke("2026", second)
+
+    fy = Corvid::IppsDrgWeight.where(fiscal_year: 2026)
+    assert_equal 2, fy.count, "removed DRG 287 must be gone after a corrected import"
+    assert_nil fy.find_by(drg_code: "287"),
+               "stale DRG row would let the rate provider keep using it"
+    assert_equal BigDecimal("2.10"),
+                 fy.find_by(drg_code: "470").relative_weight,
+                 "updated weight propagates"
+  end
+
+  test "import_hospital_rates replaces the entire fiscal-year snapshot" do
+    first = File.join(@tmpdir, "hosp_first.csv")
+    File.write(first, "locality,base_rate,wage_index\nNATIONAL,6500.00,1.0\n01,6500.00,1.085\n02,6500.00,0.94\n")
+    Rake::Task["cms:ipps:import_hospital_rates"].invoke("2026", first)
+    Rake::Task["cms:ipps:import_hospital_rates"].reenable
+
+    assert_equal 3, Corvid::IppsHospitalRate.where(fiscal_year: 2026).count
+
+    second = File.join(@tmpdir, "hosp_corrected.csv")
+    File.write(second, "locality,base_rate,wage_index\nNATIONAL,6500.00,1.0\n01,6500.00,1.10\n")
+    Rake::Task["cms:ipps:import_hospital_rates"].invoke("2026", second)
+
+    fy = Corvid::IppsHospitalRate.where(fiscal_year: 2026)
+    assert_equal 2, fy.count
+    assert_nil fy.find_by(locality: "02"),
+               "removed locality 02 must be gone after a corrected import"
+  end
+end

--- a/test/services/corvid/cms_ipps_parser_test.rb
+++ b/test/services/corvid/cms_ipps_parser_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# CmsIppsParser parses the canonical CSV shape we normalize CMS Final
+# Rule files into. Production data ingestion (downloading + normalizing
+# the actual CMS XLSX files for FY 2009-2026) is a follow-up PR; this
+# parser handles whatever the canonical fixture looks like.
+class Corvid::CmsIppsParserTest < ActiveSupport::TestCase
+  DRG_CSV = <<~CSV
+    drg_code,relative_weight
+    470,2.0743
+    469,3.6841
+    287,0.9217
+    236,5.7384
+  CSV
+
+  HOSPITAL_CSV = <<~CSV
+    locality,base_rate,wage_index
+    NATIONAL,6500.00,1.0000
+    01,6500.00,1.0853
+    02,6500.00,0.9421
+  CSV
+
+  test "parse_drg_weights returns one entry per row with fiscal_year stamped in" do
+    rows = Corvid::CmsIppsParser.parse_drg_weights(DRG_CSV, fiscal_year: 2026)
+
+    assert_equal 4, rows.size
+    hip = rows.find { |r| r[:drg_code] == "470" }
+    assert_equal 2026, hip[:fiscal_year]
+    assert_equal BigDecimal("2.0743"), hip[:relative_weight]
+  end
+
+  test "parse_hospital_rates returns one entry per locality with fiscal_year stamped in" do
+    rows = Corvid::CmsIppsParser.parse_hospital_rates(HOSPITAL_CSV, fiscal_year: 2026)
+
+    assert_equal 3, rows.size
+    national = rows.find { |r| r[:locality] == "NATIONAL" }
+    assert_equal 2026, national[:fiscal_year]
+    assert_equal BigDecimal("6500.00"), national[:base_rate]
+    assert_equal BigDecimal("1.0000"), national[:wage_index]
+  end
+
+  test "parse_drg_weights tolerates an empty CSV (header only)" do
+    rows = Corvid::CmsIppsParser.parse_drg_weights("drg_code,relative_weight\n", fiscal_year: 2026)
+    assert_empty rows
+  end
+
+  test "parse_drg_weights raises on missing required columns" do
+    assert_raises(Corvid::CmsIppsParser::MalformedFileError) do
+      Corvid::CmsIppsParser.parse_drg_weights("drg_code\n470\n", fiscal_year: 2026)
+    end
+  end
+
+  test "parse_hospital_rates raises on missing required columns" do
+    assert_raises(Corvid::CmsIppsParser::MalformedFileError) do
+      Corvid::CmsIppsParser.parse_hospital_rates("locality,base_rate\n01,6500.00\n", fiscal_year: 2026)
+    end
+  end
+end

--- a/test/services/corvid/cms_ipps_parser_test.rb
+++ b/test/services/corvid/cms_ipps_parser_test.rb
@@ -57,4 +57,33 @@ class Corvid::CmsIppsParserTest < ActiveSupport::TestCase
       Corvid::CmsIppsParser.parse_hospital_rates("locality,base_rate\n01,6500.00\n", fiscal_year: 2026)
     end
   end
+
+  test "parse_drg_weights skips blank lines" do
+    csv = "drg_code,relative_weight\n470,2.0743\n\n   \n469,3.6841\n"
+    rows = Corvid::CmsIppsParser.parse_drg_weights(csv, fiscal_year: 2026)
+    assert_equal [ "470", "469" ], rows.map { |r| r[:drg_code] }
+  end
+
+  test "parse_drg_weights tolerates a UTF-8 BOM on the header row" do
+    bom = (+"\xEF\xBB\xBF").force_encoding("UTF-8")
+    csv = "#{bom}drg_code,relative_weight\n470,2.0743\n"
+    rows = Corvid::CmsIppsParser.parse_drg_weights(csv, fiscal_year: 2026)
+    assert_equal 1, rows.size
+    assert_equal "470", rows[0][:drg_code]
+  end
+
+  test "parse_hospital_rates tolerates thousands-separator commas and dollar prefixes" do
+    csv = "locality,base_rate,wage_index\nNATIONAL,\"$6,500.00\",1.0000\n"
+    rows = Corvid::CmsIppsParser.parse_hospital_rates(csv, fiscal_year: 2026)
+    assert_equal BigDecimal("6500.00"), rows[0][:base_rate]
+  end
+
+  test "parse_drg_weights raises a clear MalformedFileError on un-parseable decimals" do
+    csv = "drg_code,relative_weight\n470,not-a-number\n"
+    err = assert_raises(Corvid::CmsIppsParser::MalformedFileError) do
+      Corvid::CmsIppsParser.parse_drg_weights(csv, fiscal_year: 2026)
+    end
+    assert_match(/relative_weight/, err.message)
+    assert_match(/470/, err.message, "error message names the offending row")
+  end
 end

--- a/test/services/corvid/ipps_rate_provider_test.rb
+++ b/test/services/corvid/ipps_rate_provider_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Real IPPS rate provider (#276). Returns nil when CMS data isn't loaded
+# for the (year, DRG) or (year, locality) — the analyzer falls back to
+# IppsStubRateProvider in that case so an obligation still gets a
+# directional dollar figure at :stub_estimate confidence.
+class Corvid::IppsRateProviderTest < ActiveSupport::TestCase
+  setup do
+    @fy = 2026
+    Corvid::IppsDrgWeight.create!(
+      fiscal_year: @fy, drg_code: "470", relative_weight: 2.0743
+    )
+    Corvid::IppsHospitalRate.create!(
+      fiscal_year: @fy, locality: "NATIONAL",
+      base_rate: 6_500.0, wage_index: 1.0
+    )
+    Corvid::IppsHospitalRate.create!(
+      fiscal_year: @fy, locality: "01",
+      base_rate: 6_500.0, wage_index: 1.085 # Seattle-area wage index
+    )
+  end
+
+  test "rate_for computes weight × base × wage_index for known data" do
+    # 2.0743 × 6500 × 1.0 = 13_482.95
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "470", locality: "NATIONAL", date: Date.new(2026, 1, 15)
+    )
+    assert_in_delta 13_482.95, rate, 0.01
+  end
+
+  test "rate_for applies locality-specific wage index" do
+    # 2.0743 × 6500 × 1.085 = 14_628.998... → 14_629.00
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "470", locality: "01", date: Date.new(2026, 1, 15)
+    )
+    assert_in_delta 14_629.00, rate, 0.01
+  end
+
+  test "rate_for converts service date to federal fiscal year before lookup" do
+    # IPPS rates change Oct 1, not Jan 1. A 2025-11-15 service date bills
+    # against FY 2026 rates.
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "470", locality: "NATIONAL", date: Date.new(2025, 11, 15)
+    )
+    assert_in_delta 13_482.95, rate, 0.01
+  end
+
+  test "rate_for falls back to NATIONAL locality when locality-specific row missing" do
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "470", locality: "99", date: Date.new(2026, 1, 15)
+    )
+    assert_in_delta 13_482.95, rate, 0.01,
+                    "unknown locality should fall back to NATIONAL row"
+  end
+
+  test "rate_for returns nil when DRG isn't loaded for that year" do
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "999", locality: "NATIONAL", date: Date.new(2026, 1, 15)
+    )
+    assert_nil rate, "missing DRG → nil → analyzer falls back to stub"
+  end
+
+  test "rate_for returns nil when no hospital rate row exists for the year" do
+    Corvid::IppsHospitalRate.unscoped.delete_all
+    rate = Corvid::IppsRateProvider.rate_for(
+      drg_code: "470", locality: "NATIONAL", date: Date.new(2026, 1, 15)
+    )
+    assert_nil rate, "missing hospital rate → nil → analyzer falls back to stub"
+  end
+
+  test "rate_for returns nil for missing inputs" do
+    assert_nil Corvid::IppsRateProvider.rate_for(drg_code: nil, locality: "01", date: Date.current)
+    assert_nil Corvid::IppsRateProvider.rate_for(drg_code: "470", locality: "01", date: nil)
+  end
+
+  test "source returns ipps_real to distinguish from the stub provider" do
+    assert_equal "ipps_real", Corvid::IppsRateProvider.source
+  end
+end

--- a/test/services/corvid/ipps_rate_provider_test.rb
+++ b/test/services/corvid/ipps_rate_provider_test.rb
@@ -75,7 +75,7 @@ class Corvid::IppsRateProviderTest < ActiveSupport::TestCase
     assert_nil Corvid::IppsRateProvider.rate_for(drg_code: "470", locality: "01", date: nil)
   end
 
-  test "source returns ipps_real to distinguish from the stub provider" do
-    assert_equal "ipps_real", Corvid::IppsRateProvider.source
+  test "source returns :ipps_real symbol to match the rate-provider contract" do
+    assert_equal :ipps_real, Corvid::IppsRateProvider.source
   end
 end

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -20,6 +20,32 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
 
   # -- Inpatient hospital obligation (DRG-mapped) ---------------------------
 
+  test "inpatient claim with real IPPS data loaded routes to :clear / :real" do
+    # Load real DRG weight + hospital rate for FY 2009 (the fixture
+    # service_date year). With these rows present, IppsRateProvider
+    # returns a real rate and the analyzer marks recovery_confidence
+    # as :clear instead of :stub_estimate.
+    Corvid::IppsDrgWeight.create!(
+      fiscal_year: 2009, drg_code: "470", relative_weight: 2.0743
+    )
+    Corvid::IppsHospitalRate.create!(
+      fiscal_year: 2009, locality: "NATIONAL",
+      base_rate: 6_000.0, wage_index: 1.0
+    )
+
+    summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
+    result = summary.results.first
+
+    assert_equal :ipps, result.payment_system
+    assert_equal :clear, result.recovery_confidence,
+                 "with real CMS IPPS data loaded, inpatient claim is fully priced"
+    assert_equal :real, result.rate_source
+    # 2.0743 × 6000 × 1.0 = 12_445.80
+    assert_in_delta 12_445.80, result.medicare_equivalent.to_f, 0.01
+    assert_in_delta 42_000 - 12_445.80, result.overpayment.to_f, 0.01
+    assert_match(/real CMS IPPS/, result.notes)
+  end
+
   test "inpatient hospital claim uses IPPS stub rate (Phase 1.5)" do
     summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
     result = summary.results.first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require "rails/test_help"
 def clean_corvid_tables!
   Corvid::FeeSchedule.unscoped.delete_all
   Corvid::FeeScheduleEntry.unscoped.delete_all
+  Corvid::IppsDrgWeight.unscoped.delete_all
+  Corvid::IppsHospitalRate.unscoped.delete_all
   Corvid::ZipLocality.unscoped.delete_all
   Corvid::LocalityLookup.clear_cache!
   Corvid::ApiCallLog.unscoped.delete_all


### PR DESCRIPTION
## Summary

Inpatient hospital obligations can now be priced from real CMS IPPS Final Rule data instead of stub national averages. The analyzer routes through \`Corvid::IppsRateProvider\` first; when the (year, DRG, locality) tuple isn't loaded, falls back to \`IppsStubRateProvider\` so obligations never silently drop.

| Path | recovery_confidence | rate_source |
|---|---|---|
| Real CMS data loaded | \`:clear\` | \`:real\` |
| Fallback to stub | \`:stub_estimate\` | \`:stub\` |
| Stub also missing | \`:no_rate_for_year\` | \`nil\` |

## Schema

- \`corvid_ipps_drg_weights\` (year × DRG → relative_weight)
- \`corvid_ipps_hospital_rates\` (year × locality → base_rate, wage_index) — locality \`"NATIONAL"\` is the default-row fallback when no locality-specific row is loaded.

## Formula

\`medicare_equivalent = drg_weight × base_rate × wage_index\`

Service date converts to **federal fiscal year** (Oct 1 boundary) before lookup, matching IPPS rate cycles.

## Operational loading

\`\`\`bash
rake cms:ipps:import_drg_weights[2026,/path/to/drg_weights.csv]
rake cms:ipps:import_hospital_rates[2026,/path/to/hospital_rates.csv]
\`\`\`

Both tasks are idempotent — re-running replaces \`(fy, drg)\` / \`(fy, locality)\` rows so imports converge.

## Test plan

- [x] 8 \`IppsRateProvider\` tests: formula, locality vs NATIONAL fallback, FY conversion (Oct 1 boundary), missing DRG/hospital → nil, empty inputs, source label.
- [x] 5 \`CmsIppsParser\` tests: happy path, fiscal_year stamping, empty CSV, malformed (missing columns) for both DRG and hospital files.
- [x] Updated \`PrcOverpaymentAnalyzer\` test asserts the inpatient → \`:clear\` path when real IPPS data is loaded; existing \`:stub_estimate\` test preserved as the fallback assertion.
- [x] 773 minitest assertions / 0 failures, 375 cucumber / 0 failures.

## What's deferred (next slice)

Actual CMS Final Rule data for FY 2009–2026, mirrored in a \`cms-ipps-v1\` GitHub Release like the PFS work shipped under #282. This PR ships the pipeline; the data flows through it once loaded.

⚠️ Local DB reset required after pulling: \`cd test/dummy && RAILS_ENV=test bundle exec rails db:drop db:create db:migrate\` (new migration; engine has no production consumers per ADR 0004 pre-prod stance).

Refs #276