### PR TITLE
Split PrcOverpaymentReportService into recoverable vs exceptions

### DIFF
--- a/app/models/corvid/prc_overpayment_analysis.rb
+++ b/app/models/corvid/prc_overpayment_analysis.rb
@@ -27,8 +27,10 @@ module Corvid
 
     # Recoverable-now: priced from real CMS rate data with clear confidence.
     # Single source of truth lives in Corvid::RecoverableRule — council-
-    # facing CSV/PDF reports gate dollar totals on this predicate.
-    scope :recoverable, -> { clear.where(rate_source: Corvid::RecoverableRule::RECOVERABLE_RATE_SOURCE) }
+    # facing CSV/PDF reports gate dollar totals on this predicate. The
+    # scope uses the same set (IN clause) so model-level filtering can't
+    # diverge from the predicate when new "real" labels are whitelisted.
+    scope :recoverable, -> { clear.where(rate_source: Corvid::RecoverableRule::RECOVERABLE_RATE_SOURCES) }
     scope :exceptions, -> { where.not(id: recoverable) }
 
     def recoverable?

--- a/app/models/corvid/prc_overpayment_analysis.rb
+++ b/app/models/corvid/prc_overpayment_analysis.rb
@@ -24,5 +24,15 @@ module Corvid
     scope :stub_estimate, -> { where(recovery_confidence: "stub_estimate") }
     scope :pending_real_data,
           -> { where(recovery_confidence: %w[stub_estimate no_rate_for_year]) }
+
+    # Recoverable-now: priced from real CMS rate data with clear confidence.
+    # Single source of truth lives in Corvid::RecoverableRule — council-
+    # facing CSV/PDF reports gate dollar totals on this predicate.
+    scope :recoverable, -> { clear.where(rate_source: Corvid::RecoverableRule::RECOVERABLE_RATE_SOURCE) }
+    scope :exceptions, -> { where.not(id: recoverable) }
+
+    def recoverable?
+      Corvid::RecoverableRule.recoverable?(self)
+    end
   end
 end

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -87,34 +87,76 @@ module Corvid
         end
       end
 
-      def to_csv_summary(tenant:, **filters)
-        rows = detail(tenant: tenant, **filters)
+      # CSV summary emits only recoverable rows by default — never mixes
+      # stub-derived dollars into council-facing totals. Set
+      # `include_legacy_stub: true` for a forensic export that includes
+      # the legacy stub_estimate column (always zero in the recoverable
+      # bucket; populated only when the include_legacy_stub flag is set).
+      def to_csv_summary(tenant:, include_legacy_stub: false, **filters)
+        all_rows = detail(tenant: tenant, **filters)
+        rows = include_legacy_stub ? all_rows : all_rows.select { |r| Corvid::RecoverableRule.recoverable?(r) }
         groups = rows.group_by { |r| [ r[:fiscal_year], r[:vendor_id], r[:payment_system], r[:currency] ] }
                      .sort_by { |key, _| key.map { |v| v.to_s } }
 
         CSV.generate do |csv|
           csv << SUMMARY_CSV_HEADERS
           groups.each do |(fy, vendor, system, currency), group|
+            recoverable_rows = group.select { |r| Corvid::RecoverableRule.recoverable?(r) }
+            stub_rows = group.reject { |r| Corvid::RecoverableRule.recoverable?(r) }
+            stub_total = sum_money(stub_rows, :overpayment) || Money.new(0, currency || "USD")
             csv << [
               fy, vendor, system, currency, group.size,
-              fmt_money(sum_money(group, :billed_amount)),
-              fmt_money(sum_money(group, :paid_amount)),
-              fmt_money(sum_money(group, :medicare_equivalent)),
-              fmt_money(sum_money(group.select { |r| r[:recovery_confidence] == "clear" }, :overpayment)),
-              fmt_money(sum_money(group.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment))
+              fmt_money(sum_money(recoverable_rows, :billed_amount)),
+              fmt_money(sum_money(recoverable_rows, :paid_amount)),
+              fmt_money(sum_money(recoverable_rows, :medicare_equivalent)),
+              fmt_money(sum_money(recoverable_rows, :overpayment)),
+              fmt_money(stub_total)
             ]
           end
         end
       end
 
-      def to_csv_detail(tenant:, **filters)
+      # CSV detail emits only recoverable rows by default. Exceptions
+      # are inspected via `to_csv_exceptions` for the ops backlog —
+      # the two artifacts have different audiences and shouldn't be
+      # mixed into one file.
+      def to_csv_detail(tenant:, include_legacy_stub: false, **filters)
         rows = detail(tenant: tenant, **filters)
+        rows = rows.select { |r| Corvid::RecoverableRule.recoverable?(r) } unless include_legacy_stub
         CSV.generate do |csv|
           csv << DETAIL_CSV_HEADERS
           rows.each do |r|
             csv << DETAIL_CSV_HEADERS.map do |h|
               key = h.to_sym
               MONEY_KEYS.include?(key) ? fmt_money(r[key]) : r[key]
