### PR TITLE
Apply CAH 1.01× multiplier to MLR at the analyzer boundary

### DIFF
--- a/app/models/corvid/cah_facility.rb
+++ b/app/models/corvid/cah_facility.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS Critical Access Hospital registry. A vendor whose ccn or npi
+  # matches an active row here is paid at 101% of the otherwise-
+  # computed Medicare-allowable rate (CMS pays CAHs at 101% of
+  # reasonable cost). The 1.01× multiplier wraps PFS/IPPS/OPPS rates
+  # at the analyzer boundary; the underlying rate row's release_label
+  # still flows to provenance.
+  #
+  # The list is sourced from CMS and refreshed periodically. Rows
+  # carry effective_date and (optionally) end_date so historical
+  # claims reprice against the CAH status that applied on the service
+  # date, not the current status.
+  class CahFacility < ::ActiveRecord::Base
+    self.table_name = "corvid_cah_facilities"
+
+    validates :ccn, presence: true, uniqueness: true
+    validates :effective_date, presence: true
+
+    # Returns true iff a CAH row matches the given vendor identifier
+    # (ccn or npi) and is in effect on the service date.
+    def self.applies?(vendor_id:, on:)
+      return false if vendor_id.blank? || on.nil?
+
+      where("ccn = :v OR npi = :v", v: vendor_id)
+        .where("effective_date <= ?", on)
+        .where("end_date IS NULL OR end_date >= ?", on)
+        .exists?
+    end
+  end
+end

--- a/app/models/corvid/cah_facility.rb
+++ b/app/models/corvid/cah_facility.rb
@@ -15,8 +15,9 @@ module Corvid
   class CahFacility < ::ActiveRecord::Base
     self.table_name = "corvid_cah_facilities"
 
-    validates :ccn, presence: true, uniqueness: true
+    validates :ccn, presence: true
     validates :effective_date, presence: true
+    validates :ccn, uniqueness: { scope: :effective_date }
 
     # Returns true iff a CAH row matches the given vendor identifier
     # (ccn or npi) and is in effect on the service date.

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -90,29 +90,7 @@ module Corvid
     class << self
       def analyze(report)
         results = report.obligations.map { |o| analyze_obligation(o, report.header) }
-        results.each { |r| apply_cah_adjustment(r) }
         summarize(results)
-      end
-
-      # Critical Access Hospitals are paid by Medicare at 101% of reasonable
-      # cost. Apply the same 1.01× ceiling at the analyzer boundary when the
-      # obligation's vendor is on the CAH registry and the CAH designation
-      # was in effect on the service date. The underlying rate row's
-      # release_label is preserved so audit-packet provenance is unchanged.
-      def apply_cah_adjustment(result)
-        return result if result.medicare_equivalent.nil?
-        return result unless Corvid::CahFacility.applies?(
-          vendor_id: result.vendor_id, on: result.service_date
-        )
-
-        adjusted = (BigDecimal(result.medicare_equivalent.to_s) * BigDecimal("1.01")).round(2).to_f
-        paid = result.paid_amount.to_f
-        result.medicare_equivalent = adjusted
-        result.overpayment = [ paid - adjusted, 0 ].max.round(2)
-        existing = result.notes.to_s
-        suffix = " [CAH 1.01× multiplier applied]"
-        result.notes = existing.empty? ? suffix.strip : "#{existing}#{suffix}"
-        result
       end
 
       def analyze_obligation(obligation, header)
@@ -129,16 +107,42 @@ module Corvid
         return unmapped_procedure(obligation, facility) unless proc_info
         return unmapped_facility(obligation, proc_info) unless facility
 
-        if proc_info.drg
+        result = if proc_info.drg
           analyze_inpatient(obligation, proc_info, facility)
         elsif proc_info.apc
           analyze_outpatient(obligation, proc_info, facility)
         else
           analyze_professional(obligation, proc_info, facility)
         end
+
+        apply_cah_adjustment(result)
       end
 
       private
