### PR TITLE
Add trailer integrity check on PrcImporter.import

### DIFF
--- a/app/services/corvid/prc_importer.rb
+++ b/app/services/corvid/prc_importer.rb
@@ -56,8 +56,47 @@ module Corvid
             obligations_updated: obligation_counts[:updated],
             payments_parsed: report.payments.size,
             payments_imported: payment_counts[:imported],
-            payments_dropped_orphan: payment_counts[:dropped_orphan]
+            payments_dropped_orphan: payment_counts[:dropped_orphan],
+            trailer_check: check_trailer(report, source_file: source_file)
           }
+        end
+      end
+
+      # Compare the trailer's self-reported counts/total against what we
+      # actually parsed. The trailer is upstream RPMS's integrity claim;
+      # a mismatch usually means the file truncated in transit or an ETL
+      # hop dropped rows. Pre-prod stance is warn-only — surface the
+      # discrepancy in the result so the caller (and an oncall reader)
+      # can see it, but don't raise and lock the import.
+      #
+      # Returns :ok / :mismatched / :missing.
+      def check_trailer(report, source_file:)
+        if report.trailer.nil?
+          Rails.logger.warn(
+            "[PrcImporter] trailer missing — no integrity check available " \
+            "for source=#{source_file}"
+          )
+          return :missing
+        end
+
+        t = report.trailer
+        parsed_total_paid = report.payments.sum { |p| p.amount || 0.to_d }
+        discrepancies = []
+        discrepancies << "obligation_count stated=#{t.obligation_count} parsed=#{report.obligations.size}" \
+          if t.obligation_count && t.obligation_count != report.obligations.size
+        discrepancies << "payment_count stated=#{t.payment_count} parsed=#{report.payments.size}" \
+          if t.payment_count && t.payment_count != report.payments.size
+        discrepancies << "total_paid stated=#{t.total_paid} parsed=#{parsed_total_paid}" \
+          if t.total_paid && t.total_paid != parsed_total_paid
+
+        if discrepancies.any?
+          Rails.logger.warn(
+            "[PrcImporter] trailer mismatch source=#{source_file} — " +
+            discrepancies.join("; ")
+          )
+          :mismatched
+        else
+          :ok
         end
       end
 

--- a/test/services/corvid/prc_importer_test.rb
+++ b/test/services/corvid/prc_importer_test.rb
@@ -161,6 +161,48 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Trailer integrity check -----------------------------------------------
+  # The trailer's obligation_count / payment_count / total_paid is
+  # upstream RPMS's self-report of what it emitted. If our parsed
+  # counts disagree, something corrupted the file in transit (ETL
+  # truncation, line drop, encoding) — silent acceptance would let
+  # short imports masquerade as clean. Pre-prod stance is warn-only:
+  # surface the discrepancy in the result + log, don't raise.
+
+  test "well-formed file: trailer_check is :ok" do
+    with_tenant(TENANT) do
+      result = Corvid::PrcImporter.import(SAMPLE, source_file: "ok.prc")
+      assert_equal :ok, result[:trailer_check],
+                   "all trailer counts and total_paid match the parsed records"
+    end
+  end
+
+  test "missing-trailer file: trailer_check is :missing and a warning is logged" do
+    with_tenant(TENANT) do
+      no_trailer = SAMPLE.lines.reject { |l| l.start_with?("T^") }.join
+      logs = capture_warns do
+        result = Corvid::PrcImporter.import(no_trailer, source_file: "no_trailer.prc")
+        assert_equal :missing, result[:trailer_check]
+      end
+      assert_match(/trailer.*missing/i, logs,
+                   "missing-trailer must log so an oncall reader sees the degraded state")
+    end
+  end
+
+  test "mismatched trailer: trailer_check is :mismatched, warning details the discrepancy" do
+    with_tenant(TENANT) do
+      # Stated payment_count: 4 (real: 3). Stated total_paid: 99999.99 (real: 42180.00).
+      tampered = SAMPLE.sub("T^2^2^3^42180.00^0.00", "T^2^2^4^99999.99^0.00")
+      logs = capture_warns do
+        result = Corvid::PrcImporter.import(tampered, source_file: "bad_trailer.prc")
+        assert_equal :mismatched, result[:trailer_check]
+      end
+      assert_match(/payment_count/i, logs,
+                   "warning must name the field that disagrees so triage is fast")
+      assert_match(/total_paid/i, logs)
+    end
+  end
+
   # -- Within-file duplicate IDs: last-wins dedup ----------------------------
   # Regression: PrcImporter.upsert_obligations used Array#uniq, which
   # keeps the FIRST occurrence per key. Both the FORMAT_MATRIX.md
@@ -329,6 +371,20 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Capture Rails.logger.warn output for the duration of the block.
+  # Returns the captured string. The importer logs trailer mismatches
+  # there, so we read it back instead of poking at the logger globals.
+  def capture_warns
+    captured = StringIO.new
+    original_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(captured)
+    Rails.logger.level = ::Logger::WARN
+    yield
+    captured.string
+  ensure
+    Rails.logger = original_logger if original_logger
+  end
 
   def seed_pfs_for_office_visit
     Corvid::FeeScheduleEntry.create!(


### PR DESCRIPTION
## Summary
- `check_trailer` compares trailer `obligation_count`, `payment_count`, `total_paid` against parsed records.
- Import result carries `trailer_check: :ok | :mismatched | :missing`.
- Mismatch and missing both log a warning; no raise (pre-prod warn-only).

## Test plan
- [x] Well-formed file → `:ok`.
- [x] No-trailer file → `:missing` + log.
- [x] Tampered file (stated payment_count/total_paid disagree with parsed) → `:mismatched` + log names the disagreeing fields.
- [x] Full suite (831) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)