+            end
+          end
+        end
+      end
+
+      # Operations-facing backlog: every non-recoverable analyzed
+      # obligation, with the reason it fell out of the recoverable
+      # bucket. No dollar totals — these are work items, not money.
+      EXCEPTIONS_CSV_HEADERS = %w[
+        obligation_id fiscal_year service_date vendor_id procedure_code
+        payment_system recovery_confidence rate_source currency
+        reason
+        analyzer_version rate_source_release source_file analyzed_at
+      ].freeze
+
+      def to_csv_exceptions(tenant:, **filters)
+        rows = detail(tenant: tenant, **filters)
+                 .reject { |r| Corvid::RecoverableRule.recoverable?(r) }
+        CSV.generate do |csv|
+          csv << EXCEPTIONS_CSV_HEADERS
+          rows.each do |r|
+            csv << EXCEPTIONS_CSV_HEADERS.map do |h|
+              key = h.to_sym
+              if key == :reason
+                exception_reason(r)
+              else
+                r[key]
+              end
             end
           end
         end
@@ -149,31 +191,70 @@ module Corvid
           .order(Arel.sql("prc_obligation_id, analyzed_at DESC, id DESC"))
       end
 
-      # Summaries always partition rows by currency before summing — per
-      # ADR 0004, mixed-currency aggregation never auto-FXes. A single-
-      # currency tenant produces one entry under `by_currency`; a future
-      # multi-currency tenant produces one entry per ISO code, side by
-      # side, with their own Money totals.
+      # Two-bucket summary: the `recoverable` block carries dollar
+      # totals computed strictly over rows that pass
+      # Corvid::RecoverableRule (clear confidence + real rate source).
+      # The `exceptions` block enumerates everything else without
+      # dollar totals — counts and reasons only — so it's clear at a
+      # glance that those obligations are operational backlog (need
+      # dictionary update, real rate ingest, etc.), not citation-ready
+      # demand-letter dollars.
+      #
+      # Within `recoverable`, rows still partition by currency (per
+      # ADR 0004 — no auto-FX). Within `exceptions`, rows are grouped
+      # by the reason they're not recoverable.
       def summary_from_rows(rows)
+        recoverable_rows = rows.select { |r| Corvid::RecoverableRule.recoverable?(r) }
+        exception_rows = rows - recoverable_rows
+
         {
           obligations_analyzed: rows.size,
-          by_currency: rows.group_by { |r| r[:currency] }.map { |iso, group| currency_totals(iso, group) },
-          by_payment_system: group_totals(rows, :payment_system),
-          by_vendor: group_totals(rows, :vendor_id),
-          by_year: group_totals(rows, :fiscal_year)
+          recoverable: {
+            count: recoverable_rows.size,
+            by_currency: recoverable_rows.group_by { |r| r[:currency] }.map { |iso, group| currency_totals(iso, group) },
+            by_payment_system: group_totals(recoverable_rows, :payment_system),
+            by_vendor: group_totals(recoverable_rows, :vendor_id),
+            by_year: group_totals(recoverable_rows, :fiscal_year)
+          },
+          exceptions: {
+            count: exception_rows.size,
+            by_reason: exception_rows.group_by { |r| exception_reason(r) }
+                                     .transform_values(&:size)
+                                     .sort_by { |_, n| -n }
+                                     .to_h
+          }
         }
       end
 
+      # Recoverable-bucket totals carry the full money roll-up. The
+      # legacy column total_overpayment_stub_estimate (always zero
+      # under the strict rule) is preserved with a documented zero
+      # so legacy CSV consumers don't crash on schema change. New
+      # callers should ignore it and use exceptions.count instead.
       def currency_totals(iso, rows)
+        zero = Money.new(0, iso) if iso
         {
           currency: iso,
           obligations: rows.size,
           total_billed: sum_money(rows, :billed_amount),
           total_paid: sum_money(rows, :paid_amount),
           total_medicare_equivalent: sum_money(rows, :medicare_equivalent),
-          total_overpayment_known: sum_money(rows.select { |r| r[:recovery_confidence] == "clear" }, :overpayment),
-          total_overpayment_stub_estimate: sum_money(rows.select { |r| r[:recovery_confidence] == "stub_estimate" }, :overpayment)
+          total_overpayment_known: sum_money(rows, :overpayment),
+          total_overpayment_stub_estimate: zero
         }
+      end
+
+      def exception_reason(row)
+        confidence = row[:recovery_confidence].to_s
+        source = row[:rate_source].to_s
+        case confidence
+        when "stub_estimate"
+          source.start_with?("stub") ? "stub_data_loaded" : "stub_fallback"
+        when "unmapped_procedure", "unmapped_facility", "no_rate_for_year"
+          confidence
+        else
+          "unknown_#{confidence}"
+        end
       end
 
       def detail_row(analysis)

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -248,10 +248,14 @@ module Corvid
 
       def exception_reason(row)
         confidence = row[:recovery_confidence].to_s
-        source = row[:rate_source].to_s
         case confidence
         when "stub_estimate"
