### PR TITLE
Real CMS FY 2026 IPPS data + release-label confidence (Phase 2 of #276)

### DIFF
--- a/app/services/corvid/cms_ipps_parser.rb
+++ b/app/services/corvid/cms_ipps_parser.rb
@@ -22,7 +22,7 @@ module Corvid
     class MalformedFileError < StandardError; end
 
     class << self
-      def parse_drg_weights(io_or_string, fiscal_year:)
+      def parse_drg_weights(io_or_string, fiscal_year:, release_label: nil)
         rows = read_csv(io_or_string, required_headers: DRG_HEADERS)
         rows.filter_map do |row|
           drg_code = row["drg_code"].to_s.strip
@@ -31,12 +31,13 @@ module Corvid
           {
             fiscal_year: fiscal_year,
             drg_code: drg_code,
-            relative_weight: parse_decimal(weight_raw, column: "relative_weight", row: row)
+            relative_weight: parse_decimal(weight_raw, column: "relative_weight", row: row),
+            release_label: release_label
           }
         end
       end
 
-      def parse_hospital_rates(io_or_string, fiscal_year:)
+      def parse_hospital_rates(io_or_string, fiscal_year:, release_label: nil)
         rows = read_csv(io_or_string, required_headers: HOSPITAL_HEADERS)
         rows.filter_map do |row|
           locality = row["locality"].to_s.strip
@@ -47,7 +48,8 @@ module Corvid
             fiscal_year: fiscal_year,
             locality: locality,
             base_rate: parse_decimal(base_raw, column: "base_rate", row: row),
-            wage_index: parse_decimal(wage_raw, column: "wage_index", row: row)
+            wage_index: parse_decimal(wage_raw, column: "wage_index", row: row),
+            release_label: release_label
           }
         end
       end

--- a/app/services/corvid/ipps_rate_provider.rb
+++ b/app/services/corvid/ipps_rate_provider.rb
@@ -19,18 +19,35 @@ module Corvid
     # in the analyzer's notes/provenance instead.
     SOURCE = :ipps_real
 
+    # Result struct so callers can inspect the release_label and decide
+    # confidence. The label travels alongside the rate so a stub-derived
+    # row (release_label: "stub_v1") can be reported as :stub_estimate
+    # rather than misrepresented as :clear.
+    Lookup = Struct.new(:rate, :release_label, keyword_init: true)
+
     class << self
       def rate_for(drg_code:, locality: nil, date: nil)
+        result = lookup_for(drg_code: drg_code, locality: locality, date: date)
+        result&.rate
+      end
+
+      def lookup_for(drg_code:, locality: nil, date: nil)
         return nil if drg_code.nil? || date.nil?
 
         fy = federal_fiscal_year(date)
-        weight = IppsDrgWeight.weight_for(drg_code: drg_code, fiscal_year: fy)
-        return nil unless weight
+        weight_row = IppsDrgWeight.find_by(drg_code: drg_code.to_s, fiscal_year: fy)
+        return nil unless weight_row
 
         hospital_rate = IppsHospitalRate.lookup(fiscal_year: fy, locality: locality)
         return nil unless hospital_rate
 
-        (weight * hospital_rate.base_rate * hospital_rate.wage_index).round(2)
+        rate = (weight_row.relative_weight * hospital_rate.base_rate * hospital_rate.wage_index).round(2)
+        # Take the more conservative label between the two rows: if
+        # either is stub-derived, the resulting rate is stub-derived.
+        label = [ weight_row.release_label, hospital_rate.release_label ]
+                  .compact.find { |l| l.to_s.start_with?("stub") } ||
+                weight_row.release_label || hospital_rate.release_label
+        Lookup.new(rate: rate, release_label: label)
       end
 
       def source

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -102,27 +102,34 @@ module Corvid
       end
 
       def analyze_inpatient(obligation, proc_info, facility)
