### PR TITLE
Add to_audit_packet: council-facing bundle with provenance manifest

### DIFF
--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -162,6 +162,31 @@ module Corvid
         end
       end
 
+      # Audit packet: the council-facing / IHS-auditor bundle. Returns a
+      # Hash<String, String> mapping filename to content so the caller
+      # owns zipping / signing / shipping. Composes the existing CSV
+      # outputs plus a methodology.json manifest that pins, at the time
+      # of the export, the analyzer versions and CMS rate-source releases
+      # that contributed dollars, plus the recoverable-rule constants
+      # themselves. An auditor reading the packet in 2030 can answer
+      # "what was the rule at the time of this packet?" without having
+      # to dig into the engine's git history.
+      def to_audit_packet(tenant:, **filters)
+        rows = detail(tenant: tenant, **filters)
+        recoverable_rows = rows.select { |r| Corvid::RecoverableRule.recoverable?(r) }
+        exception_rows = rows - recoverable_rows
+
+        {
+          "summary.csv" => to_csv_summary(tenant: tenant, **filters),
+          "detail.csv" => to_csv_detail(tenant: tenant, **filters),
+          "exceptions.csv" => to_csv_exceptions(tenant: tenant, **filters),
+          "methodology.json" => methodology_manifest(
+            tenant: tenant, filters: filters,
+            recoverable_rows: recoverable_rows, exception_rows: exception_rows
+          )
+        }
+      end
+
       # JSON export defaults to recoverable-only detail so naive integrators
       # can't surface stub-derived dollars by walking the body. Summary
       # always carries the two-bucket structure (recoverable + exceptions).
@@ -180,6 +205,34 @@ module Corvid
       end
 
       private
+
+      # Provenance manifest for the audit packet. Lists every analyzer
+      # version that contributed a row (so a single packet that mixes
+      # phase_1.5 + phase_2 rows is self-documenting) and every
+      # rate_source_release used in the recoverable bucket (the dollars
+      # the auditor will actually try to verify). Also pins the rule
+      # constants so the packet is interpretable years later even if the
+      # engine widens its source set.
+      def methodology_manifest(tenant:, filters:, recoverable_rows:, exception_rows:)
+        analyzer_versions = (recoverable_rows + exception_rows).map { |r| r[:analyzer_version] }.compact.uniq.sort
+        rate_releases = recoverable_rows.map { |r| r[:rate_source_release] }.compact.uniq.sort
+
+        JSON.pretty_generate(
+          tenant: tenant,
+          generated_at: Time.current.iso8601,
+          filters: filters.compact,
+          analyzer_versions: analyzer_versions,
+          rate_source_releases: rate_releases,
+          rule: {
+            recoverable_confidence: Corvid::RecoverableRule::RECOVERABLE_CONFIDENCE,
+            recoverable_rate_sources: Corvid::RecoverableRule::RECOVERABLE_RATE_SOURCES.to_a
+          },
+          counts: {
+            recoverable: recoverable_rows.size,
+            exceptions: exception_rows.size
+          }
+        )
+      end
 
       # Latest-analysis-per-obligation expressed as a Postgres DISTINCT ON
       # subquery. Embedding it in `WHERE id IN (...)` keeps the whole