-          source.start_with?("stub") ? "stub_data_loaded" : "stub_fallback"
+          # Both stub paths in PrcOverpaymentAnalyzer set rate_source: :stub,
+          # so it can't distinguish loaded canonical stub data from the
+          # in-code fallback. rate_source_release is set only on the loaded
+          # path (e.g., "stub_v1") and is nil for the fallback path.
+          release = row[:rate_source_release].to_s
+          release.start_with?("stub") ? "stub_data_loaded" : "stub_fallback"
         when "unmapped_procedure", "unmapped_facility", "no_rate_for_year"
           confidence
         when Corvid::RecoverableRule::RECOVERABLE_CONFIDENCE

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -105,7 +105,7 @@ module Corvid
             stub_rows = group.reject { |r| Corvid::RecoverableRule.recoverable?(r) }
             stub_total = sum_money(stub_rows, :overpayment) || Money.new(0, currency || "USD")
             csv << [
-              fy, vendor, system, currency, group.size,
+              fy, vendor, system, currency, recoverable_rows.size,
               fmt_money(sum_money(recoverable_rows, :billed_amount)),
               fmt_money(sum_money(recoverable_rows, :paid_amount)),
               fmt_money(sum_money(recoverable_rows, :medicare_equivalent)),
@@ -162,18 +162,20 @@ module Corvid
         end
       end
 
-      # Computes detail once and derives summary from the same in-memory
-      # set so the JSON payload's summary and detail are consistent and
-      # we don't repeat DB work — important for large tenants where
-      # detail() is the dominant cost.
-      def to_json_export(tenant:, **filters)
+      # JSON export defaults to recoverable-only detail so naive integrators
+      # can't surface stub-derived dollars by walking the body. Summary
+      # always carries the two-bucket structure (recoverable + exceptions).
+      # Set `include_legacy_stub: true` for the forensic payload that
+      # includes every analyzed row in `detail`.
+      def to_json_export(tenant:, include_legacy_stub: false, **filters)
         rows = detail(tenant: tenant, **filters)
+        detail_rows = include_legacy_stub ? rows : rows.select { |r| Corvid::RecoverableRule.recoverable?(r) }
         {
           tenant: tenant,
           generated_at: Time.current.iso8601,
           filters: filters.compact,
           summary: serialize_money(summary_from_rows(rows)),
-          detail: rows.map { |r| serialize_money(r) }
+          detail: detail_rows.map { |r| serialize_money(r) }
         }.to_json
       end
 
@@ -252,6 +254,11 @@ module Corvid
           source.start_with?("stub") ? "stub_data_loaded" : "stub_fallback"
         when "unmapped_procedure", "unmapped_facility", "no_rate_for_year"
           confidence
+        when Corvid::RecoverableRule::RECOVERABLE_CONFIDENCE
+          # Clear confidence but a rate_source outside the recoverable set
+          # (e.g., a new analyzer label not yet whitelisted). Surface
+          # explicitly so ops can decide whether to widen RECOVERABLE_RATE_SOURCES.
+          "clear_non_real_source"
         else
           "unknown_#{confidence}"
         end

--- a/app/services/corvid/recoverable_rule.rb
+++ b/app/services/corvid/recoverable_rule.rb
@@ -22,9 +22,9 @@ module Corvid
     # by default; expand here (e.g., add "cms_real" or another label
     # if a future analyzer emits one) rather than relaxing the rule
     # at call sites. Anything outside this set falls into exceptions.
+    # Both the predicate below and PrcOverpaymentAnalysis.recoverable
+    # read from this set so they can't drift.
     RECOVERABLE_RATE_SOURCES = %w[real].freeze
-    # Canonical label used by today's analyzer / tests.
-    RECOVERABLE_RATE_SOURCE = "real"
 
     class << self
       # Returns true iff the row (an AR record OR a detail-row hash

--- a/app/services/corvid/recoverable_rule.rb
+++ b/app/services/corvid/recoverable_rule.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Single source of truth for "what counts as a recoverable overpayment."
+  # An obligation is recoverable iff its analysis was priced from real
+  # CMS rate data — clear confidence AND real rate source.
+  #
+  # All council-facing artifacts (summary CSV, audit packet, demand
+  # letter) gate dollar totals on this predicate. Stub-derived rows,
+  # unmapped procedures/facilities, and rows with no rate for the
+  # service year all show up in the "exceptions" backlog instead of
+  # the recoverable total — they are operational signal, not citation-
+  # ready demand-letter dollars.
+  #
+  # Rationale: a single mislabeled stub-derived row in a council
+  # presentation creates a credibility hazard that's hard to walk
+  # back. Better to over-route to the exceptions queue and let
+  # operators force-include via an explicit forensic flag.
+  module RecoverableRule
+    RECOVERABLE_CONFIDENCE = "clear"
+    RECOVERABLE_RATE_SOURCE = "real"
+
+    class << self
+      # Returns true iff the row (an AR record OR a detail-row hash
+      # produced by PrcOverpaymentReportService) qualifies as
+      # recoverable-now.
+      def recoverable?(row)
+        confidence = read_attr(row, :recovery_confidence)
+        source = read_attr(row, :rate_source)
+        confidence.to_s == RECOVERABLE_CONFIDENCE && source.to_s == RECOVERABLE_RATE_SOURCE
+      end
+
+      private
+
+      def read_attr(row, key)
+        if row.respond_to?(key)
+          row.public_send(key)
+        elsif row.is_a?(Hash)
+          row[key] || row[key.to_s]
+        end
+      end
+    end
+  end
+end

--- a/app/services/corvid/recoverable_rule.rb
+++ b/app/services/corvid/recoverable_rule.rb
@@ -18,6 +18,12 @@ module Corvid
   # operators force-include via an explicit forensic flag.
   module RecoverableRule
     RECOVERABLE_CONFIDENCE = "clear"
+    # Set of rate_source values that count as "real" CMS data. Strict
+    # by default; expand here (e.g., add "cms_real" or another label
+    # if a future analyzer emits one) rather than relaxing the rule
+    # at call sites. Anything outside this set falls into exceptions.
+    RECOVERABLE_RATE_SOURCES = %w[real].freeze
+    # Canonical label used by today's analyzer / tests.
     RECOVERABLE_RATE_SOURCE = "real"
 
     class << self
@@ -27,7 +33,7 @@ module Corvid
       def recoverable?(row)
         confidence = read_attr(row, :recovery_confidence)
         source = read_attr(row, :rate_source)
-        confidence.to_s == RECOVERABLE_CONFIDENCE && source.to_s == RECOVERABLE_RATE_SOURCE
+        confidence.to_s == RECOVERABLE_CONFIDENCE && RECOVERABLE_RATE_SOURCES.include?(source.to_s)
       end
 
       private

--- a/test/services/corvid/prc_overpayment_report_service_test.rb
+++ b/test/services/corvid/prc_overpayment_report_service_test.rb
@@ -56,45 +56,54 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
 
   # -- Summary ----------------------------------------------------------------
 
-  test "summary aggregates totals across all obligations, partitioned by currency" do
+  test "summary partitions into recoverable and exceptions buckets" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT)
 
     assert_equal 2, summary[:obligations_analyzed]