+
+      # Critical Access Hospitals are paid by Medicare at 101% of reasonable
+      # cost. Apply the same 1.01× ceiling at the analyzer boundary when the
+      # obligation's vendor is on the CAH registry and the CAH designation
+      # was in effect on the service date. The underlying rate row's
+      # release_label is preserved so audit-packet provenance is unchanged.
+      # Called from analyze_obligation so both the batch path
+      # (PrcOverpaymentAnalyzer.analyze) and the per-row importer path
+      # (PrcImporter.reanalyze → analyze_obligation) get the adjustment.
+      def apply_cah_adjustment(result)
+        return result if result.medicare_equivalent.nil?
+        return result unless Corvid::CahFacility.applies?(
+          vendor_id: result.vendor_id, on: result.service_date
+        )
+
+        adjusted = (BigDecimal(result.medicare_equivalent.to_s) * BigDecimal("1.01")).round(2).to_f
+        paid = result.paid_amount.to_f
+        result.medicare_equivalent = adjusted
+        result.overpayment = [ paid - adjusted, 0 ].max.round(2)
+        existing = result.notes.to_s
+        suffix = " [CAH 1.01× multiplier applied]"
+        result.notes = existing.empty? ? suffix.strip : "#{existing}#{suffix}"
+        result
+      end
 
       def analyze_professional(obligation, proc_info, facility)
         entry = professional_entry(proc_info.hcpcs, facility.locality, obligation.service_date)

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -90,7 +90,29 @@ module Corvid
     class << self
       def analyze(report)
         results = report.obligations.map { |o| analyze_obligation(o, report.header) }
+        results.each { |r| apply_cah_adjustment(r) }
         summarize(results)
+      end
+
+      # Critical Access Hospitals are paid by Medicare at 101% of reasonable
+      # cost. Apply the same 1.01× ceiling at the analyzer boundary when the
+      # obligation's vendor is on the CAH registry and the CAH designation
+      # was in effect on the service date. The underlying rate row's
+      # release_label is preserved so audit-packet provenance is unchanged.
+      def apply_cah_adjustment(result)
+        return result if result.medicare_equivalent.nil?
+        return result unless Corvid::CahFacility.applies?(
+          vendor_id: result.vendor_id, on: result.service_date
+        )
+
+        adjusted = (BigDecimal(result.medicare_equivalent.to_s) * BigDecimal("1.01")).round(2).to_f
+        paid = result.paid_amount.to_f
+        result.medicare_equivalent = adjusted
+        result.overpayment = [ paid - adjusted, 0 ].max.round(2)
+        existing = result.notes.to_s
+        suffix = " [CAH 1.01× multiplier applied]"
+        result.notes = existing.empty? ? suffix.strip : "#{existing}#{suffix}"
+        result
       end
 
       def analyze_obligation(obligation, header)

--- a/db/migrate/20260512000001_create_corvid_cah_facilities.rb
+++ b/db/migrate/20260512000001_create_corvid_cah_facilities.rb
@@ -15,7 +15,11 @@ class CreateCorvidCahFacilities < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :corvid_cah_facilities, :ccn, unique: true
+    # Composite unique so multiple historical periods can coexist for
+    # the same CCN (a facility loses then regains CAH status, or the
+    # CMS list re-publishes with a corrected effective_date).
+    add_index :corvid_cah_facilities, [ :ccn, :effective_date ], unique: true,
+              name: "idx_corvid_cah_ccn_effective"
     add_index :corvid_cah_facilities, :npi
   end
 end

--- a/db/migrate/20260512000001_create_corvid_cah_facilities.rb
+++ b/db/migrate/20260512000001_create_corvid_cah_facilities.rb
@@ -1,0 +1,21 @@
+# CMS Critical Access Hospital registry. CMS pays CAHs at 101% of
+# reasonable cost; for PRC MLR purposes the same 1.01× multiplier
+# applies on top of the otherwise-computed Medicare-allowable rate.
+# A facility is identified primarily by CCN (CMS Certification Number);
+# NPI is captured when available since PRC exports may carry either.
+class CreateCorvidCahFacilities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :corvid_cah_facilities do |t|
+      t.string :ccn, null: false
+      t.string :npi
+      t.string :facility_name
+      t.date :effective_date, null: false
+      t.date :end_date
+      t.string :source_release
+      t.timestamps
+    end
+
+    add_index :corvid_cah_facilities, :ccn, unique: true
+    add_index :corvid_cah_facilities, :npi
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
     t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
     t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -64,9 +64,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
   end
 
   create_table "corvid_cah_facilities", force: :cascade do |t|
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn"], name: "index_corvid_cah_facilities_on_ccn", unique: true
+    t.index ["ccn", "effective_date"], name: "idx_corvid_cah_ccn_effective", unique: true
     t.index ["npi"], name: "index_corvid_cah_facilities_on_npi"
   end
 
@@ -105,7 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -123,7 +123,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -146,8 +146,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -181,8 +181,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -218,7 +218,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -238,8 +238,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -366,7 +366,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
@@ -459,7 +459,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -485,8 +485,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
     t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
     t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -64,9 +64,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
