### PR TITLE
Add :missing_service_date as a distinct analyzer reason

### DIFF
--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -78,11 +78,14 @@ module Corvid
     )
 
     # Recovery confidence levels.
-    #   :clear                — Medicare equivalent from real CMS data; overpayment is final
-    #   :stub_estimate        — Hospital obligation priced via stub provider; rough but actionable
-    #   :unmapped_procedure   — Procedure description not in PrcProcedureDictionary
-    #   :unmapped_facility    — RPMS facility code not in PrcFacilityDictionary
-    #   :no_rate_for_year     — DB has no PFS row for this CPT/locality on the service date
+    #   :clear                  — Medicare equivalent from real CMS data; overpayment is final
+    #   :stub_estimate          — Hospital obligation priced via stub provider; rough but actionable
+    #   :unmapped_procedure     — Procedure description not in PrcProcedureDictionary
+    #   :unmapped_facility      — RPMS facility code not in PrcFacilityDictionary
+    #   :no_rate_for_year       — DB has no PFS row for this CPT/locality on the service date
+    #   :missing_service_date   — Obligation has no parseable service_date (malformed
+    #                             YYYYMMDD upstream); ops must clean the obligation itself,
+    #                             distinct from a fee-schedule gap.
 
     class << self
       def analyze(report)
@@ -91,6 +94,13 @@ module Corvid
       end
 
       def analyze_obligation(obligation, header)
+        # Short-circuit before procedure/facility lookup: without a
+        # service_date, none of the downstream rate paths can do
+        # anything sensible. Route this to its own ops-triage reason
+        # rather than letting it fall through to :no_rate_for_year,
+        # which would mislead ops into looking for missing rate data.
+        return missing_service_date(obligation) if obligation.service_date.nil?
+
         proc_info = Corvid::PrcProcedureDictionary.lookup(obligation.procedure_code)
         facility = Corvid::PrcFacilityDictionary.lookup(header.facility)
 
@@ -281,6 +291,21 @@ module Corvid
           paid_amount: obligation.paid_amount.to_f,
           recovery_confidence: :unmapped_facility,
           notes: "Facility code not in PrcFacilityDictionary; cannot determine locality."
+        )
+      end
+
+      def missing_service_date(obligation)
+        Result.new(
+          obligation_id: obligation.obligation_id,
+          patient_dfn: obligation.patient_dfn,
+          vendor_id: obligation.vendor_id,
+          procedure_code: obligation.procedure_code,
+          service_date: nil,
+          billed_amount: obligation.billed_amount.to_f,
+          paid_amount: obligation.paid_amount.to_f,
+          recovery_confidence: :missing_service_date,
+          notes: "Obligation has no parseable service_date (upstream date malformed); " \
+                 "cannot select a fee schedule. Clean the obligation row, then re-import."
         )
       end
 

--- a/app/services/corvid/prc_overpayment_report_service.rb
+++ b/app/services/corvid/prc_overpayment_report_service.rb
@@ -328,7 +328,8 @@ module Corvid
           # path (e.g., "stub_v1") and is nil for the fallback path.
           release = row[:rate_source_release].to_s
           release.start_with?("stub") ? "stub_data_loaded" : "stub_fallback"
-        when "unmapped_procedure", "unmapped_facility", "no_rate_for_year"
+        when "unmapped_procedure", "unmapped_facility", "no_rate_for_year",
+             "missing_service_date"
           confidence
         when Corvid::RecoverableRule::RECOVERABLE_CONFIDENCE
           # Clear confidence but a rate_source outside the recoverable set

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -227,6 +227,31 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
                "inventing a label that an auditor could chase"
   end
 