-    assert_equal 1, summary[:by_currency].size, "single-currency tenant has one bucket"
-    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
-    assert_equal Money.from_amount(65_200, "USD"), usd[:total_billed]
-    assert_equal Money.from_amount(42_180, "USD"), usd[:total_paid]
-    assert_equal Money.from_amount(18_100, "USD"), usd[:total_medicare_equivalent]
+    # Fixture: visit (pfs/real/clear) is recoverable; hip (ipps/stub/stub_estimate) is exception.
+    assert_equal 1, summary[:recoverable][:count]
+    assert_equal 1, summary[:exceptions][:count]
+
+    assert_equal 1, summary[:recoverable][:by_currency].size, "single-currency tenant"
+    usd = summary[:recoverable][:by_currency].find { |b| b[:currency] == "USD" }
+    # Only the recoverable office visit ($200 billed, $180 paid, $100 medicare, $80 overpayment) contributes.
+    assert_equal Money.from_amount(200, "USD"), usd[:total_billed]
+    assert_equal Money.from_amount(180, "USD"), usd[:total_paid]
+    assert_equal Money.from_amount(100, "USD"), usd[:total_medicare_equivalent]
     assert_equal Money.from_amount(80, "USD"), usd[:total_overpayment_known]
-    assert_equal Money.from_amount(24_000, "USD"), usd[:total_overpayment_stub_estimate]
+    assert_equal Money.new(0, "USD"), usd[:total_overpayment_stub_estimate],
+                 "legacy column always zero under the strict rule"
+
+    assert summary[:exceptions][:by_reason].keys.any?
   end
 
-  test "summary breaks down by payment_system, vendor, and fiscal_year" do
+  test "summary breakdowns partition recoverable rows by payment_system, vendor, year" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT)
 
-    assert_equal 2, summary[:by_payment_system].size
-    ipps_row = summary[:by_payment_system].find { |r| r[:payment_system] == "ipps" }
-    assert_equal 1, ipps_row[:obligations]
-    assert_equal Money.from_amount(24_000, "USD"), ipps_row[:overpayment]
+    # Only the recoverable visit row is in the breakdowns now.
+    assert_equal 1, summary[:recoverable][:by_payment_system].size
+    pfs_row = summary[:recoverable][:by_payment_system].find { |r| r[:payment_system] == "pfs" }
+    assert_equal 1, pfs_row[:obligations]
+    assert_equal Money.from_amount(80, "USD"), pfs_row[:overpayment]
 
-    assert_equal 2, summary[:by_vendor].size
-    assert_equal 2, summary[:by_year].size
+    assert_equal 1, summary[:recoverable][:by_vendor].size
+    assert_equal 1, summary[:recoverable][:by_year].size
   end
 