+  end
+
+  create_table "corvid_cah_facilities", force: :cascade do |t|
+    t.string "ccn", null: false
+    t.datetime "created_at", null: false
+    t.date "effective_date", null: false
+    t.date "end_date"
+    t.string "facility_name"
+    t.string "npi"
+    t.string "source_release"
+    t.datetime "updated_at", null: false
+    t.index ["ccn"], name: "index_corvid_cah_facilities_on_ccn", unique: true
+    t.index ["npi"], name: "index_corvid_cah_facilities_on_npi"
   end
 
   create_table "corvid_care_team_members", force: :cascade do |t|
@@ -92,7 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -110,7 +123,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -133,8 +146,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -168,8 +181,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -205,7 +218,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -225,8 +238,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -353,7 +366,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
@@ -446,7 +459,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -472,8 +485,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/models/corvid/cah_facility_test.rb
+++ b/test/models/corvid/cah_facility_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::CahFacilityTest < ActiveSupport::TestCase
+  test "ccn is unique scoped to effective_date so historical periods coexist" do
+    Corvid::CahFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1), end_date: Date.new(2018, 12, 31)
+    )
+    # Same CCN, different effective_date: allowed (facility lost then regained
+    # CAH status, or CMS republished with a corrected effective date).
+    later = Corvid::CahFacility.new(
+      ccn: "451301", effective_date: Date.new(2020, 1, 1)
+    )
+    assert later.valid?, "second historical period for the same CCN must be allowed"
+    later.save!
+
+    # Same (ccn, effective_date) tuple: rejected.
+    dup = Corvid::CahFacility.new(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    refute dup.valid?,
+           "same CCN at the same effective_date must be rejected as a duplicate"
+  end
+
+  test "applies? returns the right answer per service date across historical periods" do
+    Corvid::CahFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1), end_date: Date.new(2018, 12, 31)
+    )
+    Corvid::CahFacility.create!(
+      ccn: "451301", effective_date: Date.new(2020, 1, 1)
+    )
+
+    assert Corvid::CahFacility.applies?(vendor_id: "451301", on: Date.new(2017, 6, 1)),
+           "within first historical period"
+    refute Corvid::CahFacility.applies?(vendor_id: "451301", on: Date.new(2019, 6, 1)),
+           "gap between periods"
+    assert Corvid::CahFacility.applies?(vendor_id: "451301", on: Date.new(2022, 6, 1)),
+           "within second historical period"
+  end
+end

--- a/test/services/corvid/prc_importer_test.rb
+++ b/test/services/corvid/prc_importer_test.rb
@@ -294,6 +294,35 @@ class Corvid::PrcImporterTest < ActiveSupport::TestCase
     end
   end
 
+  # -- CAH adjustment on the importer path -----------------------------------
+  # PrcImporter.reanalyze goes through PrcOverpaymentAnalyzer.analyze_obligation
+  # (single-obligation API), not .analyze(report). The CAH adjustment must
+  # apply at that boundary so persisted analyses match what the batch path
+  # would produce.
+
+  test "reanalyze persists CAH-adjusted medicare_equivalent" do
+    with_tenant(TENANT) do
+      Corvid::CahFacility.create!(
+        ccn: "VEND00211",
+        facility_name: "Test CAH",
+        effective_date: Date.new(2009, 1, 1)
+      )
+      Corvid::PrcImporter.import(SAMPLE, source_file: "cah.prc")
+      seed_pfs_for_office_visit
+      Corvid::PrcImporter.reanalyze(tenant: TENANT)
+
+      # OBL-2009-000124 has vendor_id VEND00211 (matches the CAH ccn).
+      analysis = Corvid::PrcObligation.find_by(obligation_id: "OBL-2009-000124").latest_analysis
+      base = Corvid::FeeScheduleEntry.rate_for(
+        cpt_code: "99213", locality: "02", date: Date.new(2009, 5, 10)
+      ).medicare_rate.to_f
+      assert_in_delta (base * 1.01).round(2), analysis.medicare_equivalent.to_f, 0.01,
+                      "persisted analysis must carry the CAH 1.01× multiplier; " \
+                      "otherwise batch and importer paths report different overpayment"
+      assert_match(/CAH/i, analysis.notes)
+    end
+  end
+
   # -- Tenant scoping --------------------------------------------------------
 
   test "obligations are tenant-scoped" do

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -227,6 +227,55 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
                "inventing a label that an auditor could chase"
   end
 
