### PR TITLE
Detect sub-cent precision truncations on PrcImporter.import

### DIFF
--- a/app/services/corvid/prc_importer.rb
+++ b/app/services/corvid/prc_importer.rb
@@ -57,9 +57,43 @@ module Corvid
             payments_parsed: report.payments.size,
             payments_imported: payment_counts[:imported],
             payments_dropped_orphan: payment_counts[:dropped_orphan],
-            trailer_check: check_trailer(report, source_file: source_file)
+            trailer_check: check_trailer(report, source_file: source_file),
+            sub_cent_truncations: detect_sub_cent_truncations(report, source_file: source_file)
           }
         end
+      end
+
+      # Money columns are integer-cents (USD has a 2-decimal subunit), so an
+      # input like 185.0099 truncates to 18500 cents = $185.00. The fix is
+      # to surface this in the result + log once, not to change rounding
+      # semantics (downstream auditors would see different numbers).
+      # Counts fields, not rows — three fields each carrying .0099 is
+      # three signals of upstream sub-cent precision.
+      SUB_CENT_OBLIGATION_FIELDS = %i[billed_amount paid_amount savings balance].freeze
+
+      def detect_sub_cent_truncations(report, source_file:)
+        count = 0
+        report.obligations.each do |o|
+          SUB_CENT_OBLIGATION_FIELDS.each do |f|
+            count += 1 if sub_cent?(o.public_send(f))
+          end
+        end
+        report.payments.each { |p| count += 1 if sub_cent?(p.amount) }
+
+        if count.positive?
+          Rails.logger.warn(
+            "[PrcImporter] sub-cent precision truncated on #{count} field(s) " \
+            "source=#{source_file} — upstream values with > 2 decimal places " \
+            "are floored to integer cents"
+          )
+        end
+        count
+      end
+
+      def sub_cent?(value)
+        return false if value.nil?
+        v = BigDecimal(value.to_s)
+        v != v.truncate(2)
       end
 
       # Compare the trailer's self-reported counts/total against what we

--- a/test/services/corvid/prc_importer_test.rb
+++ b/test/services/corvid/prc_importer_test.rb
@@ -161,6 +161,38 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
     end
   end
 
+  # -- Sub-cent precision detection ------------------------------------------
+  # Money is integer-cents by design, so $185.0099 truncates to $185.00
+  # on import. Truncation itself is fine; silent truncation is not. An
+  # ETL passing 4-decimal intermediate values shouldn't lose precision
+  # without a signal. Detect at the boundary, count, log once.
+
+  test "no sub-cent values: sub_cent_truncations is 0" do
+    with_tenant(TENANT) do
+      result = Corvid::PrcImporter.import(SAMPLE, source_file: "ok.prc")
+      assert_equal 0, result[:sub_cent_truncations]
+    end
+  end
+
+  test "obligation/payment with > 2-decimal amount: counted and logged" do
+    with_tenant(TENANT) do
+      sub_cent = <<~PRC
+        H^PRC_EXPORT^SEA^20090506^1
+        O^OBL-PREC^DFN1^V1^OFFICE_VISIT_EST^20090504^A^185.0099^185.0099^0.0000^0.0000^2009
+        P^OBL-PREC^PMT-PREC^20090518^CHK^185.0099^CLINIC
+        T^1^1^1^185.0099^0.00
+      PRC
+      logs = capture_warns do
+        result = Corvid::PrcImporter.import(sub_cent, source_file: "subcent.prc")
+        # billed + paid on the obligation = 2 fields; payment amount = 1.
+        # savings/balance are 0 so don't trigger.
+        assert_equal 3, result[:sub_cent_truncations]
+      end
+      assert_match(/sub.?cent/i, logs,
+                   "warning must surface the truncation so an oncall reader sees it")
+    end
+  end
+
   # -- Trailer integrity check -----------------------------------------------
   # The trailer's obligation_count / payment_count / total_paid is
   # upstream RPMS's self-report of what it emitted. If our parsed


### PR DESCRIPTION
## Summary
- `detect_sub_cent_truncations` counts obligation/payment fields whose value has more than 2 decimal places.
- Result carries `sub_cent_truncations: N`; positive count logs a warning.
- `to_cents` truncation behavior unchanged (changing rounding would alter every downstream auditor's reconciliation math).

## Test plan
- [x] Standard file → `sub_cent_truncations: 0`.
- [x] Obligation + payment with 4-decimal amounts → counted (3 fields: billed, paid, payment amount), warning logged.
- [x] Full suite (833) green.
- [x] Smoke vs `amount_precision_extremes_v1.prc`: count=3, warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)