-  test "summary filters by fiscal_year" do
+  test "summary filters by fiscal_year — 2009 has only the stub hip obligation, no recoverable" do
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT, year: 2009)
     assert_equal 1, summary[:obligations_analyzed]
-    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
-    assert_nil usd[:total_overpayment_known], "no clear-confidence rows in 2009"
-    assert_equal Money.from_amount(24_000, "USD"), usd[:total_overpayment_stub_estimate]
+    assert_equal 0, summary[:recoverable][:count]
+    assert_equal 1, summary[:exceptions][:count]
   end
 
-  test "summary filters by recovery_confidence" do
+  test "summary filters by recovery_confidence — clear surfaces the recoverable visit" do
     summary = Corvid::PrcOverpaymentReportService.summary(
       tenant: TENANT, recovery_confidence: "clear"
     )
     assert_equal 1, summary[:obligations_analyzed]
-    usd = summary[:by_currency].find { |b| b[:currency] == "USD" }
+    assert_equal 1, summary[:recoverable][:count]
+    usd = summary[:recoverable][:by_currency].find { |b| b[:currency] == "USD" }
     assert_equal Money.from_amount(80, "USD"), usd[:total_overpayment_known]
   end
 
@@ -153,10 +162,12 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     assert_includes table.headers, "payment_system"
     assert_includes table.headers, "total_overpayment_known"
     assert_includes table.headers, "total_overpayment_stub_estimate"
-    assert_equal 2, table.size
+    # Default summary CSV only carries recoverable rows. The stub
+    # hip obligation goes to the exceptions report.
+    assert_equal 1, table.size
   end
 
-  test "to_csv_detail emits one row per obligation with provenance columns" do
+  test "to_csv_detail emits only recoverable rows by default" do
     csv = Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: TENANT)
     table = CSV.parse(csv, headers: true)
 
@@ -164,10 +175,19 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
        analyzer_version rate_source rate_source_release source_file].each do |col|
       assert_includes table.headers, col
     end
-    assert_equal 2, table.size
-    hip_row = table.find { |r| r["obligation_id"] == "OBL-A" }
-    assert_equal "ipps", hip_row["payment_system"]
-    assert_equal "fy09.prc", hip_row["source_file"]
+    assert_equal 1, table.size,
+                 "default CSV detail excludes stub-derived rows; only the recoverable visit appears"
+    visit_row = table.find { |r| r["obligation_id"] == "OBL-B" }
+    assert_equal "pfs", visit_row["payment_system"]
+    assert_equal "clear", visit_row["recovery_confidence"]
+    assert_equal "real", visit_row["rate_source"]
+  end
+
+  test "to_csv_detail with include_legacy_stub: true emits the stub row too" do
+    csv = Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: TENANT, include_legacy_stub: true)
+    table = CSV.parse(csv, headers: true)
+    assert_equal 2, table.size,
+                 "forensic export surfaces every analyzed obligation"
   end
 
   test "CSV output respects filters" do
@@ -279,7 +299,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       end
     end
 
-    usd_bucket = parsed["summary"]["by_currency"].find { |b| b["currency"] == "USD" }
+    usd_bucket = parsed["summary"]["recoverable"]["by_currency"].find { |b| b["currency"] == "USD" }
     refute_nil usd_bucket
     %w[total_billed total_paid total_medicare_equivalent
        total_overpayment_known total_overpayment_stub_estimate].each do |col|
@@ -307,6 +327,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
         prc_obligation: ob,
         analyzer_version: "phase_1.5",
         recovery_confidence: "clear",
+        rate_source: "real",
         currency_iso: "JOD",
         medicare_equivalent_cents: 80_000,
         overpayment_cents: 20_000,