--- a/test/services/corvid/audit_packet_test.rb
+++ b/test/services/corvid/audit_packet_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "csv"
+require "json"
+
+# An audit packet is the council-facing / IHS-auditor-facing bundle that
+# ties together every report-layer artifact (summary, recoverable detail,
+# exceptions, methodology) with shared provenance. Same recoverable-rule
+# gate as the demand letter — stub-derived dollars never appear in the
+# recoverable-detail or summary, only in the exceptions queue.
+class Corvid::AuditPacketTest < ActiveSupport::TestCase
+  TENANT = "tnt_audit_packet"
+
+  setup do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      recoverable_ob = Corvid::PrcObligation.create!(
+        facility_identifier: "SEA",
+        obligation_id: "OBL-AP-REAL",
+        billed_amount_cents: 2_000_00,
+        paid_amount_cents: 1_500_00,
+        currency_iso: "USD",
+        fiscal_year: 2026,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: recoverable_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "cms_fy2026_final_rule",
+        payment_system: "ipps", rate_source: "real",
+        recovery_confidence: "clear",
+        currency_iso: "USD",
+        medicare_equivalent_cents: 1_000_00,
+        overpayment_cents: 500_00,
+        analyzed_at: Time.current
+      )
+
+      stub_ob = Corvid::PrcObligation.create!(
+        facility_identifier: "SEA",
+        obligation_id: "OBL-AP-STUB",
+        billed_amount_cents: 2_000_00,
+        paid_amount_cents: 1_500_00,
+        currency_iso: "USD",
+        fiscal_year: 2026,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: stub_ob,
+        analyzer_version: "phase_1.5",
+        rate_source_release: "stub_v1",
+        payment_system: "ipps", rate_source: "stub",
+        recovery_confidence: "stub_estimate",
+        currency_iso: "USD",
+        overpayment_cents: 999_999_900,
+        analyzed_at: Time.current
+      )
+    end
+  end
+
+  test "to_audit_packet returns the four expected entries" do
+    packet = Corvid::PrcOverpaymentReportService.to_audit_packet(tenant: TENANT)
+    assert_equal %w[summary.csv detail.csv exceptions.csv methodology.json].sort,
+                 packet.keys.sort
+    packet.each_value { |content| refute_nil content; refute content.empty? }
+  end
+
+  test "detail.csv carries only recoverable rows; stub stays out" do
+    packet = Corvid::PrcOverpaymentReportService.to_audit_packet(tenant: TENANT)
+    table = CSV.parse(packet["detail.csv"], headers: true)
+    obligation_ids = table.map { |r| r["obligation_id"] }
+    assert_equal [ "OBL-AP-REAL" ], obligation_ids,
+                 "audit packet detail must mirror the council-facing CSV — no stub rows"
+  end
+
+  test "exceptions.csv enumerates non-recoverable rows" do
+    packet = Corvid::PrcOverpaymentReportService.to_audit_packet(tenant: TENANT)
+    table = CSV.parse(packet["exceptions.csv"], headers: true)
+    obligation_ids = table.map { |r| r["obligation_id"] }
+    assert_includes obligation_ids, "OBL-AP-STUB"
+  end
+
+  test "methodology.json carries provenance: analyzer versions, rate-source releases, rule" do
+    packet = Corvid::PrcOverpaymentReportService.to_audit_packet(tenant: TENANT)
+    meta = JSON.parse(packet["methodology.json"])
+
+    assert_equal TENANT, meta["tenant"]
+    refute_nil meta["generated_at"]
+    assert_includes meta["analyzer_versions"], "phase_1.5",
+                    "must list every analyzer version that contributed to this packet"
+    assert_includes meta["rate_source_releases"], "cms_fy2026_final_rule",
+                    "must list every CMS release used in the recoverable bucket"
+    # The rule constants travel with the packet so an auditor reading it
+    # in 2030 can answer 'what was the rule at the time of this packet?'
+    assert_equal "clear", meta["rule"]["recoverable_confidence"]
+    assert_includes meta["rule"]["recoverable_rate_sources"], "real"
+    # Recoverable/exceptions counts come along so the manifest is
+    # self-contained (no cross-reference to detail.csv required).
+    assert_equal 1, meta["counts"]["recoverable"]
+    assert_equal 1, meta["counts"]["exceptions"]
+  end
+
+  test "methodology.json filters reflect the call arguments" do
+    packet = Corvid::PrcOverpaymentReportService.to_audit_packet(
+      tenant: TENANT, fiscal_year: 2026
+    )
+    meta = JSON.parse(packet["methodology.json"])
+    assert_equal({ "fiscal_year" => 2026 }, meta["filters"])
+  end
+end


### PR DESCRIPTION
## Summary
- `PrcOverpaymentReportService.to_audit_packet(tenant:, **filters)` returns a `Hash<String, String>` mapping filename → content: `summary.csv`, `detail.csv`, `exceptions.csv`, `methodology.json`.
- `methodology.json` pins the rule at export time: analyzer versions used, CMS rate-source releases that contributed dollars, `RECOVERABLE_CONFIDENCE` + `RECOVERABLE_RATE_SOURCES` constants, and recoverable/exceptions counts.
- Same recoverable-rule gate as the rest of the report layer — `detail.csv` is recoverable-only, stub rows stay in `exceptions.csv`. Caller owns zipping/signing/shipping.

## Test plan
- [x] All four entries present and non-empty.
- [x] `detail.csv` contains only the recoverable row; stub row excluded.
- [x] `exceptions.csv` contains the stub row.
- [x] `methodology.json` lists analyzer_versions, rate_source_releases, rule constants, and recoverable/exceptions counts.
- [x] Filters round-trip into the manifest.
- [x] Full suite (818) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)