### PR TITLE
Fix PrcImporter dedup: last record wins

### DIFF
--- a/app/services/corvid/prc_importer.rb
+++ b/app/services/corvid/prc_importer.rb
@@ -104,7 +104,10 @@ module Corvid
       def upsert_obligations(obligations, tenant:, facility:, source_file:, imported_at:)
         return { inserted: 0, updated: 0 } if obligations.empty?
 
-        unique_obligations = obligations.uniq { |o| o.obligation_id }
+        # Last-record-wins dedup within the file (corrected-row-after-original
+        # is a real PRC export pattern). Array#uniq keeps the FIRST occurrence,
+        # which inverts the contract, so collect by id and keep .last.
+        unique_obligations = obligations.group_by(&:obligation_id).map { |_, group| group.last }
         ids = unique_obligations.map(&:obligation_id)
         existing_ids = Corvid::PrcObligation.where(obligation_id: ids).pluck(:obligation_id).to_set
 
@@ -146,7 +149,8 @@ module Corvid
       # treated as orphans (parser drift / truncated upload signal),
       # dropped, counted, and logged.
       def reconcile_and_upsert_payments(payments, tenant:, oblig_pks_in_file:, source_file:)
-        unique_payments = payments.uniq { |p| p.payment_id }
+        # Last-record-wins dedup (same rationale as obligations above).
+        unique_payments = payments.group_by(&:payment_id).map { |_, group| group.last }
 
         rows = []
         dropped_orphan = 0

--- a/test/services/corvid/prc_importer_test.rb
+++ b/test/services/corvid/prc_importer_test.rb
@@ -161,6 +161,49 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Within-file duplicate IDs: last-wins dedup ----------------------------
+  # Regression: PrcImporter.upsert_obligations used Array#uniq, which
+  # keeps the FIRST occurrence per key. Both the FORMAT_MATRIX.md
+  # contract and the importer's own comment said "last record wins."
+  # If a PRC export emits the same obligation_id twice (e.g., an ETL
+  # appended a corrected row after the original), the corrected row
+  # is what should land.
+
+  test "within-file duplicate obligation_id: last record wins" do
+    with_tenant(TENANT) do
+      dup_export = <<~PRC
+        H^PRC_EXPORT^SEA^20090506^1
+        O^OBL-DUP^DFN1^V1^OFFICE_VISIT_EST^20090504^A^185.00^185.00^0.00^0.00^2009
+        O^OBL-DUP^DFN1^V1^OFFICE_VISIT_EST^20090504^A^200.00^200.00^0.00^0.00^2009
+        T^2^1^0^385.00^0.00
+      PRC
+      Corvid::PrcImporter.import(dup_export, source_file: "dup.prc")
+
+      ob = Corvid::PrcObligation.find_by(obligation_id: "OBL-DUP")
+      assert_equal 200_00, ob.paid_amount_cents,
+                   "the second (corrected) row must win, not the first"
+      assert_equal 200_00, ob.billed_amount_cents
+    end
+  end
+
+  test "within-file duplicate payment_id: last record wins" do
+    with_tenant(TENANT) do
+      dup_export = <<~PRC
+        H^PRC_EXPORT^SEA^20090506^1
+        O^OBL-DUP-P^DFN1^V1^OFFICE_VISIT_EST^20090504^A^200.00^200.00^0.00^0.00^2009
+        P^OBL-DUP-P^PMT-DUP^20090518^CHK_FIRST^185.00^CLINIC
+        P^OBL-DUP-P^PMT-DUP^20090519^CHK_SECOND^200.00^CLINIC
+        T^1^1^2^385.00^0.00
+      PRC
+      Corvid::PrcImporter.import(dup_export, source_file: "dup_p.prc")
+
+      pmt = Corvid::PrcPayment.find_by(payment_id: "PMT-DUP")
+      assert_equal "CHK_SECOND", pmt.check_number,
+                   "the second (corrected) payment row must win, not the first"
+      assert_equal 200_00, pmt.amount_cents
+    end
+  end
+
   # -- Tenant scoping --------------------------------------------------------
 
   test "obligations are tenant-scoped" do


### PR DESCRIPTION
## Why
Smoke-running the new `duplicate_ids_v1.prc` format fixture revealed the importer's dedup-within-file is inverted: a corrected obligation/payment row emitted after the original is silently dropped, and the stale original persists.

The importer's own comment (`prc_importer.rb:100`), `FORMAT_MATRIX.md`, and standard ETL semantics all say *"last record wins"*. The implementation used `Array#uniq { |o| o.obligation_id }`, which keeps the **first** occurrence.

## What
- `obligations.uniq { ... }` → `obligations.group_by(&:obligation_id).map { |_, g| g.last }`
- Same for `payments`.
- Two regression tests pin the contract through `PrcImporter.import` (within-file duplicate obligation_id and within-file duplicate payment_id, each with different values across the two rows).

## Test plan
- [x] Tests fail red on `main` (existing code keeps first occurrence).
- [x] Tests pass green on this branch.
- [x] Full suite (826) green.
- [x] No behavior change for non-duplicate inputs — `group_by(&:key).map { |_, g| g.last }` returns one row per unique key, identical to `uniq` semantics for single-occurrence keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)