@@ -358,7 +379,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       Corvid::PrcOverpaymentAnalysis.create!(
         prc_obligation: eur_ob,
         analyzer_version: "phase_1.5",
-        recovery_confidence: "clear",
+        recovery_confidence: "clear", rate_source: "real",
         currency_iso: "EUR",
         medicare_equivalent_cents: 30_000,
         overpayment_cents: 20_000,
@@ -377,7 +398,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
       Corvid::PrcOverpaymentAnalysis.create!(
         prc_obligation: usd_ob,
         analyzer_version: "phase_1.5",
-        recovery_confidence: "clear",
+        recovery_confidence: "clear", rate_source: "real",
         currency_iso: "USD",
         medicare_equivalent_cents: 50_00,
         overpayment_cents: 50_00,
@@ -387,11 +408,11 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
 
     summary = Corvid::PrcOverpaymentReportService.summary(tenant: tenant)
     assert_equal 2, summary[:obligations_analyzed]
-    assert_equal 2, summary[:by_currency].size, "two currency buckets, no merger"
+    assert_equal 2, summary[:recoverable][:by_currency].size, "two currency buckets, no merger"
     assert_equal Money.from_amount(500, "EUR"),
-                 summary[:by_currency].find { |b| b[:currency] == "EUR" }[:total_billed]
+                 summary[:recoverable][:by_currency].find { |b| b[:currency] == "EUR" }[:total_billed]
     assert_equal Money.from_amount(100, "USD"),
-                 summary[:by_currency].find { |b| b[:currency] == "USD" }[:total_billed]
+                 summary[:recoverable][:by_currency].find { |b| b[:currency] == "USD" }[:total_billed]
   end
 
   test "mixed-currency CSV summary emits one row per (year, vendor, system, currency)" do
@@ -410,7 +431,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
         Corvid::PrcOverpaymentAnalysis.create!(
           prc_obligation: ob,
           analyzer_version: "phase_1.5",
-          recovery_confidence: "clear",
+          recovery_confidence: "clear", rate_source: "real",
           payment_system: "pfs",
           currency_iso: iso,
           overpayment_cents: 100,

--- a/test/services/corvid/recoverable_rule_invariants_test.rb
+++ b/test/services/corvid/recoverable_rule_invariants_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "csv"
+require "json"
 
 # Council-facing contract tests. These assert the "recoverable" rule
 # can't be silently weakened — every test here protects against a
@@ -134,7 +135,86 @@ class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
     refute_includes table.headers, "total_overpayment_known"
   end
 
-  # -- Invariant 7: PrcOverpaymentAnalysis#recoverable? matches the rule --
+  # -- Invariant 7: JSON detail defaults to recoverable-only --
+
+  test "to_json_export default detail excludes stub rows" do
+    json = Corvid::PrcOverpaymentReportService.to_json_export(tenant: TENANT)
+    parsed = JSON.parse(json)
+    ids = parsed["detail"].map { |r| r["obligation_id"] }
+    assert_equal [ "OBL-REAL" ], ids,
+                 "JSON detail must mirror CSV detail — naive integrators must not " \
+                 "be able to surface stub-derived dollars by walking the body"
+  end
+
+  test "to_json_export with include_legacy_stub: true emits all rows" do
+    json = Corvid::PrcOverpaymentReportService.to_json_export(
+      tenant: TENANT, include_legacy_stub: true
+    )
+    parsed = JSON.parse(json)
+    assert parsed["detail"].size >= 3,
+           "forensic JSON export carries every analyzed row"
+  end
+
+  # -- Invariant 8: summary CSV count matches recoverable dollars even in forensic mode --
+
+  test "to_csv_summary obligations_count equals recoverable-only count in forensic mode" do
+    # Add a stub-only obligation with a distinct vendor so it forms its
+    # own grouping row and we can assert the count semantics directly.
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ob = make_obligation("OBL-STUB-ONLY", year: 2026)
+      ob.update!(vendor_id: "VEND-STUB-ONLY")
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "stub_v1",
+        payment_system: "ipps", rate_source: "stub",
+        recovery_confidence: "stub_estimate",
+        currency_iso: "USD",
+        overpayment_cents: 700_000_00,
+        analyzed_at: Time.current
+      )
+    end
+
+    csv = Corvid::PrcOverpaymentReportService.to_csv_summary(
+      tenant: TENANT, include_legacy_stub: true
+    )
+    table = CSV.parse(csv, headers: true)
+    stub_only_row = table.find { |r| r["vendor_id"] == "VEND-STUB-ONLY" }
+    refute_nil stub_only_row, "forensic mode must emit a row for the stub-only group"
+    assert_equal 0, stub_only_row["obligations_count"].to_i,
+                 "stub-only group has zero recoverable rows; count must reflect that " \
+                 "so a spreadsheet reader can't divide stub-inclusive counts by " \
+                 "recoverable-only dollar totals"
+  end
+
+  # -- Invariant 9: clear_non_real_source reason is explicit, not "unknown_clear" --
+
+  test "to_csv_exceptions labels clear + non-real source as clear_non_real_source" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ob = make_obligation("OBL-CLEAR-NONREAL", year: 2026)
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "cms_fy2026_final_rule",
+        payment_system: "ipps", rate_source: "fictional_label",
+        recovery_confidence: "clear",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 1_000_000,
+        overpayment_cents: 500_000,
+        analyzed_at: Time.current
+      )
+    end
+
+    csv = Corvid::PrcOverpaymentReportService.to_csv_exceptions(tenant: TENANT)
+    table = CSV.parse(csv, headers: true)
+    nonreal_row = table.find { |r| r["obligation_id"] == "OBL-CLEAR-NONREAL" }
+    refute_nil nonreal_row, "clear+non-real row must appear in exceptions, not recoverable"
+    assert_equal "clear_non_real_source", nonreal_row["reason"],
+                 "ops triage needs an explicit label here — 'unknown_clear' would " \
+                 "look like a data bug rather than a whitelist gap"
+  end
+
+  # -- Invariant 10: PrcOverpaymentAnalysis#recoverable? matches the rule --
 
   test "recoverable? predicate matches Corvid::RecoverableRule" do
     Corvid::TenantContext.with_tenant(TENANT) do

--- a/test/services/corvid/recoverable_rule_invariants_test.rb
+++ b/test/services/corvid/recoverable_rule_invariants_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "csv"
+
+# Council-facing contract tests. These assert the "recoverable" rule
+# can't be silently weakened — every test here protects against a
+# class of bug that would put stub-derived numbers in front of an
+# auditor or tribal council.
+class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
+  TENANT = "tnt_recov_inv"
+
+  setup do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      # Recoverable row: real CMS data, clear confidence.
+      recoverable_ob = make_obligation("OBL-REAL", year: 2026)
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: recoverable_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "cms_fy2026_final_rule",
+        payment_system: "ipps", rate_source: "real",
+        recovery_confidence: "clear",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 1_000_000, # $10,000
+        overpayment_cents: 500_000, # $5,000
+        analyzed_at: Time.current
+      )
+
+      # Stub-derived row: directional dollars but never recoverable.
+      stub_ob = make_obligation("OBL-STUB", year: 2026)
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: stub_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "stub_v1",
+        payment_system: "ipps", rate_source: "stub",
+        recovery_confidence: "stub_estimate",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 100_000, # $1,000 — must NOT count
+        overpayment_cents: 999_999_99, # $9,999,999 — pathological — must NOT count
+        analyzed_at: Time.current
+      )
+
+      # Unmapped procedure: no rate at all.
+      unmapped_ob = make_obligation("OBL-UNMAPPED", year: 2026)
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: unmapped_ob,
+        analyzer_version: "phase_1.5",
+        payment_system: nil, rate_source: nil,
+        recovery_confidence: "unmapped_procedure",
+        currency_iso: "USD",
+        analyzed_at: Time.current
+      )
+    end
+  end
+
+  # -- Invariant 1: no :clear result can have rate_source :stub --
+
+  test "no PrcOverpaymentAnalysis row may have recovery_confidence=clear AND rate_source=stub" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      bad_row = Corvid::PrcOverpaymentAnalysis.where(
+        recovery_confidence: "clear", rate_source: "stub"
+      )
+      assert_empty bad_row,
+                   "a :clear / :stub row would let stub-derived data slip through " \
+                   "every council-facing export — Corvid::RecoverableRule gates on " \
+                   "(confidence==clear AND source==real), and stub-source rows must " \
+                   "stay in the exceptions backlog"
+    end
+  end
+
+  # -- Invariant 2: summary totals match recoverable rows only --
+
+  test "summary totals exclude stub-derived dollars" do
+    summary = Corvid::PrcOverpaymentReportService.summary(tenant: TENANT)
+
+    usd = summary[:recoverable][:by_currency].find { |b| b[:currency] == "USD" }
+    refute_nil usd
+    assert_equal Money.from_amount(5_000, "USD"), usd[:total_overpayment_known],
+                 "only the recoverable row's $5,000 contributes; the stub row's " \
+                 "$9,999,999 must NOT appear in any council-facing total"
+    assert_equal 1, summary[:recoverable][:count]
+
+    assert_equal 2, summary[:exceptions][:count]
+    assert summary[:exceptions][:by_reason].keys.any?,
+           "exceptions roll up by reason (stub_data_loaded, unmapped_procedure, etc.)"
+  end
+
+  # -- Invariant 3: detail CSV excludes non-recoverable rows by default --
+
+  test "to_csv_detail default emits only recoverable rows" do
+    csv = Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: TENANT)
+    table = CSV.parse(csv, headers: true)
+    obligation_ids = table.map { |r| r["obligation_id"] }
+    assert_equal [ "OBL-REAL" ], obligation_ids,
+                 "stub and unmapped obligations belong in the exceptions report, " \
+                 "not the council-facing detail CSV"
+  end
+
+  # -- Invariant 4: summary CSV's stub_estimate column is zero by default --
+
+  test "to_csv_summary default has zero stub_estimate dollars" do
+    csv = Corvid::PrcOverpaymentReportService.to_csv_summary(tenant: TENANT)
+    table = CSV.parse(csv, headers: true)
+    table.each do |row|
+      assert_equal "0.00", row["total_overpayment_stub_estimate"],
+                   "default CSV must never carry stub dollars; got #{row.inspect}"
+    end
+  end
+
+  # -- Invariant 5: forensic flag exposes the legacy stub column --
+
+  test "include_legacy_stub: true CSV detail includes non-recoverable rows" do
+    csv = Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: TENANT, include_legacy_stub: true)
+    table = CSV.parse(csv, headers: true)
+    assert table.size >= 3,
+           "include_legacy_stub: true is the forensic export — all analyzed rows"
+  end
+
+  # -- Invariant 6: exceptions CSV enumerates non-recoverable rows by reason --
+
+  test "to_csv_exceptions enumerates the backlog without dollars" do
+    csv = Corvid::PrcOverpaymentReportService.to_csv_exceptions(tenant: TENANT)
+    table = CSV.parse(csv, headers: true)
+
+    obligation_ids = table.map { |r| r["obligation_id"] }.sort
+    assert_equal [ "OBL-STUB", "OBL-UNMAPPED" ], obligation_ids
+
+    reasons = table.map { |r| r["reason"] }.sort
+    assert_includes reasons, "stub_data_loaded"
+    assert_includes reasons, "unmapped_procedure"
+
+    refute_includes table.headers, "total_overpayment",
+                    "exceptions are work items, not money"
+    refute_includes table.headers, "total_overpayment_known"
+  end
+
+  # -- Invariant 7: PrcOverpaymentAnalysis#recoverable? matches the rule --
+
+  test "recoverable? predicate matches Corvid::RecoverableRule" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      real_row = Corvid::PrcOverpaymentAnalysis.find_by(rate_source: "real")
+      assert real_row.recoverable?
+      assert Corvid::RecoverableRule.recoverable?(real_row)
+
+      stub_row = Corvid::PrcOverpaymentAnalysis.find_by(rate_source: "stub")
+      refute stub_row.recoverable?
+      refute Corvid::RecoverableRule.recoverable?(stub_row)
+    end
+  end
+
+  private
+
+  def make_obligation(id, year:)
+    Corvid::PrcObligation.create!(
+      facility_identifier: "SEA",
+      obligation_id: id,
+      billed_amount_cents: 2_000_000,
+      paid_amount_cents: 1_500_000,
+      currency_iso: "USD",
+      fiscal_year: year,
+      imported_at: Time.current
+    )
+  end
+end