+  # -- Missing service_date: distinct reason, not no_rate_for_year ----------
+
+  # A nil service_date (parser failed on a malformed YYYYMMDD like
+  # 20250230 or BADDATE) is a different operational problem from
+  # "no PFS row exists for this year." Conflating them sends ops
+  # triage hunting for missing fee-schedule data when the obligation
+  # itself is the input that needs cleaning. Distinct reason short-
+  # circuits before procedure/facility lookup.
+
+  test "obligation with nil service_date yields :missing_service_date" do
+    sample = <<~PRC
+      H^PRC_EXPORT^SEA^20090506^1
+      O^OBL-NOSD^DFN1^V1^OFFICE_VISIT_EST^BADDATE^A^200.00^180.00^20.00^0.00^2009
+      T^1^1^0^180.00^0.00
+    PRC
+    report = Corvid::PrcReportParser.parse(sample)
+    summary = Corvid::PrcOverpaymentAnalyzer.analyze(report)
+    result = summary.results.first
+
+    assert_equal :missing_service_date, result.recovery_confidence,
+                 "nil service_date is its own ops-triage reason, not no_rate_for_year"
+    assert_nil result.medicare_equivalent
+    assert_match(/service_date/i, result.notes)
+  end
+
   # -- Unmapped inputs -------------------------------------------------------
 
   test "unmapped procedure code yields :unmapped_procedure" do

--- a/test/services/corvid/recoverable_rule_invariants_test.rb
+++ b/test/services/corvid/recoverable_rule_invariants_test.rb
@@ -187,6 +187,39 @@ class Corvid::RecoverableRuleInvariantsTest < ActiveSupport::TestCase
                  "recoverable-only dollar totals"
   end
 
+  # -- Invariant 8.5: missing_service_date is a distinct exception reason --
+
+  test "to_csv_exceptions labels nil-service-date rows as missing_service_date" do
+    Corvid::TenantContext.with_tenant(TENANT) do
+      ob = Corvid::PrcObligation.create!(
+        facility_identifier: "SEA",
+        obligation_id: "OBL-NO-SD",
+        billed_amount_cents: 2_000_00,
+        paid_amount_cents: 1_500_00,
+        currency_iso: "USD",
+        fiscal_year: 2026,
+        service_date: nil,
+        imported_at: Time.current
+      )
+      Corvid::PrcOverpaymentAnalysis.create!(
+        prc_obligation: ob,
+        analyzer_version: "phase_1.5",
+        payment_system: nil, rate_source: nil,
+        recovery_confidence: "missing_service_date",
+        currency_iso: "USD",
+        analyzed_at: Time.current
+      )
+    end
+
+    csv = Corvid::PrcOverpaymentReportService.to_csv_exceptions(tenant: TENANT)
+    table = CSV.parse(csv, headers: true)
+    row = table.find { |r| r["obligation_id"] == "OBL-NO-SD" }
+    refute_nil row, "nil-service-date row must appear in exceptions"
+    assert_equal "missing_service_date", row["reason"],
+                 "distinct reason so ops triage points at the obligation, " \
+                 "not at fee-schedule coverage"
+  end
+
   # -- Invariant 9: clear_non_real_source reason is explicit, not "unknown_clear" --
 
   test "to_csv_exceptions labels clear + non-real source as clear_non_real_source" do


### PR DESCRIPTION
## Why
Surfaced by `invalid_dates_v1.prc` from the fixture matrix sweep. An obligation with a malformed YYYYMMDD upstream (e.g. `20250230`, `BADDATE`) parses to `service_date: nil`, then falls through `professional_entry`'s early-return and lands in the exceptions bucket as `:no_rate_for_year`. That misleads ops triage into hunting for missing fee-schedule coverage when the actual problem is the obligation row itself.

## What
- Short-circuit in `PrcOverpaymentAnalyzer.analyze_obligation` before procedure/facility lookup: nil service_date → `:missing_service_date`.
- New `missing_service_date` Result builder with ops-actionable notes (\"clean the obligation row, then re-import\").
- `PrcOverpaymentReportService.exception_reason` recognizes the new confidence so `exceptions.csv` labels it distinctly (not `unknown_missing_service_date`).

## Test plan
- [x] Analyzer test: nil service_date → `:missing_service_date` (not `:no_rate_for_year`).
- [x] Invariants test: exceptions CSV labels the row `missing_service_date`.
- [x] Full suite (828) green.
- [x] Manual smoke vs `invalid_dates_v1.prc`: bucket now reports `{"missing_service_date" => 2}`, previously `{"no_rate_for_year" => 2}`.

## Related
- Bug 4 from the fixture-matrix sweep (post-#318).

🤖 Generated with [Claude Code](https://claude.com/claude-code)