### PR TITLE
Gate DemandLetterGenerator on RecoverableRule

### DIFF
--- a/app/services/corvid/overpayment_recovery/demand_letter_generator.rb
+++ b/app/services/corvid/overpayment_recovery/demand_letter_generator.rb
@@ -13,6 +13,77 @@ module Corvid
       TRIBAL_DEADLINE_DAYS = 60
       RURAL_DEADLINE_DAYS = 30
 
+      # Raised when generate_from_analyses receives any row that fails
+      # Corvid::RecoverableRule. A Section-506 demand cites the FCA, so
+      # stub-derived dollars must never reach this path — refuse the
+      # whole batch loudly rather than letting one bad row slip through.
+      class NotRecoverableError < StandardError
+        attr_reader :offending
+
+        def initialize(offending)
+          @offending = offending
+          super(build_message(offending))
+        end
+
+        private
+
+        def build_message(offending)
+          lines = offending.map do |a|
+            "  #{a.prc_obligation.obligation_id} " \
+              "recovery_confidence=#{a.recovery_confidence} " \
+              "rate_source=#{a.rate_source.inspect}"
+          end
+          "DemandLetterGenerator refuses #{offending.size} non-recoverable " \
+            "row(s). Stub-derived or unmapped rows belong in the exceptions " \
+            "queue, not a Section 506 / FCA-citing demand letter:\n" + lines.join("\n")
+        end
+      end
+
+      # Build a demand letter from PrcOverpaymentAnalysis rows. Every
+      # input must pass Corvid::RecoverableRule; otherwise raises
+      # NotRecoverableError naming only the offending obligations.
+      # Use this entry point whenever the source of truth is an
+      # analysis row (the report layer, recovery case workflow). The
+      # raw-claims `.generate` entry point stays available for callers
+      # that have already flattened to claim hashes — but those callers
+      # are responsible for their own filtering.
+      def self.generate_from_analyses(
+        provider_name:, provider_npi: nil,
+        analyses:,
+        customer_type: :tribal,
+        medicare_participating: true,
+        authorization_reference: nil,
+        referral_authorization_terms: nil,
+        sent_on: Date.current
+      )
+        raise ArgumentError, "analyses must be non-empty" if analyses.nil? || analyses.empty?
+
+        offending = analyses.reject { |a| Corvid::RecoverableRule.recoverable?(a) }
+        raise NotRecoverableError, offending if offending.any?
+
+        claims = analyses.map { |a| claim_from_analysis(a) }
+        generate(
+          provider_name: provider_name, provider_npi: provider_npi,
+          claims: claims,
+          customer_type: customer_type,
+          medicare_participating: medicare_participating,
+          authorization_reference: authorization_reference,
+          referral_authorization_terms: referral_authorization_terms,
+          sent_on: sent_on
+        )
+      end
+
+      def self.claim_from_analysis(analysis)
+        obligation = analysis.prc_obligation
+        {
+          cpt_code: obligation.procedure_code,
+          date_of_service: obligation.service_date,
+          paid_amount: obligation.paid_amount,
+          medicare_rate: analysis.medicare_equivalent,
+          overpayment: analysis.overpayment
+        }
+      end
+
       def self.generate(
         provider_name:, provider_npi: nil,
         claims:, # Array<Hash> with cpt_code, date_of_service, paid_amount, medicare_rate, overpayment

--- a/test/services/corvid/overpayment_recovery/demand_letter_recoverable_guard_test.rb
+++ b/test/services/corvid/overpayment_recovery/demand_letter_recoverable_guard_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A Section-506 demand letter cites the False Claims Act and threatens
+# treble damages, so a stub-derived dollar that slips into this path is
+# the highest-stakes failure mode in the system. These tests pin the
+# guard: DemandLetterGenerator.generate_from_analyses must refuse the
+# whole batch if any input fails Corvid::RecoverableRule.
+class Corvid::OverpaymentRecovery::DemandLetterRecoverableGuardTest < ActiveSupport::TestCase
+  TENANT = "tnt_demand_guard"
+
+  setup do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      @recoverable_ob = make_obligation("OBL-REAL-1", procedure_code: "99213")
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: @recoverable_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "cms_fy2026_final_rule",
+        payment_system: "pfs", rate_source: "real",
+        recovery_confidence: "clear",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 5_000_00,
+        overpayment_cents: 2_500_00,
+        analyzed_at: Time.current
+      )
+
+      @stub_ob = make_obligation("OBL-STUB-1", procedure_code: "99214")
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: @stub_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "stub_v1",
+        payment_system: "ipps", rate_source: "stub",
+        recovery_confidence: "stub_estimate",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 100_00,
+        overpayment_cents: 1_000_000_00,
+        analyzed_at: Time.current
+      )
+    end
+  end
+
+  test "generate_from_analyses builds a Section 506 letter from recoverable rows" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      letter = Corvid::OverpaymentRecovery::DemandLetterGenerator.generate_from_analyses(
+        provider_name: "Real Provider",
+        provider_npi: "1234567890",
+        analyses: [ recoverable_analysis ]
+      )
+      assert letter.cites_section_506
+      assert letter.cites_fca
+      assert_equal 1, letter.claims.size
+      assert_in_delta 2_500.00, letter.total_demanded.to_f, 0.01
+      assert letter.body.include?("99213"), "claim CPT must appear in body"
+    end
+  end
+
+  test "generate_from_analyses refuses the batch if ANY row is non-recoverable" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      err = assert_raises(Corvid::OverpaymentRecovery::DemandLetterGenerator::NotRecoverableError) do
+        Corvid::OverpaymentRecovery::DemandLetterGenerator.generate_from_analyses(
+          provider_name: "Mixed Provider",
+          analyses: [ recoverable_analysis, stub_analysis ]
+        )
+      end
+      msg = err.message
+      assert_includes msg, "OBL-STUB-1",
+                      "error must name the offending obligation so ops can find it fast"
+      refute_includes msg, "OBL-REAL-1",
+                      "error must list only the rows that failed the rule, not the whole batch"
+    end
+  end
+
+  test "generate_from_analyses refuses an all-stub batch with rule-specific reason" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      err = assert_raises(Corvid::OverpaymentRecovery::DemandLetterGenerator::NotRecoverableError) do
+        Corvid::OverpaymentRecovery::DemandLetterGenerator.generate_from_analyses(
+          provider_name: "Stub Provider",
+          analyses: [ stub_analysis ]
+        )
+      end
+      # Error carries the recovery_confidence + rate_source so ops triage
+      # knows whether to ingest real rate data or update the dictionary.
+      assert_match(/recovery_confidence=stub_estimate/, err.message)
+      assert_match(/rate_source="?stub/, err.message)
+    end
+  end
+
+  test "generate_from_analyses raises if the analyses array is empty" do
+    assert_raises(ArgumentError) do
+      Corvid::OverpaymentRecovery::DemandLetterGenerator.generate_from_analyses(
+        provider_name: "Nobody", analyses: []
+      )
+    end
+  end
+
+  private
+
+  def recoverable_analysis
+    Corvid::PrcOverpaymentAnalysis.find_by!(prc_obligation: @recoverable_ob)
+  end
+
+  def stub_analysis
+    Corvid::PrcOverpaymentAnalysis.find_by!(prc_obligation: @stub_ob)
+  end
+
+  def make_obligation(id, procedure_code:)
+    Corvid::PrcObligation.create!(
+      facility_identifier: "SEA",
+      obligation_id: id,
+      procedure_code: procedure_code,
+      billed_amount_cents: 1_000_00,
+      paid_amount_cents: 7_500_00,
+      currency_iso: "USD",
+      fiscal_year: 2026,
+      service_date: Date.new(2026, 3, 1),
+      imported_at: Time.current
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- `DemandLetterGenerator.generate_from_analyses(analyses:, ...)` accepts `PrcOverpaymentAnalysis` rows and refuses the whole batch with `NotRecoverableError` if any input fails `Corvid::RecoverableRule`.
- Error names only the offending obligations and includes `recovery_confidence` + `rate_source` for ops triage.
- Raw-claims `.generate(claims:)` entry point unchanged; callers that already flatten to claim hashes are responsible for their own filtering.

A Section 506 demand letter cites the FCA and threatens treble damages — a stub-derived row reaching this path is the highest-stakes failure mode in the recovery pipeline. Refuse loudly rather than letting one bad row through.

## Test plan
- [x] Recoverable batch → letter generated with FCA + Section 506 citation
- [x] Mixed batch → NotRecoverableError naming only the stub row (not the recoverable one)
- [x] All-stub batch → error carries recovery_confidence + rate_source for triage
- [x] Empty analyses → ArgumentError
- [x] Full suite (812 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)