--- a/test/services/corvid/recoverable_rule_invariants_test.rb
+++ b/test/services/corvid/recoverable_rule_invariants_test.rb
@@ -37,7 +37,7 @@ class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
         recovery_confidence: "stub_estimate",
         currency_iso: "USD",
         medicare_equivalent_cents: 100_000, # $1,000 — must NOT count
-        overpayment_cents: 999_999_99, # $9,999,999 — pathological — must NOT count
+        overpayment_cents: 999_999_900, # $9,999,999 — pathological — must NOT count
         analyzed_at: Time.current
       )
 
@@ -225,6 +225,22 @@ class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
       stub_row = Corvid::PrcOverpaymentAnalysis.find_by(rate_source: "stub")
       refute stub_row.recoverable?
       refute Corvid::RecoverableRule.recoverable?(stub_row)
+    end
+  end
+
+  # -- Invariant 11: model scope agrees with predicate over the rate_source set --
+
+  test "PrcOverpaymentAnalysis.recoverable scope reads the same set as the predicate" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      scope_ids = Corvid::PrcOverpaymentAnalysis.recoverable.pluck(:id).sort
+      predicate_ids = Corvid::PrcOverpaymentAnalysis
+                        .all
+                        .select { |a| Corvid::RecoverableRule.recoverable?(a) }
+                        .map(&:id).sort
+      assert_equal predicate_ids, scope_ids,
+                   "model scope and rule predicate must read the same source set " \
+                   "so model-level filtering can't diverge if a second \"real\" " \
+                   "label is added to RECOVERABLE_RATE_SOURCES"
     end
   end
 