-        # Real IPPS first (#276); fall back to stub when (year, DRG,
-        # locality) data isn't loaded. Real path → :clear / "real"
-        # source. Stub path → :stub_estimate / "stub" source. Operators
-        # can drive stub→clear coverage by importing more years/DRGs
-        # via Corvid::CmsIppsParser.
-        real_rate = Corvid::IppsRateProvider.rate_for(
+        # IPPS lookup (#276): real CMS data first; fall back to in-code
+        # stub provider when no row is loaded. Recovery confidence keys
+        # off the loaded row's release_label — "stub_v1" (or any "stub_*"
+        # prefix) marks :stub_estimate so seed canonical CSVs we ship
+        # in the release don't get misrepresented as recoverable-now.
+        # Real CMS Final Rule labels (e.g., "cms_fy2026_final_rule")
+        # mark :clear / :real.
+        lookup = Corvid::IppsRateProvider.lookup_for(
           drg_code: proc_info.drg,
           locality: facility.locality,
           date: obligation.service_date
         )
 
-        if real_rate
+        if lookup
+          stub_derived = lookup.release_label.to_s.start_with?("stub")
           Result.new(
             base_fields(obligation, proc_info, facility).merge(
-              medicare_equivalent: real_rate,
-              overpayment: [ obligation.paid_amount.to_f - real_rate, 0 ].max.round(2),
+              medicare_equivalent: lookup.rate,
+              overpayment: [ obligation.paid_amount.to_f - lookup.rate, 0 ].max.round(2),
               payment_system: :ipps,
-              rate_source: :real,
-              recovery_confidence: :clear,
-              notes: "Inpatient hospital claim (DRG #{proc_info.drg}). " \
-                     "Priced via real CMS IPPS Final Rule rates."
+              rate_source: stub_derived ? :stub : :real,
+              recovery_confidence: stub_derived ? :stub_estimate : :clear,
+              notes: stub_derived ?
+                "Inpatient hospital claim (DRG #{proc_info.drg}). Priced via " \
+                "stub-derived IPPS canonical CSV (release=#{lookup.release_label}); " \
+                "replace with real CMS Final Rule data as it's normalized." :
+                "Inpatient hospital claim (DRG #{proc_info.drg}). " \
+                "Priced via real CMS IPPS Final Rule (release=#{lookup.release_label})."
             )
           )
         else

--- a/db/migrate/20260509000001_create_corvid_ipps_tables.rb
+++ b/db/migrate/20260509000001_create_corvid_ipps_tables.rb
@@ -6,6 +6,12 @@ class CreateCorvidIppsTables < ActiveRecord::Migration[8.1]
       t.integer :fiscal_year, null: false
       t.string :drg_code, null: false
       t.decimal :relative_weight, precision: 8, scale: 4, null: false
+      # Identifies which release filled this row — e.g., "stub_v1"
+      # for the seed canonical CSVs we ship in the release, or
+      # "cms_fy2026_final_rule" for a hand-vetted Final Rule import.
+      # The analyzer keys recovery_confidence off this label so a
+      # stub-derived row reports :stub_estimate, not :clear.
+      t.string :release_label
       t.timestamps
     end
 
@@ -23,6 +29,7 @@ class CreateCorvidIppsTables < ActiveRecord::Migration[8.1]
       t.string :locality, null: false
       t.decimal :base_rate, precision: 12, scale: 2, null: false
       t.decimal :wage_index, precision: 8, scale: 4, null: false, default: 1.0
+      t.string :release_label
       t.timestamps
     end
 

--- a/docs/cms_ipps_data.md
+++ b/docs/cms_ipps_data.md
@@ -1,0 +1,134 @@
+# CMS IPPS Data Ingestion
+
+The PRC overpayment analyzer prices inpatient hospital obligations
+against real CMS IPPS (Inpatient Prospective Payment System) Final
+Rule rates loaded into `corvid_ipps_drg_weights` and
+`corvid_ipps_hospital_rates`. This doc covers where the source data
+comes from, how it's normalized into the canonical CSV shape, and
+how to ingest a year.
+
+## Coverage target
+
+FY 2007 through FY 2026 (matches PFS coverage; supports querying all
+PRC overpayments since July 2007).
+
+## Source
+
+CMS publishes annual **IPPS Final Rule** tables at:
+https://www.cms.gov/medicare/payment/prospective-payment-systems/acute-inpatient-pps
+
+For each fiscal year the relevant tables are:
+
+| Table | Contents | Used for |
+| --- | --- | --- |
+| Table 5 | MS-DRG list, relative weights, mean LOS | `corvid_ipps_drg_weights` |
+| Table 1A / 1B | National Adjusted Operating Standardized Amounts (labor + nonlabor) | `corvid_ipps_hospital_rates.base_rate` (NATIONAL row) |
+| Table 4A / 4B | Wage indexes by CBSA / state | `corvid_ipps_hospital_rates.wage_index` (per-locality rows; future) |
+
+CMS distributes these as ZIPs containing both `.txt` (tab-delimited)
+and `.xlsx` versions. The `.txt` is easier to parse and matches the
+`.xlsx` byte-for-byte after Excel formatting; we normalize from the
+`.txt`.
+
+## Canonical CSV shape
+
+Two files per year, named:
+
+```
+ipps_drg_weights_FY{year}.csv
+ipps_hospital_rates_FY{year}.csv
+```
+
+DRG weights:
+
+```csv
+# IPPS DRG relative weights, FY 2026
+# release_label: cms_fy2026_final_rule
+# source: CMS-1833-F Table 5 (FY 2026 IPPS Final Rule)
+# weight column: Weights - 10% Cap Applied
+drg_code,relative_weight,description
+001,28.0239,"HEART TRANSPLANT OR IMPLANT OF HEART ASSIST SYSTEM WITH MCC"
+...
+```
+
+Hospital rates:
+
+```csv
+# IPPS hospital base rates, FY 2026
+# release_label: cms_fy2026_final_rule
+# source: CMS-1833-F Table 1A/1B (FY 2026 IPPS Final Rule)
+locality,base_rate,wage_index
+NATIONAL,6752.61,1.0000
+```
+
+The leading `#`-comment lines are stripped by the importer; the first
+header line is `release_label:` so the importer knows whether the
+data is real-CMS or stub-derived. When `release_label` starts with
+`stub`, the analyzer reports `:stub_estimate` confidence; otherwise
+`:clear` / `:real`.
+
+## Per-year normalization recipe
+
+```bash
+# 1. Find the year's Final Rule home page
+open "https://www.cms.gov/medicare/payment/prospective-payment-systems/acute-inpatient-pps/fy-${YEAR}-ipps-final-rule-home-page"
+
+# 2. Download Table 5 + Tables 1A-1E ZIPs
+
+# 3. Extract the .txt files
+
+# 4. Parse Table 5 into ipps_drg_weights_FY${YEAR}.csv
+#    - Column 1 (MS-DRG, 3-digit code) → drg_code
+#    - Column 8 (Weights - 10% Cap Applied; column 7 in older years) → relative_weight
+#    - Column 6 (MS-DRG Title) → description
+
+# 5. Parse Table 1A into ipps_hospital_rates_FY${YEAR}.csv
+#    - NATIONAL row: base_rate = labor + nonlabor for the
+#      Hospital-Submitted-Quality + Meaningful-EHR-User column
+#    - wage_index = 1.0 for the NATIONAL fallback
+
+# 6. Hand-vet a few values against the published Final Rule preamble
+#    (e.g., the "operating standardized amount" sentence in section II
+#    typically quotes the labor+nonlabor sum directly).
+
+# 7. Upload to the cms-fee-schedules-v1 release
+gh release upload cms-fee-schedules-v1 \
+  ipps_drg_weights_FY${YEAR}.csv \
+  ipps_hospital_rates_FY${YEAR}.csv \
+  --repo lakeraven/corvid --clobber
+
+# 8. Fetch + import in the host app
+rake cms:ipps:fetch_release[${YEAR}]
+```
+
+## Layout drift across years
+
+CMS shifts column layouts roughly every 3–5 years and renames tables.
+Things to watch for in older files:
+
+- Pre-FY 2008: MS-DRG system didn't exist (CMS-DRG was used 1983–2007).
+  CMS published the MS-DRG conversion in FY 2008. PRC obligations
+  with service dates before FY 2008 may need DRG remapping or
+  fall back to a CMS-DRG provider (out of scope for #276).
+- FY 2008–2014: column for "Weights - 10% Cap Applied" didn't exist;
+  use the single weight column instead.
+- FY 2024 onwards: "Hospital Did NOT Submit Quality Data" columns
+  were re-numbered. Always anchor on the column header text, not
+  position.
+
+## Production ingest priority
+
+By dollar volume in tribal PRC obligations:
+
+1. FY 2026 — most recent claims; loaded today.
+2. FY 2025–2023 — recent recoverable years.
+3. FY 2022–2018 — older recoverable; statute of limitations varies.
+4. FY 2017–2007 — long-tail; stub_estimate is acceptable until
+   real demand work needs them.
+
+## Coverage status
+
+| FY | Status | release_label |
+| --- | --- | --- |
+| 2026 | Real CMS data | `cms_fy2026_final_rule` |
+| 2007–2025 | Stub fallback (in-code provider) | — |

--- a/lib/tasks/cms_ipps.rake
+++ b/lib/tasks/cms_ipps.rake
@@ -1,45 +1,79 @@
 # frozen_string_literal: true
 
+require "open-uri"
+
 namespace :cms do
   namespace :ipps do
-    desc "Import CMS IPPS DRG weights from a canonical CSV: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv]"
-    task :import_drg_weights, [ :year, :path ] => :environment do |_t, args|
-      abort "Usage: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv]" unless args[:year] && args[:path]
+    desc "Import CMS IPPS DRG weights from a canonical CSV: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv,release_label]"
+    task :import_drg_weights, [ :year, :path, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:ipps:import_drg_weights[year,/path/to/drg_weights.csv,release_label]" unless args[:year] && args[:path]
       abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
 
       year = args[:year].to_i
-      rows = Corvid::CmsIppsParser.parse_drg_weights(File.read(args[:path]), fiscal_year: year)
+      label = args[:label] || "manual"
+      rows = Corvid::CmsIppsParser.parse_drg_weights(
+        File.read(args[:path]), fiscal_year: year, release_label: label
+      )
 
       ActiveRecord::Base.transaction do
-        # Wipe the entire fiscal year first so the imported file is the
-        # complete, authoritative snapshot. A corrected CMS file that
-        # removes a DRG must propagate as a removal — replace-by-(fy, drg)
-        # alone would leave the stale row and the rate provider would
-        # keep using it.
         Corvid::IppsDrgWeight.where(fiscal_year: year).delete_all
         Corvid::IppsDrgWeight.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
       end
 
-      puts "Imported #{rows.size} DRG weights for FY #{year} (replaced full year snapshot)"
+      puts "Imported #{rows.size} DRG weights for FY #{year} (label=#{label}, replaced full year snapshot)"
     end
 
-    desc "Import CMS IPPS hospital rates from a canonical CSV: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]"
-    task :import_hospital_rates, [ :year, :path ] => :environment do |_t, args|
-      abort "Usage: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv]" unless args[:year] && args[:path]
+    desc "Import CMS IPPS hospital rates from a canonical CSV: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv,release_label]"
+    task :import_hospital_rates, [ :year, :path, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:ipps:import_hospital_rates[year,/path/to/hospital_rates.csv,release_label]" unless args[:year] && args[:path]
       abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
 
       year = args[:year].to_i
-      rows = Corvid::CmsIppsParser.parse_hospital_rates(File.read(args[:path]), fiscal_year: year)
+      label = args[:label] || "manual"
+      rows = Corvid::CmsIppsParser.parse_hospital_rates(
+        File.read(args[:path]), fiscal_year: year, release_label: label
+      )
 
       ActiveRecord::Base.transaction do
-        # Same full-FY-replace semantic as DRG weights: the imported
-        # file is the authoritative snapshot, removed localities must
-        # propagate as removals.
         Corvid::IppsHospitalRate.where(fiscal_year: year).delete_all
         Corvid::IppsHospitalRate.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
       end
 
-      puts "Imported #{rows.size} hospital rates for FY #{year} (replaced full year snapshot)"
+      puts "Imported #{rows.size} hospital rates for FY #{year} (label=#{label}, replaced full year snapshot)"
+    end
+
+    RELEASE_BASE_URL = "https://github.com/lakeraven/corvid/releases/download/cms-fee-schedules-v1"
+
+    desc "Fetch + import IPPS canonical CSVs from the cms-fee-schedules-v1 GitHub Release: rake cms:ipps:fetch_release[year]"
+    task :fetch_release, [ :year ] => :environment do |_t, args|
+      abort "Usage: rake cms:ipps:fetch_release[year]" unless args[:year]
+      year = args[:year].to_i
+
+      drg_url = "#{RELEASE_BASE_URL}/ipps_drg_weights_FY#{year}.csv"
+      hosp_url = "#{RELEASE_BASE_URL}/ipps_hospital_rates_FY#{year}.csv"
+
+      drg_csv = URI.open(drg_url, &:read)
+      hosp_csv = URI.open(hosp_url, &:read)
+
+      # Read the release_label from a header comment if present, else
+      # default to "stub_v1" — the seed-data tag we ship today.
+      label = drg_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+
+      drg_rows = Corvid::CmsIppsParser.parse_drg_weights(strip_comments(drg_csv), fiscal_year: year, release_label: label)
+      hosp_rows = Corvid::CmsIppsParser.parse_hospital_rates(strip_comments(hosp_csv), fiscal_year: year, release_label: label)
+
+      ActiveRecord::Base.transaction do
+        Corvid::IppsDrgWeight.where(fiscal_year: year).delete_all
+        Corvid::IppsDrgWeight.insert_all(drg_rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if drg_rows.any?
+        Corvid::IppsHospitalRate.where(fiscal_year: year).delete_all
+        Corvid::IppsHospitalRate.insert_all(hosp_rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if hosp_rows.any?
+      end
+
+      puts "Fetched FY #{year} from cms-fee-schedules-v1: #{drg_rows.size} DRG weights, #{hosp_rows.size} hospital rates (label=#{label})"
+    end
+
+    def strip_comments(csv_text)
+      csv_text.lines.reject { |l| l.lstrip.start_with?("#") }.join
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -299,6 +299,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000001) do
     t.string "drg_code", null: false
     t.integer "fiscal_year", null: false
     t.decimal "relative_weight", precision: 8, scale: 4, null: false
+    t.string "release_label"
     t.datetime "updated_at", null: false
     t.index ["fiscal_year", "drg_code"], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
   end
@@ -308,6 +309,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000001) do
     t.datetime "created_at", null: false
     t.integer "fiscal_year", null: false
     t.string "locality", null: false
+    t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
     t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -46,6 +46,28 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
     assert_match(/real CMS IPPS/, result.notes)
   end
 
+  test "inpatient claim with stub-labeled IPPS data still routes to :stub_estimate" do
+    # Even when rows are present in the real-IPPS tables, a
+    # release_label starting with "stub" downgrades the analyzer's
+    # confidence — protects against seed canonical CSVs we ship in
+    # the release being misrepresented as recoverable-now.
+    Corvid::IppsDrgWeight.create!(
+      fiscal_year: 2009, drg_code: "470",
+      relative_weight: 2.0743, release_label: "stub_v1"
+    )
+    Corvid::IppsHospitalRate.create!(
+      fiscal_year: 2009, locality: "NATIONAL",
+      base_rate: 6_000.0, wage_index: 1.0, release_label: "stub_v1"
+    )
+
+    summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
+    result = summary.results.first
+    assert_equal :stub_estimate, result.recovery_confidence
+    assert_equal :stub, result.rate_source
+    assert_match(/stub-derived/, result.notes)
+    assert_match(/stub_v1/, result.notes)
+  end
+
   test "inpatient hospital claim uses IPPS stub rate (Phase 1.5)" do
     summary = analyze_single_obligation(procedure: "HIP_REPLACE_THR", paid: 42_000)
     result = summary.results.first


### PR DESCRIPTION
## Summary

Closes the loop on IPPS pricing for **FY 2026** with real CMS Final Rule data sourced directly from cms.gov. Inpatient hospital obligations with FY 2026 service dates now route to \`:clear\` / \`:real\` confidence backed by the actual published rates.

## Real CMS data ingested

- **770 MS-DRG relative weights** from \`CMS-1833-F Table 5\` (FY 2026 IPPS Final Rule, "Weights - 10% Cap Applied" column).
- **National operating standardized amount** from \`CMS-1833-F Table 1A\`: $4,456.72 labor + $2,295.89 nonlabor = **$6,752.61**.
- Both normalized to canonical CSV with \`release_label: cms_fy2026_final_rule\` baked into header comments, uploaded to the existing \`cms-fee-schedules-v1\` GitHub Release alongside the PFS RVU zips. The release is now the single source of truth for CMS definition files across payment systems.

## End-to-end verification

\`\`\`
rake cms:ipps:fetch_release[2026]
# → Fetched FY 2026 from cms-fee-schedules-v1: 770 DRG weights, 1 hospital rates (label=cms_fy2026_final_rule)

# DRG 470 (Major joint replacement, no MCC):
# weight = 1.9289 × base = 6752.61 × wage = 1.0 → $13,025.11
\`\`\`

## release_label → confidence mapping

| release_label | recovery_confidence | rate_source |
|---|---|---|
| \`cms_fy2026_final_rule\` (or any non-"stub_*") | \`:clear\` | \`:real\` |
| \`stub_v1\` (or any "stub_*" prefix) | \`:stub_estimate\` | \`:stub\` |
| no row loaded → in-code \`IppsStubRateProvider\` fallback | \`:stub_estimate\` | \`:stub\` |

## Coverage status

| FY | Status | release_label |
|---|---|---|
| **2026** | **Real CMS data ✓** | \`cms_fy2026_final_rule\` |
| 2007–2025 | Stub fallback (in-code provider) | — |

The recipe to backfill remaining years is documented in [\`docs/cms_ipps_data.md\`](docs/cms_ipps_data.md). Each year's Final Rule has slight layout drift so each is a separate hand-vetted slice; by dollar volume the next priorities are FY 2025 → 2023 → 2022 → 2018 → 2017 → 2007.

## Test plan

- [x] New analyzer test asserts a row labeled \`stub_v1\` downgrades the result to \`:stub_estimate\` even when the row lives in the real tables.
- [x] Existing \`:clear\` / \`:real\` test still green (default \`nil\` label → \`:clear\` by design).
- [x] End-to-end fetch + lookup against the live release verified manually.
- [x] 778 minitest tests / 1732 assertions / 0 failures, 375 cucumber / 0 failures.

⚠️ Local DB reset required after pulling: \`cd test/dummy && RAILS_ENV=test bundle exec rails db:drop db:create db:migrate\` (in-place migration adds \`release_label\` column).

Refs #276