### PR TITLE
Rename CSV column: stub_estimate → excluded_stub

### DIFF
--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -28,7 +28,7 @@ module Corvid
       fiscal_year vendor_id payment_system currency
       obligations_count
       total_billed total_paid total_medicare_equivalent
-      total_overpayment_known total_overpayment_stub_estimate
+      total_overpayment_known total_overpayment_excluded_stub
     ].freeze
 
     DETAIL_CSV_HEADERS = %w[
@@ -42,7 +42,7 @@ module Corvid
     MONEY_KEYS = %i[
       billed_amount paid_amount medicare_equivalent overpayment
       total_billed total_paid total_medicare_equivalent
-      total_overpayment_known total_overpayment_stub_estimate
+      total_overpayment_known total_overpayment_excluded_stub
       billed paid
     ].freeze
 
@@ -299,10 +299,12 @@ module Corvid
       end
 
       # Recoverable-bucket totals carry the full money roll-up. The
-      # legacy column total_overpayment_stub_estimate (always zero
-      # under the strict rule) is preserved with a documented zero
-      # so legacy CSV consumers don't crash on schema change. New
-      # callers should ignore it and use exceptions.count instead.
+      # column total_overpayment_excluded_stub is the dollars-in-the-
+      # exceptions-bucket figure: zero in the council-facing default
+      # mode (recoverable rows by definition exclude stub) and
+      # populated only by the forensic CSV via include_legacy_stub.
+      # New callers wanting the operational backlog should use
+      # exceptions.count or to_csv_exceptions instead.
       def currency_totals(iso, rows)
         zero = Money.new(0, iso) if iso
         {
@@ -312,7 +314,7 @@ module Corvid
           total_paid: sum_money(rows, :paid_amount),
           total_medicare_equivalent: sum_money(rows, :medicare_equivalent),
           total_overpayment_known: sum_money(rows, :overpayment),
-          total_overpayment_stub_estimate: zero
+          total_overpayment_excluded_stub: zero
         }
       end
 

--- a/features/prc/overpayment_report.feature
+++ b/features/prc/overpayment_report.feature
@@ -12,7 +12,7 @@ Feature: PRC overpayment report
 
   Scenario: Summary CSV shows recoverable-now and directional totals separately
     When I export a summary CSV for "tnt_yakama"
-    Then the CSV includes columns for total_overpayment_known and total_overpayment_stub_estimate
+    Then the CSV includes columns for total_overpayment_known and total_overpayment_excluded_stub
     And there is one row per fiscal_year + vendor_id + payment_system grouping
 
   Scenario: Detail CSV cites analyzer version and rate-source release on every row

--- a/features/step_definitions/overpayment_report_steps.rb
+++ b/features/step_definitions/overpayment_report_steps.rb
@@ -57,9 +57,9 @@ When("I export the report as JSON for {string} filtered to fiscal year {int}") d
   @report_parsed = JSON.parse(@report_json)
 end
 
-Then("the CSV includes columns for total_overpayment_known and total_overpayment_stub_estimate") do
+Then("the CSV includes columns for total_overpayment_known and total_overpayment_excluded_stub") do
   assert_includes @report_table.headers, "total_overpayment_known"
-  assert_includes @report_table.headers, "total_overpayment_stub_estimate"
+  assert_includes @report_table.headers, "total_overpayment_excluded_stub"
 end
 
 Then("there is one row per fiscal_year + vendor_id + payment_system grouping") do

--- a/test/services/corvid/prc_overpayment_report_service_test.rb
+++ b/test/services/corvid/prc_overpayment_report_service_test.rb
@@ -71,8 +71,8 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     assert_equal Money.from_amount(180, "USD"), usd[:total_paid]
     assert_equal Money.from_amount(100, "USD"), usd[:total_medicare_equivalent]
     assert_equal Money.from_amount(80, "USD"), usd[:total_overpayment_known]
-    assert_equal Money.new(0, "USD"), usd[:total_overpayment_stub_estimate],
-                 "legacy column always zero under the strict rule"
+    assert_equal Money.new(0, "USD"), usd[:total_overpayment_excluded_stub],
+                 "excluded_stub column always zero under the strict default rule"
 
     assert summary[:exceptions][:by_reason].keys.any?
   end
@@ -161,7 +161,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     assert_includes table.headers, "vendor_id"
     assert_includes table.headers, "payment_system"
     assert_includes table.headers, "total_overpayment_known"
-    assert_includes table.headers, "total_overpayment_stub_estimate"
+    assert_includes table.headers, "total_overpayment_excluded_stub"
     # Default summary CSV only carries recoverable rows. The stub
     # hip obligation goes to the exceptions report.
     assert_equal 1, table.size
@@ -277,7 +277,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     csv = Corvid::PrcOverpaymentReportService.to_csv_summary(tenant: TENANT)
     table = CSV.parse(csv, headers: true)
     money_cols = %w[total_billed total_paid total_medicare_equivalent
-                    total_overpayment_known total_overpayment_stub_estimate]
+                    total_overpayment_known total_overpayment_excluded_stub]
     table.each do |row|
       money_cols.each do |col|
         refute_match(/E/i, row[col].to_s,
@@ -302,7 +302,7 @@ class Corvid::PrcOverpaymentReportServiceTest < ActiveSupport::TestCase
     usd_bucket = parsed["summary"]["recoverable"]["by_currency"].find { |b| b["currency"] == "USD" }
     refute_nil usd_bucket
     %w[total_billed total_paid total_medicare_equivalent
-       total_overpayment_known total_overpayment_stub_estimate].each do |col|
+       total_overpayment_known total_overpayment_excluded_stub].each do |col|
       next if usd_bucket[col].nil? # not all confidence buckets always populate
       assert_kind_of String, usd_bucket[col]
       refute_match(/E/i, usd_bucket[col])

--- a/test/services/corvid/recoverable_rule_invariants_test.rb
+++ b/test/services/corvid/recoverable_rule_invariants_test.rb
@@ -97,13 +97,13 @@ class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
                  "not the council-facing detail CSV"
   end
 
-  # -- Invariant 4: summary CSV's stub_estimate column is zero by default --
+  # -- Invariant 4: summary CSV's excluded_stub column is zero by default --
 
-  test "to_csv_summary default has zero stub_estimate dollars" do
+  test "to_csv_summary default has zero excluded_stub dollars" do
     csv = Corvid::PrcOverpaymentReportService.to_csv_summary(tenant: TENANT)
     table = CSV.parse(csv, headers: true)
     table.each do |row|
-      assert_equal "0.00", row["total_overpayment_stub_estimate"],
+      assert_equal "0.00", row["total_overpayment_excluded_stub"],
                    "default CSV must never carry stub dollars; got #{row.inspect}"
     end
   end


### PR DESCRIPTION
## Summary
Closes out slice 4 of the recoverable-rule line. Rename the summary CSV column `total_overpayment_stub_estimate` → `total_overpayment_excluded_stub` to match what it actually is: dollars in the *exceptions* bucket, zero in the council-facing default mode and populated only via the forensic `include_legacy_stub` flag.

The old name read as "an estimate of overpayment dollars," which was misleading once the recoverable rule split made the column always-zero by default.

Report-layer scope only. The analyzer's narrower `Summary#total_overpayment_stub_estimate` field is unchanged — it sums specifically over rows with `recovery_confidence == :stub_estimate`, which is a narrower bucket than the report's exceptions roll-up.

## Test plan
- [x] Service test suite (820) green
- [x] Cucumber `overpayment_report.feature` 16/16 green
- [x] All five touch-points renamed: service constants + hash key, two test files, one cucumber step, one feature scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)