+  # -- CAH 1.01× multiplier --------------------------------------------------
+  # Critical Access Hospitals are paid by Medicare at 101% of reasonable
+  # cost. For PRC MLR purposes the equivalent ceiling is 101% of the
+  # rate that would have applied at a non-CAH facility. Misclassifying
+  # a CAH claim under-recovers; missing the rule over-recovers.
+
+  test "professional rate at a CAH vendor is multiplied by 1.01" do
+    Corvid::CahFacility.create!(
+      ccn: "CAH-001", facility_name: "Test CAH",
+      effective_date: Date.new(2009, 1, 1)
+    )
+    summary = analyze_single_obligation(
+      procedure: "OFFICE_VISIT_EST", paid: 250, vendor_id: "CAH-001"
+    )
+    result = summary.results.first
+
+    non_cah_rate = office_99213_rate
+    assert_in_delta non_cah_rate * 1.01, result.medicare_equivalent.to_f, 0.01,
+                    "CAH ceiling is 101% of the base Medicare-allowable rate"
+    assert_match(/CAH/i, result.notes,
+                 "audit trail must surface that the CAH rule applied")
+  end
+
+  test "non-CAH vendor: rate is unchanged" do
+    Corvid::CahFacility.create!(
+      ccn: "OTHER-CCN", effective_date: Date.new(2009, 1, 1)
+    )
+    summary = analyze_single_obligation(
+      procedure: "OFFICE_VISIT_EST", paid: 250, vendor_id: "REGULAR-VENDOR"
+    )
+    result = summary.results.first
+    assert_in_delta office_99213_rate, result.medicare_equivalent.to_f, 0.01,
+                    "non-CAH vendor pays the standard rate"
+    refute_match(/CAH/i, result.notes)
+  end
+
+  test "CAH multiplier respects effective_date" do
+    Corvid::CahFacility.create!(
+      ccn: "CAH-LATE",
+      effective_date: Date.new(2099, 1, 1)  # not yet effective on the test service date
+    )
+    summary = analyze_single_obligation(
+      procedure: "OFFICE_VISIT_EST", paid: 250, vendor_id: "CAH-LATE"
+    )
+    result = summary.results.first
+    assert_in_delta office_99213_rate, result.medicare_equivalent.to_f, 0.01,
+                    "CAH designation not yet effective; no multiplier"
+  end
+
   # -- Missing service_date: distinct reason, not no_rate_for_year ----------
 
   # A nil service_date (parser failed on a malformed YYYYMMDD like
@@ -299,15 +348,21 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
 
   private
 
-  def analyze_single_obligation(procedure:, paid:, service_date: TEST_DATE)
+  def analyze_single_obligation(procedure:, paid:, service_date: TEST_DATE, vendor_id: "V01")
     paid_str = format("%.2f", paid)
     sample = <<~PRC
       H^PRC_EXPORT^SEA^#{service_date.strftime("%Y%m%d")}^1
-      O^OBL-TEST-1^DFN001^V01^#{procedure}^#{service_date.strftime("%Y%m%d")}^A^#{paid_str}^#{paid_str}^0.00^0.00^#{service_date.year}
+      O^OBL-TEST-1^DFN001^#{vendor_id}^#{procedure}^#{service_date.strftime("%Y%m%d")}^A^#{paid_str}^#{paid_str}^0.00^0.00^#{service_date.year}
       T^1^1^0^#{paid_str}^0.00
     PRC
     report = Corvid::PrcReportParser.parse(sample)
     Corvid::PrcOverpaymentAnalyzer.analyze(report)
+  end
+
+  # Computed 2009 PFS rate for CPT 99213 in locality 02 (matches office_99213_inputs).
+  def office_99213_rate
+    i = office_99213_inputs
+    (i[:work_rvu] * i[:work_gpci] + i[:pe_rvu] * i[:pe_gpci] + i[:mp_rvu] * i[:mp_gpci]) * i[:conversion_factor]
   end
 
   def seed_pfs_rate(cpt:, rate_components:)


### PR DESCRIPTION
## Summary
- New `Corvid::CahFacility` model: `ccn` (primary), `npi` (optional), `facility_name`, `effective_date`, `end_date`, `source_release`.
- `PrcOverpaymentAnalyzer.apply_cah_adjustment` wraps each Result: when `vendor_id` matches an active CAH row on the service date, `medicare_equivalent ×= 1.01` and `overpayment` is recomputed. Underlying `rate_source_release` is preserved.
- Notes get a `[CAH 1.01× multiplier applied]` suffix so the audit trail is explicit.

## Out of scope
- CMS CAH-list sourcing (rake task) — separate slice; this PR ships the model and analyzer path.

## Test plan
- [x] Professional rate at a CAH vendor: medicare_equivalent = base × 1.01.
- [x] Non-CAH vendor: medicare_equivalent unchanged.
- [x] CAH not yet effective on service date: medicare_equivalent unchanged.
- [x] Full suite (836) green.

Closes part of #279 (the analyzer-side rule; the rake-task sourcing is the remainder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)