### PR DESCRIPTION
## Summary

\`PrcOverpaymentReportService\` now returns separate \`recoverable\` and \`exceptions\` blocks. Money totals roll up only over rows that pass \`Corvid::RecoverableRule\` (\`recovery_confidence == "clear" && rate_source == "real"\`). Non-recoverable rows enumerate by reason without dollar totals.

## API changes

\`\`\`ruby
summary = Corvid::PrcOverpaymentReportService.summary(tenant: ...)
# {
#   obligations_analyzed: N,
#   recoverable: { count, by_currency, by_payment_system, by_vendor, by_year },
#   exceptions: { count, by_reason }  # counts only, no money
# }

# Default exports: recoverable rows only
Corvid::PrcOverpaymentReportService.to_csv_summary(tenant: ...)
Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: ...)
Corvid::PrcOverpaymentReportService.to_json_export(tenant: ...)

# Forensic export with non-recoverable rows
Corvid::PrcOverpaymentReportService.to_csv_detail(tenant: ..., include_legacy_stub: true)

# Operations backlog — every non-recoverable obligation + reason, no money
Corvid::PrcOverpaymentReportService.to_csv_exceptions(tenant: ...)
\`\`\`

## Reasons enumerated under exceptions.by_reason

- \`stub_data_loaded\` — DB row exists but \`release_label\` starts with \`stub\`
- \`stub_fallback\` — analyzer fell back to in-code stub provider
- \`unmapped_procedure\` — PrcProcedureDictionary doesn't know the procedure
- \`unmapped_facility\` — PrcFacilityDictionary doesn't know the facility code
- \`no_rate_for_year\` — no PFS row for the (CPT, locality, service date)

## Invariant tests

\`test/services/corvid/recoverable_rule_invariants_test.rb\` — 7 assertions, including the DB-level "no row with confidence=clear AND source=stub" check.

## Test plan

- [x] 803 minitest assertions / 0 failures, 375 cucumber / 0 failures.
- [x] Existing report-service tests navigate the new summary shape.

## Follow-ups (separate PRs)

- Audit-packet export + demand-letter \`refuse_if_not_recoverable!\` guard.
- Rename / remove the legacy \`total_overpayment_stub_estimate\` column.