### PR TITLE
Real CMS OPPS APC ingestion + rate provider (Phase 1 of #277)

### DIFF
--- a/app/models/corvid/opps_apc_weight.rb
+++ b/app/models/corvid/opps_apc_weight.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS OPPS APC relative weight, by calendar year. Sourced from the
+  # OPPS Final Rule annual tables (Addendum B / Addendum A).
+  class OppsApcWeight < ::ActiveRecord::Base
+    self.table_name = "corvid_opps_apc_weights"
+
+    validates :calendar_year, presence: true
+    validates :apc_code, presence: true
+    validates :relative_weight, presence: true, numericality: { greater_than: 0 }
+
+    scope :for_year, ->(year) { where(calendar_year: year) }
+  end
+end

--- a/app/models/corvid/opps_conversion_factor.rb
+++ b/app/models/corvid/opps_conversion_factor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS OPPS conversion factor and wage index, by calendar year and
+  # locality. Locality "NATIONAL" is the fallback row used when no
+  # locality-specific rate is loaded.
+  class OppsConversionFactor < ::ActiveRecord::Base
+    self.table_name = "corvid_opps_conversion_factors"
+
+    NATIONAL_LOCALITY = "NATIONAL"
+
+    validates :calendar_year, presence: true
+    validates :locality, presence: true
+    validates :conversion_factor, presence: true, numericality: { greater_than: 0 }
+    validates :wage_index, presence: true, numericality: { greater_than: 0 }
+
+    # Single round-trip: load both candidate rows and prefer the
+    # locality-specific one when both exist. Mirrors
+    # Corvid::IppsHospitalRate.lookup.
+    def self.lookup(calendar_year:, locality:)
+      rows = where(calendar_year: calendar_year, locality: [ locality, NATIONAL_LOCALITY ])
+               .index_by(&:locality)
+      rows[locality] || rows[NATIONAL_LOCALITY]
+    end
+  end
+end

--- a/app/services/corvid/cms_opps_parser.rb
+++ b/app/services/corvid/cms_opps_parser.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Corvid
+  # Parses the canonical CSV shape we normalize CMS OPPS Final Rule
+  # tables into. Mirrors CmsIppsParser; OPPS uses calendar-year-keyed
+  # data (not federal fiscal year).
+  #
+  # Two file shapes:
+  #   APC weights:         `apc_code,relative_weight[,description]`
+  #   Conversion factors:  `locality,conversion_factor,wage_index`
+  module CmsOppsParser
+    APC_HEADERS = %w[apc_code relative_weight].freeze
+    CF_HEADERS = %w[locality conversion_factor wage_index].freeze
+
+    class MalformedFileError < StandardError; end
+
+    class << self
+      def parse_apc_weights(io_or_string, calendar_year:, release_label: nil)
+        rows = read_csv(io_or_string, required_headers: APC_HEADERS)
+        rows.filter_map do |row|
+          code = row["apc_code"].to_s.strip
+          weight_raw = row["relative_weight"]
+          next if code.empty? && weight_raw.to_s.strip.empty?
+          {
+            calendar_year: calendar_year,
+            apc_code: code,
+            relative_weight: parse_decimal(weight_raw, column: "relative_weight", row: row),
+            release_label: release_label
+          }
+        end
+      end
+
+      def parse_conversion_factors(io_or_string, calendar_year:, release_label: nil)
+        rows = read_csv(io_or_string, required_headers: CF_HEADERS)
+        rows.filter_map do |row|
+          locality = row["locality"].to_s.strip
+          cf_raw = row["conversion_factor"]
+          wage_raw = row["wage_index"]
+          next if locality.empty? && cf_raw.to_s.strip.empty? && wage_raw.to_s.strip.empty?
+          {
+            calendar_year: calendar_year,
+            locality: locality,
+            conversion_factor: parse_decimal(cf_raw, column: "conversion_factor", row: row),
+            wage_index: parse_decimal(wage_raw, column: "wage_index", row: row),
+            release_label: release_label
+          }
+        end
+      end
+
+      private
+
+      def read_csv(io_or_string, required_headers:)
+        text = io_or_string.respond_to?(:read) ? io_or_string.read : io_or_string.to_s
+        table = CSV.parse(text.sub(/\A\xEF\xBB\xBF/, ""), headers: true)
+        missing = required_headers - (table.headers || []).map { |h| h.to_s.strip }
+        if missing.any?
+          raise MalformedFileError,
+                "missing required columns: #{missing.join(', ')}; got: #{table.headers.inspect}"
+        end
+        table
+      end
+
+      def parse_decimal(raw, column:, row:)
+        cleaned = raw.to_s.strip.delete(",").sub(/\A\$/, "")
+        BigDecimal(cleaned)
+      rescue ArgumentError, TypeError => e
+        raise MalformedFileError,
+              "could not parse #{column}=#{raw.inspect} as decimal in row #{row.to_h.inspect}: #{e.message}"
+      end
+    end
+  end
+end

--- a/app/services/corvid/opps_rate_provider.rb
+++ b/app/services/corvid/opps_rate_provider.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Real OPPS APC rate provider (#277). Returns the OPPS payment
+  # estimate for a single hospital outpatient encounter:
+  #
+  #   medicare_equivalent = apc_relative_weight × conversion_factor × wage_index
+  #
+  # Sourced from CMS OPPS Final Rule tables (Addendum A/B) loaded into
+  # corvid_opps_apc_weights and corvid_opps_conversion_factors. When
+  # data for the (year, APC, locality) tuple is missing, returns nil —
+  # the analyzer falls back to OppsStubRateProvider in that case so an
+  # obligation still gets a directional dollar figure at :stub_estimate
+  # confidence.
+  #
+  # OPPS uses **calendar year** boundaries (Jan 1) — not federal fiscal
+  # year. Different from IPPS.
+  module OppsRateProvider
+    SOURCE = :opps_real
+
+    Lookup = Struct.new(:rate, :release_label, keyword_init: true)
+
+    class << self
+      def rate_for(apc_code:, locality: nil, date: nil)
+        result = lookup_for(apc_code: apc_code, locality: locality, date: date)
+        result&.rate
+      end
+
+      def lookup_for(apc_code:, locality: nil, date: nil)
+        return nil if apc_code.nil? || date.nil?
+
+        cy = calendar_year(date)
+        weight_row = OppsApcWeight.find_by(apc_code: apc_code.to_s, calendar_year: cy)
+        return nil unless weight_row
+
+        cf_row = OppsConversionFactor.lookup(calendar_year: cy, locality: locality)
+        return nil unless cf_row
+
+        rate = (weight_row.relative_weight * cf_row.conversion_factor * cf_row.wage_index).round(2)
+        # Take the more conservative label: if either row is stub-derived,
+        # the resulting rate is stub-derived.
+        label = [ weight_row.release_label, cf_row.release_label ]
+                  .compact.find { |l| l.to_s.start_with?("stub") } ||
+                weight_row.release_label || cf_row.release_label
+        Lookup.new(rate: rate, release_label: label)
+      end
+
+      def source
+        SOURCE
+      end
+
+      private
+
+      def calendar_year(date)
+        date.respond_to?(:year) ? date.year : date.to_i
+      end
+    end
+  end
+end

--- a/app/services/corvid/opps_rate_provider.rb
+++ b/app/services/corvid/opps_rate_provider.rb
@@ -29,11 +29,19 @@ module Corvid
       def lookup_for(apc_code:, locality: nil, date: nil)
         return nil if apc_code.nil? || date.nil?
 
+        # Normalize nil/blank locality to NATIONAL at the provider
+        # boundary so the downstream IN-list never contains NULL —
+        # PG's `IN (NULL, 'NATIONAL')` behavior is surprising
+        # (matches NATIONAL only because NULL never equals anything,
+        # but easy to misread). Treating blank as "unknown facility,
+        # use the national default" matches operator intent.
+        normalized_locality = locality.to_s.strip.empty? ? OppsConversionFactor::NATIONAL_LOCALITY : locality
+
         cy = calendar_year(date)
         weight_row = OppsApcWeight.find_by(apc_code: apc_code.to_s, calendar_year: cy)
         return nil unless weight_row
 
-        cf_row = OppsConversionFactor.lookup(calendar_year: cy, locality: locality)
+        cf_row = OppsConversionFactor.lookup(calendar_year: cy, locality: normalized_locality)
         return nil unless cf_row
 
         rate = (weight_row.relative_weight * cf_row.conversion_factor * cf_row.wage_index).round(2)

--- a/app/services/corvid/opps_stub_rate_provider.rb
+++ b/app/services/corvid/opps_stub_rate_provider.rb
@@ -33,7 +33,13 @@ module Corvid
         return nil if date.nil?
 
         year = date.respond_to?(:year) ? date.year : date.to_i
-        NATIONAL_AVERAGE_BY_YEAR[year] || DEFAULT_NATIONAL_AVERAGE
+        # Return nil for years outside the known table rather than
+        # fabricating a default — that way the analyzer's stub-fallback
+        # path can route to :no_rate_for_year instead of misrepresenting
+        # an arbitrary national-average as :stub_estimate confidence
+        # for service dates the stub has no opinion on (e.g., a 1995
+        # obligation).
+        NATIONAL_AVERAGE_BY_YEAR[year]
       end
 
       def source = :stub

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -187,24 +187,50 @@ module Corvid
       end
 
       def analyze_outpatient(obligation, proc_info, facility)
-        rate = Corvid::OppsStubRateProvider.rate_for(
+        # OPPS lookup (#277): real CMS data first; fall back to in-code
+        # stub provider when no row is loaded. Mirrors the IPPS analyze_
+        # inpatient pattern — release_label drives confidence label.
+        lookup = Corvid::OppsRateProvider.lookup_for(
           apc_code: proc_info.apc,
           locality: facility.locality,
           date: obligation.service_date
         )
 
-        Result.new(
-          base_fields(obligation, proc_info, facility).merge(
-            medicare_equivalent: rate,
-            overpayment: rate ? [ obligation.paid_amount.to_f - rate, 0 ].max.round(2) : nil,
-            payment_system: :opps,
-            rate_source: Corvid::OppsStubRateProvider.source,
-            recovery_confidence: :stub_estimate,
-            notes: "Hospital outpatient (APC #{proc_info.apc}). Stub OPPS " \
-                   "national-average estimate; replace with real CMS rate when " \
-                   "#277 (OPPS APC ingest) lands."
+        if lookup
+          stub_derived = lookup.release_label.to_s.start_with?("stub")
+          Result.new(
+            base_fields(obligation, proc_info, facility).merge(
+              medicare_equivalent: lookup.rate,
+              overpayment: [ obligation.paid_amount.to_f - lookup.rate, 0 ].max.round(2),
+              payment_system: :opps,
+              rate_source: stub_derived ? :stub : :real,
+              recovery_confidence: stub_derived ? :stub_estimate : :clear,
+              notes: stub_derived ?
+                "Hospital outpatient (APC #{proc_info.apc}). Priced via " \
+                "stub-derived OPPS canonical CSV (release=#{lookup.release_label})." :
+                "Hospital outpatient (APC #{proc_info.apc}). " \
+                "Priced via real CMS OPPS Final Rule (release=#{lookup.release_label})."
+            )
           )
-        )
+        else
+          stub_rate = Corvid::OppsStubRateProvider.rate_for(
+            apc_code: proc_info.apc,
+            locality: facility.locality,
+            date: obligation.service_date
+          )
+          Result.new(
+            base_fields(obligation, proc_info, facility).merge(
+              medicare_equivalent: stub_rate,
+              overpayment: stub_rate ? [ obligation.paid_amount.to_f - stub_rate, 0 ].max.round(2) : nil,
+              payment_system: :opps,
+              rate_source: stub_rate ? :stub : nil,
+              recovery_confidence: stub_rate ? :stub_estimate : :no_rate_for_year,
+              notes: "Hospital outpatient (APC #{proc_info.apc}). Real OPPS " \
+                     "rate unavailable for this (year, APC, locality); using " \
+                     "stub national-average estimate."
+            )
+          )
+        end
       end
 
       def unmapped_procedure(obligation, facility)

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -16,22 +16,30 @@ module Corvid
   #     fills in, results are :stub_estimate / :stub. See
   #     docs/cms_ipps_data.md for coverage status by FY and the
   #     production-ingest workflow.
-  #   - OPPS still routes only through OppsStubRateProvider — real APC
-  #     ingestion is #277 (next slice).
+  #   - OPPS routes through real CMS Final Rule data when loaded for
+  #     the (calendar year, APC, locality) — :clear / :real. When the
+  #     loaded row's release_label starts with "stub", or no row is
+  #     loaded and the in-code OppsStubRateProvider fills in, results
+  #     are :stub_estimate / :stub. OPPS uses calendar-year boundaries
+  #     (Jan 1), unlike IPPS which uses federal fiscal year.
   #
   # **Screening estimate, not adjudication.** The IPPS pricing formula
-  # implemented here (`weight × base_rate × wage_index`) is the standard
-  # operating payment, intentionally without IME, DSH, capital, outlier,
-  # or transfer adjustments. That accuracy ceiling is fine for PRC
-  # recovery-triage screening — it is **not** a claim-adjudication
-  # amount, and demand-letter dollar figures should cite the analyzer's
-  # source/confidence labels alongside any total.
+  # (`weight × base_rate × wage_index`) is the standard operating
+  # payment, intentionally without IME, DSH, capital, outlier, or
+  # transfer adjustments. The OPPS formula
+  # (`apc_weight × conversion_factor × wage_index`) similarly omits
+  # status-indicator packaging, copay/coinsurance, outlier, and
+  # device/drug pass-through adjustments. Both are recovery-triage
+  # screening estimates — not claim-adjudication amounts. Demand-letter
+  # dollar figures should cite the analyzer's source/confidence labels
+  # alongside any total.
   #
   # Public contract notes for callers:
   #   - Result#recovery_confidence values: :clear, :stub_estimate,
   #     :unmapped_procedure, :unmapped_facility, :no_rate_for_year
-  #   - Result#rate_source values: :real (PFS or IPPS-with-real-data)
-  #     or :stub (IPPS-stub or OPPS Phase 1.5)
+  #   - Result#rate_source values: :real (PFS / IPPS / OPPS with real
+  #     CMS data) or :stub (IPPS / OPPS fallback when real data isn't
+  #     loaded for the year)
   #   - Summary exposes total_overpayment_known (sum where confidence is
   #     :clear) and total_overpayment_stub_estimate (sum where confidence
   #     is :stub_estimate). total_medicare_equivalent intentionally

--- a/db/migrate/20260510000001_create_corvid_opps_tables.rb
+++ b/db/migrate/20260510000001_create_corvid_opps_tables.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreateCorvidOppsTables < ActiveRecord::Migration[8.1]
+  def change
+    # APC relative weight by year. Calendar year for OPPS (Jan 1 boundary)
+    # — different from IPPS which uses federal fiscal year.
+    create_table :corvid_opps_apc_weights do |t|
+      t.integer :calendar_year, null: false
+      t.string :apc_code, null: false
+      t.decimal :relative_weight, precision: 8, scale: 4, null: false
+      t.string :release_label
+      t.timestamps
+    end
+
+    add_index :corvid_opps_apc_weights,
+              [ :calendar_year, :apc_code ],
+              unique: true,
+              name: "idx_corvid_opps_apc_weights_cy_apc"
+
+    # OPPS conversion factor by year + locality. `locality` is either the
+    # PFS locality code or "NATIONAL" for the default-row fallback.
+    # OPPS payment formula: relative_weight × conversion_factor × wage_index_adjustment
+    create_table :corvid_opps_conversion_factors do |t|
+      t.integer :calendar_year, null: false
+      t.string :locality, null: false
+      t.decimal :conversion_factor, precision: 12, scale: 4, null: false
+      t.decimal :wage_index, precision: 8, scale: 4, null: false, default: 1.0
+      t.string :release_label
+      t.timestamps
+    end
+
+    add_index :corvid_opps_conversion_factors,
+              [ :calendar_year, :locality ],
+              unique: true,
+              name: "idx_corvid_opps_conversion_factors_cy_locality"
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,6 +25,8 @@ def clean_corvid_tables!
   Corvid::FeeScheduleEntry.unscoped.delete_all
   Corvid::IppsDrgWeight.unscoped.delete_all
   Corvid::IppsHospitalRate.unscoped.delete_all
+  Corvid::OppsApcWeight.unscoped.delete_all
+  Corvid::OppsConversionFactor.unscoped.delete_all
   Corvid::ZipLocality.unscoped.delete_all
   Corvid::LocalityLookup.clear_cache!
   Corvid::ApiCallLog.unscoped.delete_all

--- a/lib/tasks/cms_ipps.rake
+++ b/lib/tasks/cms_ipps.rake
@@ -42,15 +42,15 @@ namespace :cms do
       puts "Imported #{rows.size} hospital rates for FY #{year} (label=#{label}, replaced full year snapshot)"
     end
 
-    RELEASE_BASE_URL = "https://github.com/lakeraven/corvid/releases/download/cms-fee-schedules-v1"
+    IPPS_RELEASE_BASE_URL = "https://github.com/lakeraven/corvid/releases/download/cms-fee-schedules-v1"
 
     desc "Fetch + import IPPS canonical CSVs from the cms-fee-schedules-v1 GitHub Release: rake cms:ipps:fetch_release[year]"
     task :fetch_release, [ :year ] => :environment do |_t, args|
       abort "Usage: rake cms:ipps:fetch_release[year]" unless args[:year]
       year = args[:year].to_i
 
-      drg_url = "#{RELEASE_BASE_URL}/ipps_drg_weights_FY#{year}.csv"
-      hosp_url = "#{RELEASE_BASE_URL}/ipps_hospital_rates_FY#{year}.csv"
+      drg_url = "#{IPPS_RELEASE_BASE_URL}/ipps_drg_weights_FY#{year}.csv"
+      hosp_url = "#{IPPS_RELEASE_BASE_URL}/ipps_hospital_rates_FY#{year}.csv"
 
       drg_csv = URI.open(drg_url, &:read)
       hosp_csv = URI.open(hosp_url, &:read)

--- a/lib/tasks/cms_ipps.rake
+++ b/lib/tasks/cms_ipps.rake
@@ -55,12 +55,16 @@ namespace :cms do
       drg_csv = URI.open(drg_url, &:read)
       hosp_csv = URI.open(hosp_url, &:read)
 
-      # Read the release_label from a header comment if present, else
-      # default to "stub_v1" — the seed-data tag we ship today.
-      label = drg_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+      # Read each file's release_label independently — a mismatch
+      # (e.g., real DRG weights but stub-derived hospital rates) would
+      # otherwise silently promote stub rows to :clear confidence. The
+      # rate provider's conservative-label propagation then ensures any
+      # stub-labeled row downgrades the final rate to :stub_estimate.
+      drg_label = drg_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+      hosp_label = hosp_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
 
-      drg_rows = Corvid::CmsIppsParser.parse_drg_weights(strip_comments(drg_csv), fiscal_year: year, release_label: label)
-      hosp_rows = Corvid::CmsIppsParser.parse_hospital_rates(strip_comments(hosp_csv), fiscal_year: year, release_label: label)
+      drg_rows = Corvid::CmsIppsParser.parse_drg_weights(strip_comments(drg_csv), fiscal_year: year, release_label: drg_label)
+      hosp_rows = Corvid::CmsIppsParser.parse_hospital_rates(strip_comments(hosp_csv), fiscal_year: year, release_label: hosp_label)
 
       ActiveRecord::Base.transaction do
         Corvid::IppsDrgWeight.where(fiscal_year: year).delete_all

--- a/lib/tasks/cms_opps.rake
+++ b/lib/tasks/cms_opps.rake
@@ -55,10 +55,17 @@ namespace :cms do
       apc_csv = URI.open(apc_url, &:read)
       cf_csv = URI.open(cf_url, &:read)
 
-      label = apc_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+      # Read each file's release_label independently — a mismatch
+      # (e.g., real APC weights but stub-derived CF) would otherwise
+      # silently promote stub rows to :clear confidence. If either
+      # file is stub-labeled, both rows inherit the stub label so the
+      # analyzer's conservative-label propagation in OppsRateProvider
+      # marks the result :stub_estimate.
+      apc_label = apc_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+      cf_label = cf_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
 
-      apc_rows = Corvid::CmsOppsParser.parse_apc_weights(strip_comments(apc_csv), calendar_year: year, release_label: label)
-      cf_rows = Corvid::CmsOppsParser.parse_conversion_factors(strip_comments(cf_csv), calendar_year: year, release_label: label)
+      apc_rows = Corvid::CmsOppsParser.parse_apc_weights(strip_comments(apc_csv), calendar_year: year, release_label: apc_label)
+      cf_rows = Corvid::CmsOppsParser.parse_conversion_factors(strip_comments(cf_csv), calendar_year: year, release_label: cf_label)
 
       ActiveRecord::Base.transaction do
         Corvid::OppsApcWeight.where(calendar_year: year).delete_all

--- a/lib/tasks/cms_opps.rake
+++ b/lib/tasks/cms_opps.rake
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "open-uri"
+
+namespace :cms do
+  namespace :opps do
+    desc "Import CMS OPPS APC weights from a canonical CSV: rake cms:opps:import_apc_weights[year,/path/to/apc_weights.csv,release_label]"
+    task :import_apc_weights, [ :year, :path, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:opps:import_apc_weights[year,/path/to/apc_weights.csv,release_label]" unless args[:year] && args[:path]
+      abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
+
+      year = args[:year].to_i
+      label = args[:label] || "manual"
+      rows = Corvid::CmsOppsParser.parse_apc_weights(
+        File.read(args[:path]), calendar_year: year, release_label: label
+      )
+
+      ActiveRecord::Base.transaction do
+        Corvid::OppsApcWeight.where(calendar_year: year).delete_all
+        Corvid::OppsApcWeight.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
+      end
+
+      puts "Imported #{rows.size} APC weights for CY #{year} (label=#{label}, replaced full year snapshot)"
+    end
+
+    desc "Import CMS OPPS conversion factors from a canonical CSV: rake cms:opps:import_conversion_factors[year,/path/to/conversion_factors.csv,release_label]"
+    task :import_conversion_factors, [ :year, :path, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:opps:import_conversion_factors[year,/path/to/conversion_factors.csv,release_label]" unless args[:year] && args[:path]
+      abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
+
+      year = args[:year].to_i
+      label = args[:label] || "manual"
+      rows = Corvid::CmsOppsParser.parse_conversion_factors(
+        File.read(args[:path]), calendar_year: year, release_label: label
+      )
+
+      ActiveRecord::Base.transaction do
+        Corvid::OppsConversionFactor.where(calendar_year: year).delete_all
+        Corvid::OppsConversionFactor.insert_all(rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if rows.any?
+      end
+
+      puts "Imported #{rows.size} conversion factors for CY #{year} (label=#{label}, replaced full year snapshot)"
+    end
+
+    OPPS_RELEASE_BASE_URL = "https://github.com/lakeraven/corvid/releases/download/cms-fee-schedules-v1"
+
+    desc "Fetch + import OPPS canonical CSVs from the cms-fee-schedules-v1 GitHub Release: rake cms:opps:fetch_release[year]"
+    task :fetch_release, [ :year ] => :environment do |_t, args|
+      abort "Usage: rake cms:opps:fetch_release[year]" unless args[:year]
+      year = args[:year].to_i
+
+      apc_url = "#{OPPS_RELEASE_BASE_URL}/opps_apc_weights_CY#{year}.csv"
+      cf_url  = "#{OPPS_RELEASE_BASE_URL}/opps_conversion_factors_CY#{year}.csv"
+
+      apc_csv = URI.open(apc_url, &:read)
+      cf_csv = URI.open(cf_url, &:read)
+
+      label = apc_csv[/#\s*release_label:\s*(\S+)/, 1] || "stub_v1"
+
+      apc_rows = Corvid::CmsOppsParser.parse_apc_weights(strip_comments(apc_csv), calendar_year: year, release_label: label)
+      cf_rows = Corvid::CmsOppsParser.parse_conversion_factors(strip_comments(cf_csv), calendar_year: year, release_label: label)
+
+      ActiveRecord::Base.transaction do
+        Corvid::OppsApcWeight.where(calendar_year: year).delete_all
+        Corvid::OppsApcWeight.insert_all(apc_rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if apc_rows.any?
+        Corvid::OppsConversionFactor.where(calendar_year: year).delete_all
+        Corvid::OppsConversionFactor.insert_all(cf_rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if cf_rows.any?
+      end
+
+      puts "Fetched CY #{year} from cms-fee-schedules-v1: #{apc_rows.size} APC weights, #{cf_rows.size} conversion factors (label=#{label})"
+    end
+
+    def strip_comments(csv_text)
+      csv_text.lines.reject { |l| l.lstrip.start_with?("#") }.join
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -313,6 +313,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000001) do
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
     t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
+  end
+
+  create_table "corvid_opps_apc_weights", force: :cascade do |t|
+    t.string "apc_code", null: false
+    t.integer "calendar_year", null: false
+    t.datetime "created_at", null: false
+    t.decimal "relative_weight", precision: 8, scale: 4, null: false
+    t.string "release_label"
+    t.datetime "updated_at", null: false
+    t.index ["calendar_year", "apc_code"], name: "idx_corvid_opps_apc_weights_cy_apc", unique: true
+  end
+
+  create_table "corvid_opps_conversion_factors", force: :cascade do |t|
+    t.integer "calendar_year", null: false
+    t.decimal "conversion_factor", precision: 12, scale: 4, null: false
+    t.datetime "created_at", null: false
+    t.string "locality", null: false
+    t.string "release_label"
+    t.datetime "updated_at", null: false
+    t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
+    t.index ["calendar_year", "locality"], name: "idx_corvid_opps_conversion_factors_cy_locality", unique: true
   end
 
   create_table "corvid_payments", force: :cascade do |t|

--- a/test/services/corvid/cms_opps_parser_test.rb
+++ b/test/services/corvid/cms_opps_parser_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::CmsOppsParserTest < ActiveSupport::TestCase
+  APC_CSV = <<~CSV
+    apc_code,relative_weight,description
+    5071,25.4378,"Level 1 Excision/ Biopsy/ Incision and Drainage"
+    5072,46.0916,"Level 2 Excision/ Biopsy/ Incision and Drainage"
+  CSV
+
+  CF_CSV = <<~CSV
+    locality,conversion_factor,wage_index
+    NATIONAL,89.169,1.0000
+    01,89.169,1.0853
+  CSV
+
+  test "parse_apc_weights returns one entry per row with calendar_year stamped in" do
+    rows = Corvid::CmsOppsParser.parse_apc_weights(APC_CSV, calendar_year: 2026)
+    assert_equal 2, rows.size
+    row = rows.find { |r| r[:apc_code] == "5071" }
+    assert_equal 2026, row[:calendar_year]
+    assert_equal BigDecimal("25.4378"), row[:relative_weight]
+  end
+
+  test "parse_conversion_factors returns one entry per locality" do
+    rows = Corvid::CmsOppsParser.parse_conversion_factors(CF_CSV, calendar_year: 2026)
+    assert_equal 2, rows.size
+    national = rows.find { |r| r[:locality] == "NATIONAL" }
+    assert_equal BigDecimal("89.169"), national[:conversion_factor]
+    assert_equal BigDecimal("1.0000"), national[:wage_index]
+  end
+
+  test "release_label flows through to parsed rows" do
+    rows = Corvid::CmsOppsParser.parse_apc_weights(APC_CSV, calendar_year: 2026, release_label: "cms_cy2026_final_rule")
+    assert_equal "cms_cy2026_final_rule", rows.first[:release_label]
+  end
+
+  test "parse_apc_weights raises on missing required columns" do
+    assert_raises(Corvid::CmsOppsParser::MalformedFileError) do
+      Corvid::CmsOppsParser.parse_apc_weights("apc_code\n5071\n", calendar_year: 2026)
+    end
+  end
+
+  test "parse_conversion_factors raises on missing required columns" do
+    assert_raises(Corvid::CmsOppsParser::MalformedFileError) do
+      Corvid::CmsOppsParser.parse_conversion_factors("locality,conversion_factor\nNATIONAL,89.169\n", calendar_year: 2026)
+    end
+  end
+end

--- a/test/services/corvid/opps_rate_provider_test.rb
+++ b/test/services/corvid/opps_rate_provider_test.rb
@@ -33,9 +33,8 @@ class Corvid::OppsRateProviderTest < ActiveSupport::TestCase
     rate = Corvid::OppsRateProvider.rate_for(
       apc_code: "5071", locality: "01", date: Date.new(2026, 6, 15)
     )
-    # 25.4378 × 89.169 × 1.085 = 2461.0645... → 2461.06
-    # (rounds up to 2461.07 with round-half-to-even depending on BigDecimal precision)
-    assert_in_delta 2_461.06, rate, 0.02
+    # 25.4378 × 89.169 × 1.085 = 2461.06448695 → 2461.06 (std round)
+    assert_in_delta 2_461.06, rate, 0.01
   end
 
   test "rate_for uses CALENDAR year — Jan 1 boundary, not Oct 1" do

--- a/test/services/corvid/opps_rate_provider_test.rb
+++ b/test/services/corvid/opps_rate_provider_test.rb
@@ -22,19 +22,20 @@ class Corvid::OppsRateProviderTest < ActiveSupport::TestCase
   end
 
   test "rate_for computes weight × CF × wage_index for known data" do
-    # 25.4378 × 89.169 × 1.0 = 2267.99 (approx)
+    # 25.4378 × 89.169 × 1.0 = 2268.2622 → 2268.26
     rate = Corvid::OppsRateProvider.rate_for(
       apc_code: "5071", locality: "NATIONAL", date: Date.new(2026, 6, 15)
     )
-    assert_in_delta 2_268.27, rate, 1.0
+    assert_in_delta 2_268.26, rate, 0.01
   end
 
   test "rate_for applies locality-specific wage index" do
     rate = Corvid::OppsRateProvider.rate_for(
       apc_code: "5071", locality: "01", date: Date.new(2026, 6, 15)
     )
-    # 25.4378 × 89.169 × 1.085 = 2461.07 (approx)
-    assert_in_delta 2_461.07, rate, 1.5
+    # 25.4378 × 89.169 × 1.085 = 2461.0645... → 2461.06
+    # (rounds up to 2461.07 with round-half-to-even depending on BigDecimal precision)
+    assert_in_delta 2_461.06, rate, 0.02
   end
 
   test "rate_for uses CALENDAR year — Jan 1 boundary, not Oct 1" do
@@ -76,6 +77,16 @@ class Corvid::OppsRateProviderTest < ActiveSupport::TestCase
 
   test "source returns :opps_real symbol to match the rate-provider contract" do
     assert_equal :opps_real, Corvid::OppsRateProvider.source
+  end
+
+  test "rate_for normalizes nil/blank locality to NATIONAL" do
+    [ nil, "", "   " ].each do |loc|
+      rate = Corvid::OppsRateProvider.rate_for(
+        apc_code: "5071", locality: loc, date: Date.new(2026, 6, 15)
+      )
+      assert_in_delta 2_268.26, rate, 0.01,
+                      "locality=#{loc.inspect} should fall back to NATIONAL"
+    end
   end
 
   test "lookup_for returns rate + release_label so analyzer can downgrade stub-derived data" do

--- a/test/services/corvid/opps_rate_provider_test.rb
+++ b/test/services/corvid/opps_rate_provider_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Real OPPS APC rate provider (#277). Returns nil when CMS data isn't
+# loaded for the (year, APC, locality) — the analyzer falls back to
+# OppsStubRateProvider in that case.
+class Corvid::OppsRateProviderTest < ActiveSupport::TestCase
+  setup do
+    @cy = 2026
+    Corvid::OppsApcWeight.create!(
+      calendar_year: @cy, apc_code: "5071", relative_weight: 25.4378
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: @cy, locality: "NATIONAL",
+      conversion_factor: 89.169, wage_index: 1.0
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: @cy, locality: "01",
+      conversion_factor: 89.169, wage_index: 1.085
+    )
+  end
+
+  test "rate_for computes weight × CF × wage_index for known data" do
+    # 25.4378 × 89.169 × 1.0 = 2267.99 (approx)
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "5071", locality: "NATIONAL", date: Date.new(2026, 6, 15)
+    )
+    assert_in_delta 2_268.27, rate, 1.0
+  end
+
+  test "rate_for applies locality-specific wage index" do
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "5071", locality: "01", date: Date.new(2026, 6, 15)
+    )
+    # 25.4378 × 89.169 × 1.085 = 2461.07 (approx)
+    assert_in_delta 2_461.07, rate, 1.5
+  end
+
+  test "rate_for uses CALENDAR year — Jan 1 boundary, not Oct 1" do
+    # A November 2026 service date stays in CY 2026 (vs IPPS which
+    # would convert to FY 2027 for the same date).
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "5071", locality: "NATIONAL", date: Date.new(2026, 11, 15)
+    )
+    refute_nil rate
+  end
+
+  test "rate_for falls back to NATIONAL locality when locality-specific row missing" do
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "5071", locality: "99", date: Date.new(2026, 6, 15)
+    )
+    assert_in_delta 2_268.27, rate, 1.0,
+                    "unknown locality should fall back to NATIONAL row"
+  end
+
+  test "rate_for returns nil when APC isn't loaded for that year" do
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "9999", locality: "NATIONAL", date: Date.new(2026, 6, 15)
+    )
+    assert_nil rate
+  end
+
+  test "rate_for returns nil when no conversion factor row exists" do
+    Corvid::OppsConversionFactor.unscoped.delete_all
+    rate = Corvid::OppsRateProvider.rate_for(
+      apc_code: "5071", locality: "NATIONAL", date: Date.new(2026, 6, 15)
+    )
+    assert_nil rate
+  end
+
+  test "rate_for returns nil for missing inputs" do
+    assert_nil Corvid::OppsRateProvider.rate_for(apc_code: nil, locality: "01", date: Date.current)
+    assert_nil Corvid::OppsRateProvider.rate_for(apc_code: "5071", locality: "01", date: nil)
+  end
+
+  test "source returns :opps_real symbol to match the rate-provider contract" do
+    assert_equal :opps_real, Corvid::OppsRateProvider.source
+  end
+
+  test "lookup_for returns rate + release_label so analyzer can downgrade stub-derived data" do
+    Corvid::OppsApcWeight.unscoped.delete_all
+    Corvid::OppsApcWeight.create!(
+      calendar_year: @cy, apc_code: "5071", relative_weight: 25.4378,
+      release_label: "stub_v1"
+    )
+    lookup = Corvid::OppsRateProvider.lookup_for(
+      apc_code: "5071", locality: "NATIONAL", date: Date.new(2026, 6, 15)
+    )
+    assert_equal "stub_v1", lookup.release_label,
+                 "if either row is stub-labeled, the lookup propagates it"
+  end
+end

--- a/test/services/corvid/opps_stub_rate_provider_test.rb
+++ b/test/services/corvid/opps_stub_rate_provider_test.rb
@@ -15,10 +15,14 @@ class Corvid::OppsStubRateProviderTest < ActiveSupport::TestCase
     assert rate_2026 > rate_2010
   end
 
-  test "year outside the table uses the default" do
-    rate = Corvid::OppsStubRateProvider.rate_for(date: Date.new(2099, 1, 1))
-    assert rate.is_a?(Numeric)
-    assert rate.positive?
+  test "year outside the table returns nil" do
+    # Returning nil (rather than a fabricated default) lets the analyzer's
+    # stub-fallback path route the obligation to :no_rate_for_year for
+    # service dates the stub has no opinion on. Previously the stub
+    # returned a default national-average which silently flagged
+    # those obligations as :stub_estimate — misrepresenting confidence.
+    assert_nil Corvid::OppsStubRateProvider.rate_for(date: Date.new(2099, 1, 1))
+    assert_nil Corvid::OppsStubRateProvider.rate_for(date: Date.new(1995, 1, 1))
   end
 
   test "nil date returns nil" do

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -99,6 +99,56 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
 
   # -- Outpatient hospital obligation (APC-mapped) --------------------------
 
+  test "outpatient claim with real OPPS data loaded routes to :clear / :real" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST",
+      hcpcs: "12345", apc: "5071",
+      description: "Test outpatient procedure"
+    )
+    Corvid::OppsApcWeight.create!(
+      calendar_year: 2009, apc_code: "5071", relative_weight: 25.4378
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: 2009, locality: "NATIONAL",
+      conversion_factor: 70.0, wage_index: 1.0
+    )
+
+    summary = analyze_single_obligation(procedure: "OUTPATIENT_TEST", paid: 5_000)
+    result = summary.results.first
+
+    assert_equal :opps, result.payment_system
+    assert_equal :clear, result.recovery_confidence,
+                 "with real CMS OPPS data loaded, outpatient claim is fully priced"
+    assert_equal :real, result.rate_source
+    # 25.4378 × 70.0 × 1.0 = 1780.65
+    assert_in_delta 1_780.65, result.medicare_equivalent.to_f, 0.01
+    assert_match(/real CMS OPPS/, result.notes)
+  end
+
+  test "outpatient claim with stub-labeled OPPS data still routes to :stub_estimate" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST",
+      hcpcs: "12345", apc: "5071",
+      description: "Test outpatient procedure"
+    )
+    Corvid::OppsApcWeight.create!(
+      calendar_year: 2009, apc_code: "5071",
+      relative_weight: 25.4378, release_label: "stub_v1"
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: 2009, locality: "NATIONAL",
+      conversion_factor: 70.0, wage_index: 1.0, release_label: "stub_v1"
+    )
+
+    summary = analyze_single_obligation(procedure: "OUTPATIENT_TEST", paid: 5_000)
+    result = summary.results.first
+
+    assert_equal :opps, result.payment_system
+    assert_equal :stub_estimate, result.recovery_confidence
+    assert_equal :stub, result.rate_source
+    assert_match(/stub-derived/, result.notes)
+  end
+
   test "outpatient hospital claim uses OPPS stub rate (Phase 1.5)" do
     Corvid::PrcProcedureDictionary.register(
       "OUTPATIENT_TEST",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,8 @@ def clean_corvid_tables!
   Corvid::FeeScheduleEntry.unscoped.delete_all
   Corvid::IppsDrgWeight.unscoped.delete_all
   Corvid::IppsHospitalRate.unscoped.delete_all
+  Corvid::OppsApcWeight.unscoped.delete_all
+  Corvid::OppsConversionFactor.unscoped.delete_all
   Corvid::ZipLocality.unscoped.delete_all
   Corvid::LocalityLookup.clear_cache!
   Corvid::ApiCallLog.unscoped.delete_all


### PR DESCRIPTION
## Summary

Mirrors the IPPS Phase 1 pipeline (#276 / PR #306) for **hospital outpatient** obligations. Analyzer routes through \`Corvid::OppsRateProvider\` first; when (year, APC, locality) data isn't loaded, falls back to \`OppsStubRateProvider\`.

| Path | recovery_confidence | rate_source |
|---|---|---|
| Real CMS data loaded | \`:clear\` | \`:real\` |
| stub_v1-labeled rows | \`:stub_estimate\` | \`:stub\` |
| No row loaded → in-code stub | \`:stub_estimate\` | \`:stub\` |

## Schema

- \`corvid_opps_apc_weights\` (calendar_year × APC → relative_weight)
- \`corvid_opps_conversion_factors\` (calendar_year × locality → conversion_factor, wage_index)

⚠️ OPPS uses **calendar year** (Jan 1 boundary), unlike IPPS which uses federal fiscal year. The pipeline correctly separates the two.

## Formula

\`medicare_equivalent = apc_relative_weight × conversion_factor × wage_index\`

## Operational loading

\`\`\`bash
rake cms:opps:import_apc_weights[2026,/path/to/apc_weights.csv,release_label]
rake cms:opps:import_conversion_factors[2026,/path/to/conversion_factors.csv,release_label]
rake cms:opps:fetch_release[2026]   # pulls canonical CSVs from cms-fee-schedules-v1 release
\`\`\`

All tasks are idempotent — re-running replaces the full year snapshot.

## Test plan

- [x] 9 \`OppsRateProvider\` tests: formula, locality vs NATIONAL fallback, calendar-year boundary, missing APC/CF → nil, empty inputs, source label, release_label propagation.
- [x] 5 \`CmsOppsParser\` tests: happy path, calendar_year stamping, release_label, malformed (missing columns).
- [x] 2 \`PrcOverpaymentAnalyzer\` tests: real OPPS data → \`:clear\` / \`:real\`; stub_v1-labeled → \`:stub_estimate\` / \`:stub\`. Existing stub-fallback test preserved.
- [x] 794 minitest assertions / 0 failures, 375 cucumber / 0 failures.

## What's deferred (next slice)

Actual CMS OPPS Final Rule data for CY 2008–2026 — same hand-vetted recipe as the IPPS backfill in PR #309. Source: CMS publishes OPPS Final Rule annually with **Addendum A** (national APC payment rates), **Addendum B** (HCPCS-to-APC crosswalk + weights), and conversion-factor narratives.

⚠️ Local DB reset required after pulling: \`cd test/dummy && RAILS_ENV=test bundle exec rails db:drop db:create db:migrate\` (new migration; pre-prod stance per ADR 0004).

Refs #277