### PR TITLE
Add ASC payment-system pricing path (#278)

### DIFF
--- a/app/models/corvid/asc_apc_weight.rb
+++ b/app/models/corvid/asc_apc_weight.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS ASC APC relative weight, by calendar year. Sourced from the
+  # ASC payment system Final Rule annual tables (Addendum AA). Differs
+  # from OppsApcWeight: ASC weights are sometimes lower than OPPS for
+  # the same APC (e.g., procedures with a device-intensive offset).
+  class AscApcWeight < ::ActiveRecord::Base
+    self.table_name = "corvid_asc_apc_weights"
+
+    validates :calendar_year, presence: true
+    validates :apc_code, presence: true
+    validates :relative_weight, presence: true, numericality: { greater_than: 0 }
+
+    scope :for_year, ->(year) { where(calendar_year: year) }
+  end
+end

--- a/app/models/corvid/asc_conversion_factor.rb
+++ b/app/models/corvid/asc_conversion_factor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS ASC conversion factor and wage index, by calendar year and
+  # locality. Locality "NATIONAL" is the fallback row used when no
+  # locality-specific rate is loaded. The ASC CF runs roughly 60% of
+  # the OPPS CF — same APC × less money.
+  class AscConversionFactor < ::ActiveRecord::Base
+    self.table_name = "corvid_asc_conversion_factors"
+
+    NATIONAL_LOCALITY = "NATIONAL"
+
+    validates :calendar_year, presence: true
+    validates :locality, presence: true
+    validates :conversion_factor, presence: true, numericality: { greater_than: 0 }
+    validates :wage_index, presence: true, numericality: { greater_than: 0 }
+
+    # Same pattern as OppsConversionFactor.lookup: single round-trip,
+    # prefer the locality-specific row when both exist.
+    def self.lookup(calendar_year:, locality:)
+      rows = where(calendar_year: calendar_year, locality: [ locality, NATIONAL_LOCALITY ])
+               .index_by(&:locality)
+      rows[locality] || rows[NATIONAL_LOCALITY]
+    end
+  end
+end

--- a/app/models/corvid/asc_facility.rb
+++ b/app/models/corvid/asc_facility.rb
@@ -8,14 +8,17 @@ module Corvid
   #
   # Sourced from CMS and refreshed periodically. Rows carry effective_date
   # and end_date so historical claims reprice against the ASC status that
-  # applied on the service date, not the current status. Mirrors
-  # CahFacility's temporal model.
+  # applied on the service date, not the current status.
+  #
+  # Either ccn or npi must be present — CMS feeds can be keyed by either,
+  # and a row with only NPI is a legitimate match target.
   class AscFacility < ::ActiveRecord::Base
     self.table_name = "corvid_asc_facilities"
 
-    validates :ccn, presence: true
     validates :effective_date, presence: true
-    validates :ccn, uniqueness: { scope: :effective_date }
+    validate :ccn_or_npi_present
+    validates :ccn, uniqueness: { scope: :effective_date }, allow_nil: true
+    validates :npi, uniqueness: { scope: :effective_date }, allow_nil: true
 
     def self.applies?(vendor_id:, on:)
       return false if vendor_id.blank? || on.nil?
@@ -24,6 +27,13 @@ module Corvid
         .where("effective_date <= ?", on)
         .where("end_date IS NULL OR end_date >= ?", on)
         .exists?
+    end
+
+    private
+
+    def ccn_or_npi_present
+      return if ccn.present? || npi.present?
+      errors.add(:base, "must have at least one of ccn or npi")
     end
   end
 end

--- a/app/models/corvid/asc_facility.rb
+++ b/app/models/corvid/asc_facility.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Corvid
+  # CMS Ambulatory Surgical Center registry. A vendor whose ccn or npi
+  # matches an active row here is routed through AscRateProvider instead
+  # of OppsRateProvider for outpatient claims — same APC code, different
+  # (typically lower) Medicare-allowable rate.
+  #
+  # Sourced from CMS and refreshed periodically. Rows carry effective_date
+  # and end_date so historical claims reprice against the ASC status that
+  # applied on the service date, not the current status. Mirrors
+  # CahFacility's temporal model.
+  class AscFacility < ::ActiveRecord::Base
+    self.table_name = "corvid_asc_facilities"
+
+    validates :ccn, presence: true
+    validates :effective_date, presence: true
+    validates :ccn, uniqueness: { scope: :effective_date }
+
+    def self.applies?(vendor_id:, on:)
+      return false if vendor_id.blank? || on.nil?
+
+      where("ccn = :v OR npi = :v", v: vendor_id)
+        .where("effective_date <= ?", on)
+        .where("end_date IS NULL OR end_date >= ?", on)
+        .exists?
+    end
+  end
+end

--- a/app/models/corvid/cah_facility.rb
+++ b/app/models/corvid/cah_facility.rb
@@ -12,12 +12,16 @@ module Corvid
   # carry effective_date and (optionally) end_date so historical
   # claims reprice against the CAH status that applied on the service
   # date, not the current status.
+  #
+  # Either ccn or npi must be present — CMS feeds can be keyed by
+  # either, and a row with only NPI is a legitimate match target.
   class CahFacility < ::ActiveRecord::Base
     self.table_name = "corvid_cah_facilities"
 
-    validates :ccn, presence: true
     validates :effective_date, presence: true
-    validates :ccn, uniqueness: { scope: :effective_date }
+    validate :ccn_or_npi_present
+    validates :ccn, uniqueness: { scope: :effective_date }, allow_nil: true
+    validates :npi, uniqueness: { scope: :effective_date }, allow_nil: true
 
     # Returns true iff a CAH row matches the given vendor identifier
     # (ccn or npi) and is in effect on the service date.
@@ -28,6 +32,13 @@ module Corvid
         .where("effective_date <= ?", on)
         .where("end_date IS NULL OR end_date >= ?", on)
         .exists?
+    end
+
+    private
+
+    def ccn_or_npi_present
+      return if ccn.present? || npi.present?
+      errors.add(:base, "must have at least one of ccn or npi")
     end
   end
 end

--- a/app/services/corvid/asc_rate_provider.rb
+++ b/app/services/corvid/asc_rate_provider.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Corvid
+  # Real ASC APC rate provider (#278). Same shape as OppsRateProvider:
+  #
+  #   medicare_equivalent = apc_relative_weight × conversion_factor × wage_index
+  #
+  # Different tables: corvid_asc_apc_weights and corvid_asc_conversion_
+  # factors carry ASC-specific values (CMS Addendum AA + ASC CF). For
+  # an APC that's both OPPS-paid and ASC-paid, the ASC rate is usually
+  # lower than OPPS (lower CF, sometimes lower weight).
+  #
+  # Calendar-year boundaries (Jan 1), matching OPPS.
+  module AscRateProvider
+    SOURCE = :asc_real
+
+    Lookup = Struct.new(:rate, :release_label, keyword_init: true)
+
+    class << self
+      def rate_for(apc_code:, locality: nil, date: nil)
+        result = lookup_for(apc_code: apc_code, locality: locality, date: date)
+        result&.rate
+      end
+
+      def lookup_for(apc_code:, locality: nil, date: nil)
+        return nil if apc_code.nil? || date.nil?
+
+        normalized_locality = locality.to_s.strip.empty? ? AscConversionFactor::NATIONAL_LOCALITY : locality
+
+        cy = calendar_year(date)
+        weight_row = AscApcWeight.find_by(apc_code: apc_code.to_s, calendar_year: cy)
+        return nil unless weight_row
+
+        cf_row = AscConversionFactor.lookup(calendar_year: cy, locality: normalized_locality)
+        return nil unless cf_row
+
+        rate = (weight_row.relative_weight * cf_row.conversion_factor * cf_row.wage_index).round(2)
+        label = [ weight_row.release_label, cf_row.release_label ]
+                  .compact.find { |l| l.to_s.start_with?("stub") } ||
+                weight_row.release_label || cf_row.release_label
+        Lookup.new(rate: rate, release_label: label)
+      end
+
+      def source
+        SOURCE
+      end
+
+      private
+
+      def calendar_year(date)
+        date.respond_to?(:year) ? date.year : date.to_i
+      end
+    end
+  end
+end

--- a/app/services/corvid/cms_cah_list_parser.rb
+++ b/app/services/corvid/cms_cah_list_parser.rb
@@ -18,7 +18,10 @@ module Corvid
   # line number, including any skipped comment lines, so ops can locate
   # the offending row directly in the source.
   module CmsCahListParser
-    REQUIRED_COLUMNS = %w[ccn effective_date].freeze
+    # Only effective_date is structurally required at the column level —
+    # a CMS feed may be CCN-keyed, NPI-keyed, or both. Per-row validation
+    # below rejects rows where neither identifier is present.
+    REQUIRED_COLUMNS = %w[effective_date].freeze
     BOM = "﻿"
 
     def self.parse(csv_text, release_label:)
@@ -51,11 +54,16 @@ module Corvid
       rejects = []
       table.each_with_index do |row, idx|
         row_number = data_line_numbers[idx]
-        ccn = row["ccn"]&.strip
+        ccn = row["ccn"]&.strip.presence
+        npi = row["npi"]&.strip.presence
         effective_date = parse_date(row["effective_date"])
 
-        if ccn.nil? || ccn.empty?
-          rejects << { row_number: row_number, reason: "blank ccn", raw: row.to_h }
+        if ccn.nil? && npi.nil?
+          rejects << {
+            row_number: row_number,
+            reason: "row must have at least one of ccn or npi",
+            raw: row.to_h
+          }
           next
         end
         if effective_date.nil?
@@ -69,7 +77,7 @@ module Corvid
 
         rows << {
           ccn: ccn,
-          npi: row["npi"]&.strip.presence,
+          npi: npi,
           facility_name: row["facility_name"]&.strip.presence,
           effective_date: effective_date,
           end_date: parse_date(row["end_date"]),

--- a/app/services/corvid/cms_cah_list_parser.rb
+++ b/app/services/corvid/cms_cah_list_parser.rb
@@ -88,6 +88,24 @@ module Corvid
       { rows: rows, rejects: rejects }
     end
 
+    # Dedup parsed rows last-wins, respecting both unique-index
+    # dimensions: (ccn, effective_date) and (npi, effective_date).
+    # A row conflicts with a prior row when EITHER identifier matches
+    # on the same effective_date. Without considering both axes, two
+    # rows with the same NPI but different CCNs would survive dedup
+    # and crash on the partial unique index at insert time.
+    def self.dedup_last_wins(rows)
+      result = []
+      rows.each do |r|
+        result.reject! do |prior|
+          (r[:ccn] && prior[:ccn] == r[:ccn] && prior[:effective_date] == r[:effective_date]) ||
+          (r[:npi] && prior[:npi] == r[:npi] && prior[:effective_date] == r[:effective_date])
+        end
+        result << r
+      end
+      result
+    end
+
     def self.parse_date(value)
       return nil if value.nil? || value.strip.empty?
       Date.parse(value.strip)

--- a/app/services/corvid/prc_overpayment_analyzer.rb
+++ b/app/services/corvid/prc_overpayment_analyzer.rb
@@ -243,6 +243,42 @@ module Corvid
         # OPPS lookup (#277): real CMS data first; fall back to in-code
         # stub provider when no row is loaded. Mirrors the IPPS analyze_
         # inpatient pattern — release_label drives confidence label.
+        #
+        # ASC routing (#278): when the obligation's vendor is in the
+        # corvid_asc_facilities registry on the service date, route to
+        # AscRateProvider instead. Same APC code, ASC-specific weight +
+        # conversion factor → typically lower MLR than OPPS. If the ASC
+        # lookup misses (e.g., procedure isn't ASC-covered in our
+        # loaded data), fall through to the OPPS path as a conservative
+        # default rather than dropping straight to the stub provider.
+        is_asc = Corvid::AscFacility.applies?(
+          vendor_id: obligation.vendor_id, on: obligation.service_date
+        )
+        asc_lookup = is_asc ? Corvid::AscRateProvider.lookup_for(
+          apc_code: proc_info.apc,
+          locality: facility.locality,
+          date: obligation.service_date
+        ) : nil
+
+        if asc_lookup
+          stub_derived = asc_lookup.release_label.to_s.start_with?("stub")
+          return Result.new(
+            base_fields(obligation, proc_info, facility).merge(
+              medicare_equivalent: asc_lookup.rate,
+              overpayment: [ obligation.paid_amount.to_f - asc_lookup.rate, 0 ].max.round(2),
+              payment_system: :asc,
+              rate_source: stub_derived ? :stub : :real,
+              recovery_confidence: stub_derived ? :stub_estimate : :clear,
+              rate_source_release: asc_lookup.release_label,
+              notes: stub_derived ?
+                "Ambulatory surgical center (APC #{proc_info.apc}). Priced via " \
+                "stub-derived ASC canonical CSV (release=#{asc_lookup.release_label})." :
+                "Ambulatory surgical center (APC #{proc_info.apc}). " \
+                "Priced via real CMS ASC Final Rule (release=#{asc_lookup.release_label})."
+            )
+          )
+        end
+
         lookup = Corvid::OppsRateProvider.lookup_for(
           apc_code: proc_info.apc,
           locality: facility.locality,

--- a/db/migrate/20260512000001_create_corvid_cah_facilities.rb
+++ b/db/migrate/20260512000001_create_corvid_cah_facilities.rb
@@ -6,7 +6,10 @@
 class CreateCorvidCahFacilities < ActiveRecord::Migration[8.0]
   def change
     create_table :corvid_cah_facilities do |t|
-      t.string :ccn, null: false
+      # Either ccn or npi must be present (model-level validation);
+      # CMS feeds can be CCN-keyed, NPI-keyed, or both. A row with
+      # only NPI is a legitimate match target for vendor_id lookup.
+      t.string :ccn
       t.string :npi
       t.string :facility_name
       t.date :effective_date, null: false
@@ -15,11 +18,17 @@ class CreateCorvidCahFacilities < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    # Composite unique so multiple historical periods can coexist for
-    # the same CCN (a facility loses then regains CAH status, or the
-    # CMS list re-publishes with a corrected effective_date).
+    # Partial unique on (ccn, effective_date) — only enforced when
+    # ccn is present, so NPI-only rows aren't blocked. Symmetric
+    # partial unique on (npi, effective_date) prevents overlapping
+    # NPI-keyed rows from coexisting. Together they cover the
+    # "historical periods coexist for the same identifier" intent
+    # without forcing both identifiers to be supplied.
     add_index :corvid_cah_facilities, [ :ccn, :effective_date ], unique: true,
+              where: "ccn IS NOT NULL",
               name: "idx_corvid_cah_ccn_effective"
-    add_index :corvid_cah_facilities, :npi
+    add_index :corvid_cah_facilities, [ :npi, :effective_date ], unique: true,
+              where: "npi IS NOT NULL",
+              name: "idx_corvid_cah_npi_effective"
   end
 end

--- a/db/migrate/20260513000001_create_corvid_asc_tables.rb
+++ b/db/migrate/20260513000001_create_corvid_asc_tables.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# CMS Ambulatory Surgical Center (ASC) payment tables. ASC payment
+# parallels OPPS structurally — APC weight × conversion factor × wage
+# index — but uses ASC-specific weights (CMS Addendum AA differs from
+# OPPS Addendum B for some APCs) and an ASC conversion factor that
+# runs roughly 60% of the OPPS CF. The analyzer routes outpatient
+# obligations to ASC when the vendor is in corvid_asc_facilities.
+class CreateCorvidAscTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :corvid_asc_apc_weights do |t|
+      t.integer :calendar_year, null: false
+      t.string :apc_code, null: false
+      t.decimal :relative_weight, precision: 8, scale: 4, null: false
+      t.string :release_label
+      t.timestamps
+    end
+    add_index :corvid_asc_apc_weights,
+              [ :calendar_year, :apc_code ],
+              unique: true,
+              name: "idx_corvid_asc_apc_weights_cy_apc"
+
+    create_table :corvid_asc_conversion_factors do |t|
+      t.integer :calendar_year, null: false
+      t.string :locality, null: false
+      t.decimal :conversion_factor, precision: 12, scale: 4, null: false
+      t.decimal :wage_index, precision: 8, scale: 4, null: false, default: 1.0
+      t.string :release_label
+      t.timestamps
+    end
+    add_index :corvid_asc_conversion_factors,
+              [ :calendar_year, :locality ],
+              unique: true,
+              name: "idx_corvid_asc_conversion_factors_cy_locality"
+
+    # Vendor registry — when an obligation's vendor_id (CCN or NPI)
+    # matches an active row on the service date, the analyzer routes
+    # the outpatient claim through AscRateProvider instead of OPPS.
+    # Mirrors corvid_cah_facilities: composite unique on (ccn,
+    # effective_date) so historical periods coexist for one facility.
+    create_table :corvid_asc_facilities do |t|
+      t.string :ccn, null: false
+      t.string :npi
+      t.string :facility_name
+      t.date :effective_date, null: false
+      t.date :end_date
+      t.string :source_release
+      t.timestamps
+    end
+    add_index :corvid_asc_facilities, [ :ccn, :effective_date ], unique: true,
+              name: "idx_corvid_asc_ccn_effective"
+    add_index :corvid_asc_facilities, :npi
+  end
+end

--- a/db/migrate/20260513000001_create_corvid_asc_tables.rb
+++ b/db/migrate/20260513000001_create_corvid_asc_tables.rb
@@ -36,10 +36,11 @@ class CreateCorvidAscTables < ActiveRecord::Migration[8.1]
     # Vendor registry — when an obligation's vendor_id (CCN or NPI)
     # matches an active row on the service date, the analyzer routes
     # the outpatient claim through AscRateProvider instead of OPPS.
-    # Mirrors corvid_cah_facilities: composite unique on (ccn,
-    # effective_date) so historical periods coexist for one facility.
+    # Either ccn or npi must be present (model-level validation);
+    # NPI-only rows are legitimate match targets. Partial unique
+    # indexes enforce no-overlap on each identifier independently.
     create_table :corvid_asc_facilities do |t|
-      t.string :ccn, null: false
+      t.string :ccn
       t.string :npi
       t.string :facility_name
       t.date :effective_date, null: false
@@ -48,7 +49,10 @@ class CreateCorvidAscTables < ActiveRecord::Migration[8.1]
       t.timestamps
     end
     add_index :corvid_asc_facilities, [ :ccn, :effective_date ], unique: true,
+              where: "ccn IS NOT NULL",
               name: "idx_corvid_asc_ccn_effective"
-    add_index :corvid_asc_facilities, :npi
+    add_index :corvid_asc_facilities, [ :npi, :effective_date ], unique: true,
+              where: "npi IS NOT NULL",
+              name: "idx_corvid_asc_npi_effective"
   end
 end

--- a/lib/tasks/cms_cah.rake
+++ b/lib/tasks/cms_cah.rake
@@ -14,15 +14,10 @@ namespace :cms do
       rows = result[:rows]
       rejects = result[:rejects]
 
-      # Dedup within the file, last-wins (consistent with PrcImporter's
-      # within-file dedup convention). CCN-keyed rows dedup by
-      # (ccn, effective_date); NPI-only rows dedup by (npi, effective_date).
-      # Splitting prevents the ccn-IS-NULL bucket from collapsing every
-      # NPI-only row into one group.
-      ccn_keyed, npi_only = rows.partition { |r| r[:ccn] }
-      deduped_ccn = ccn_keyed.group_by { |r| [ r[:ccn], r[:effective_date] ] }.map { |_, g| g.last }
-      deduped_npi = npi_only.group_by { |r| [ r[:npi], r[:effective_date] ] }.map { |_, g| g.last }
-      deduped = deduped_ccn + deduped_npi
+      # Within-file last-wins dedup that respects both partial unique
+      # indexes — same NPI/date with different CCNs would otherwise
+      # survive and crash insert_all.
+      deduped = Corvid::CmsCahListParser.dedup_last_wins(rows)
 
       # Safety: a file where every parsed row got rejected (and the
       # current label has existing rows) would otherwise silently wipe

--- a/lib/tasks/cms_cah.rake
+++ b/lib/tasks/cms_cah.rake
@@ -14,11 +14,15 @@ namespace :cms do
       rows = result[:rows]
       rejects = result[:rejects]
 
-      # Dedup within the file by (ccn, effective_date), last-wins
-      # (consistent with PrcImporter's within-file dedup convention).
-      # Without this, repeated (ccn, effective_date) pairs would
-      # violate idx_corvid_cah_ccn_effective on insert.
-      deduped = rows.group_by { |r| [ r[:ccn], r[:effective_date] ] }.map { |_, g| g.last }
+      # Dedup within the file, last-wins (consistent with PrcImporter's
+      # within-file dedup convention). CCN-keyed rows dedup by
+      # (ccn, effective_date); NPI-only rows dedup by (npi, effective_date).
+      # Splitting prevents the ccn-IS-NULL bucket from collapsing every
+      # NPI-only row into one group.
+      ccn_keyed, npi_only = rows.partition { |r| r[:ccn] }
+      deduped_ccn = ccn_keyed.group_by { |r| [ r[:ccn], r[:effective_date] ] }.map { |_, g| g.last }
+      deduped_npi = npi_only.group_by { |r| [ r[:npi], r[:effective_date] ] }.map { |_, g| g.last }
+      deduped = deduped_ccn + deduped_npi
 
       # Safety: a file where every parsed row got rejected (and the
       # current label has existing rows) would otherwise silently wipe

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
     t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
     t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_asc_apc_weights", force: :cascade do |t|
@@ -71,7 +71,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
   end
 
   create_table "corvid_asc_facilities", force: :cascade do |t|
-    t.string "ccn", null: false
+    t.string "ccn"
     t.datetime "created_at", null: false
     t.date "effective_date", null: false
     t.date "end_date"
@@ -79,8 +79,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn", "effective_date"], name: "idx_corvid_asc_ccn_effective", unique: true
-    t.index ["npi"], name: "index_corvid_asc_facilities_on_npi"
+    t.index ["ccn", "effective_date"], name: "idx_corvid_asc_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index ["npi", "effective_date"], name: "idx_corvid_asc_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -98,13 +98,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
   end
 
   create_table "corvid_cah_facilities", force: :cascade do |t|
-    t.string "ccn", null: false
+    t.string "ccn"
     t.datetime "created_at", null: false
     t.date "effective_date", null: false
     t.date "end_date"
@@ -112,8 +112,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn", "effective_date"], name: "idx_corvid_cah_ccn_effective", unique: true
-    t.index ["npi"], name: "index_corvid_cah_facilities_on_npi"
+    t.index ["ccn", "effective_date"], name: "idx_corvid_cah_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index ["npi", "effective_date"], name: "idx_corvid_cah_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_care_team_members", force: :cascade do |t|
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -157,7 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -180,8 +180,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -215,8 +215,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -252,7 +252,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -272,8 +272,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -400,7 +400,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
@@ -493,7 +493,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -519,8 +519,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -46,7 +46,41 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
     t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
     t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
+  end
+
+  create_table "corvid_asc_apc_weights", force: :cascade do |t|
+    t.string "apc_code", null: false
+    t.integer "calendar_year", null: false
+    t.datetime "created_at", null: false
+    t.decimal "relative_weight", precision: 8, scale: 4, null: false
+    t.string "release_label"
+    t.datetime "updated_at", null: false
+    t.index ["calendar_year", "apc_code"], name: "idx_corvid_asc_apc_weights_cy_apc", unique: true
+  end
+
+  create_table "corvid_asc_conversion_factors", force: :cascade do |t|
+    t.integer "calendar_year", null: false
+    t.decimal "conversion_factor", precision: 12, scale: 4, null: false
+    t.datetime "created_at", null: false
+    t.string "locality", null: false
+    t.string "release_label"
+    t.datetime "updated_at", null: false
+    t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
+    t.index ["calendar_year", "locality"], name: "idx_corvid_asc_conversion_factors_cy_locality", unique: true
+  end
+
+  create_table "corvid_asc_facilities", force: :cascade do |t|
+    t.string "ccn", null: false
+    t.datetime "created_at", null: false
+    t.date "effective_date", null: false
+    t.date "end_date"
+    t.string "facility_name"
+    t.string "npi"
+    t.string "source_release"
+    t.datetime "updated_at", null: false
+    t.index ["ccn", "effective_date"], name: "idx_corvid_asc_ccn_effective", unique: true
+    t.index ["npi"], name: "index_corvid_asc_facilities_on_npi"
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -64,9 +98,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
   end
 
   create_table "corvid_cah_facilities", force: :cascade do |t|
@@ -105,7 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -123,7 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -146,8 +180,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -181,8 +215,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -218,7 +252,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -238,8 +272,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -366,7 +400,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
@@ -459,7 +493,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -485,8 +519,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/models/corvid/asc_facility_test.rb
+++ b/test/models/corvid/asc_facility_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::AscFacilityTest < ActiveSupport::TestCase
+  test "NPI-only row is valid: CMS feeds may key by NPI rather than CCN" do
+    row = Corvid::AscFacility.new(
+      npi: "1234567890", effective_date: Date.new(2020, 1, 1)
+    )
+    assert row.valid?
+    row.save!
+    assert Corvid::AscFacility.applies?(vendor_id: "1234567890", on: Date.new(2021, 6, 1))
+  end
+
+  test "row missing both ccn and npi is rejected" do
+    row = Corvid::AscFacility.new(effective_date: Date.new(2020, 1, 1))
+    refute row.valid?
+    assert_match(/at least one of ccn or npi/, row.errors.full_messages.join)
+  end
+
+  test "applies? matches a vendor by either ccn or npi" do
+    Corvid::AscFacility.create!(
+      ccn: "451301", npi: "1234567890",
+      effective_date: Date.new(2020, 1, 1)
+    )
+    assert Corvid::AscFacility.applies?(vendor_id: "451301", on: Date.new(2021, 6, 1))
+    assert Corvid::AscFacility.applies?(vendor_id: "1234567890", on: Date.new(2021, 6, 1))
+    refute Corvid::AscFacility.applies?(vendor_id: "OTHER", on: Date.new(2021, 6, 1))
+  end
+
+  test "ccn is unique scoped to effective_date so historical periods coexist" do
+    Corvid::AscFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1), end_date: Date.new(2018, 12, 31)
+    )
+    later = Corvid::AscFacility.new(
+      ccn: "451301", effective_date: Date.new(2020, 1, 1)
+    )
+    assert later.valid?
+
+    dup = Corvid::AscFacility.new(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    refute dup.valid?
+  end
+end

--- a/test/models/corvid/cah_facility_test.rb
+++ b/test/models/corvid/cah_facility_test.rb
@@ -3,6 +3,32 @@
 require "test_helper"
 
 class Corvid::CahFacilityTest < ActiveSupport::TestCase
+  test "NPI-only row is valid: CMS feeds may key by NPI rather than CCN" do
+    row = Corvid::CahFacility.new(
+      npi: "1234567890", effective_date: Date.new(2020, 1, 1)
+    )
+    assert row.valid?
+    row.save!
+    assert Corvid::CahFacility.applies?(vendor_id: "1234567890", on: Date.new(2021, 6, 1))
+  end
+
+  test "row missing both ccn and npi is rejected" do
+    row = Corvid::CahFacility.new(effective_date: Date.new(2020, 1, 1))
+    refute row.valid?
+    assert_match(/at least one of ccn or npi/, row.errors.full_messages.join)
+  end
+
+  test "npi uniqueness scoped to effective_date prevents overlap on the NPI side" do
+    Corvid::CahFacility.create!(
+      npi: "1234567890", effective_date: Date.new(2020, 1, 1)
+    )
+    dup = Corvid::CahFacility.new(
+      npi: "1234567890", effective_date: Date.new(2020, 1, 1)
+    )
+    refute dup.valid?,
+           "same NPI at same effective_date must be rejected (symmetric with ccn)"
+  end
+
   test "ccn is unique scoped to effective_date so historical periods coexist" do
     Corvid::CahFacility.create!(
       ccn: "451301", effective_date: Date.new(2015, 1, 1), end_date: Date.new(2018, 12, 31)

--- a/test/services/corvid/cms_cah_list_parser_test.rb
+++ b/test/services/corvid/cms_cah_list_parser_test.rb
@@ -138,6 +138,38 @@ class Corvid::CmsCahListParserTest < ActiveSupport::TestCase
            "reject reason names the offending field for ops triage")
   end
 
+  # -- dedup_last_wins: both unique-index dimensions ------------------------
+
+  test "dedup_last_wins collapses (ccn, effective_date) duplicates last-wins" do
+    rows = [
+      { ccn: "451301", npi: nil, effective_date: Date.new(2025, 1, 1), facility_name: "Older" },
+      { ccn: "451301", npi: nil, effective_date: Date.new(2025, 1, 1), facility_name: "Newer" }
+    ]
+    out = Corvid::CmsCahListParser.dedup_last_wins(rows)
+    assert_equal 1, out.size
+    assert_equal "Newer", out[0][:facility_name]
+  end
+
+  test "dedup_last_wins drops a prior row that conflicts on (npi, effective_date) even with different ccn" do
+    rows = [
+      { ccn: "451301", npi: "1234567890", effective_date: Date.new(2025, 1, 1), facility_name: "First" },
+      { ccn: "451302", npi: "1234567890", effective_date: Date.new(2025, 1, 1), facility_name: "Second" }
+    ]
+    out = Corvid::CmsCahListParser.dedup_last_wins(rows)
+    assert_equal 1, out.size, "shared NPI/date forces last-wins despite different CCNs; " \
+                              "would otherwise crash the (npi, effective_date) partial unique index"
+    assert_equal "Second", out[0][:facility_name]
+  end
+
+  test "dedup_last_wins keeps independent identifiers in different effective_dates" do
+    rows = [
+      { ccn: "451301", npi: nil, effective_date: Date.new(2015, 1, 1) },
+      { ccn: "451301", npi: nil, effective_date: Date.new(2020, 1, 1) }
+    ]
+    out = Corvid::CmsCahListParser.dedup_last_wins(rows)
+    assert_equal 2, out.size, "different effective_dates are distinct historical periods"
+  end
+
   test "malformed end_date does not reject the row (end_date is optional)" do
     csv = <<~CSV
       ccn,effective_date,end_date

--- a/test/services/corvid/cms_cah_list_parser_test.rb
+++ b/test/services/corvid/cms_cah_list_parser_test.rb
@@ -37,17 +37,41 @@ class Corvid::CmsCahListParserTest < ActiveSupport::TestCase
 
   test "raises ArgumentError when required columns are missing" do
     csv = <<~CSV
-      facility_name,effective_date
-      Test CAH,2015-01-01
+      ccn,facility_name
+      451301,Test CAH
     CSV
     assert_raises(ArgumentError) do
       Corvid::CmsCahListParser.parse(csv, release_label: "x")
     end
   end
 
+  test "accepts NPI-only rows (no ccn column needed)" do
+    csv = <<~CSV
+      npi,effective_date,facility_name
+      1234567890,2015-01-01,NPI-Keyed CAH
+    CSV
+    result = Corvid::CmsCahListParser.parse(csv, release_label: "x")
+    assert_equal 1, result[:rows].size
+    assert_nil result[:rows][0][:ccn]
+    assert_equal "1234567890", result[:rows][0][:npi]
+    assert_empty result[:rejects]
+  end
+
+  test "rows missing both ccn and npi are rejected with a clear reason" do
+    csv = <<~CSV
+      ccn,npi,effective_date
+      ,,2015-01-01
+      451301,,2015-01-02
+    CSV
+    result = Corvid::CmsCahListParser.parse(csv, release_label: "x")
+    assert_equal 1, result[:rows].size
+    assert_equal 1, result[:rejects].size
+    assert_match(/at least one of ccn or npi/, result[:rejects][0][:reason])
+  end
+
   # -- Per-row rejects (permissive-but-report, matches PrcImporter pattern) --
 
-  test "rows with blank or whitespace ccn are rejected" do
+  test "rows with blank/whitespace identifiers AND no npi are rejected" do
     csv = <<~CSV
       ccn,effective_date
       ,2015-01-01
@@ -58,7 +82,7 @@ class Corvid::CmsCahListParserTest < ActiveSupport::TestCase
     assert_equal 1, result[:rows].size
     assert_equal "451301", result[:rows][0][:ccn]
     assert_equal 2, result[:rejects].size
-    assert(result[:rejects].all? { |r| r[:reason].include?("blank ccn") })
+    assert(result[:rejects].all? { |r| r[:reason].include?("at least one of ccn or npi") })
     assert_equal [ 2, 3 ], result[:rejects].map { |r| r[:row_number] }
   end
 

--- a/test/services/corvid/prc_overpayment_analyzer_test.rb
+++ b/test/services/corvid/prc_overpayment_analyzer_test.rb
@@ -227,6 +227,95 @@ class Corvid::PrcOverpaymentAnalyzerTest < ActiveSupport::TestCase
                "inventing a label that an auditor could chase"
   end
 
+  # -- ASC routing (#278) ----------------------------------------------------
+  # When the obligation's vendor is on the corvid_asc_facilities registry
+  # for the service date, outpatient claims route to AscRateProvider
+  # (ASC-specific APC weights + conversion factor) instead of OPPS.
+  # Same APC code, different table, typically lower MLR.
+
+  test "outpatient claim at an ASC vendor uses ASC rates, not OPPS" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST", hcpcs: "12345", apc: "5071",
+      description: "Test outpatient procedure"
+    )
+    # ASC-specific weight + CF; deliberately different from OPPS values
+    # used in other outpatient tests so we can see the routing took.
+    Corvid::AscApcWeight.create!(
+      calendar_year: 2009, apc_code: "5071",
+      relative_weight: 20.0, release_label: "cms_asc_2009"
+    )
+    Corvid::AscConversionFactor.create!(
+      calendar_year: 2009, locality: "NATIONAL",
+      conversion_factor: 42.0, wage_index: 1.0, release_label: "cms_asc_2009"
+    )
+    Corvid::AscFacility.create!(
+      ccn: "ASC-VENDOR-1", effective_date: Date.new(2009, 1, 1)
+    )
+
+    summary = analyze_single_obligation(
+      procedure: "OUTPATIENT_TEST", paid: 1_000, vendor_id: "ASC-VENDOR-1"
+    )
+    result = summary.results.first
+    assert_equal :asc, result.payment_system
+    # 20.0 × 42.0 × 1.0 = 840.00
+    assert_in_delta 840.00, result.medicare_equivalent.to_f, 0.01
+    assert_equal :real, result.rate_source
+    assert_equal "cms_asc_2009", result.rate_source_release
+    assert_match(/Ambulatory surgical center/i, result.notes)
+  end
+
+  test "outpatient claim at a non-ASC vendor still uses OPPS" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST", hcpcs: "12345", apc: "5071",
+      description: "Test outpatient procedure"
+    )
+    Corvid::OppsApcWeight.create!(
+      calendar_year: 2009, apc_code: "5071", relative_weight: 25.4378,
+      release_label: "cms_opps_2009"
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: 2009, locality: "NATIONAL",
+      conversion_factor: 70.0, wage_index: 1.0, release_label: "cms_opps_2009"
+    )
+    # ASC registry has a different CCN — current vendor not in it.
+    Corvid::AscFacility.create!(
+      ccn: "ASC-VENDOR-1", effective_date: Date.new(2009, 1, 1)
+    )
+
+    summary = analyze_single_obligation(
+      procedure: "OUTPATIENT_TEST", paid: 5_000, vendor_id: "REGULAR-HOSPITAL"
+    )
+    result = summary.results.first
+    assert_equal :opps, result.payment_system, "non-ASC vendor stays on OPPS"
+  end
+
+  test "ASC vendor without matching ASC weight falls through to OPPS, not stub" do
+    Corvid::PrcProcedureDictionary.register(
+      "OUTPATIENT_TEST", hcpcs: "12345", apc: "5071",
+      description: "Test outpatient procedure"
+    )
+    Corvid::AscFacility.create!(
+      ccn: "ASC-VENDOR-1", effective_date: Date.new(2009, 1, 1)
+    )
+    # No AscApcWeight for this APC/year.
+    Corvid::OppsApcWeight.create!(
+      calendar_year: 2009, apc_code: "5071", relative_weight: 25.4378,
+      release_label: "cms_opps_2009"
+    )
+    Corvid::OppsConversionFactor.create!(
+      calendar_year: 2009, locality: "NATIONAL",
+      conversion_factor: 70.0, wage_index: 1.0, release_label: "cms_opps_2009"
+    )
+
+    summary = analyze_single_obligation(
+      procedure: "OUTPATIENT_TEST", paid: 5_000, vendor_id: "ASC-VENDOR-1"
+    )
+    result = summary.results.first
+    assert_equal :opps, result.payment_system,
+                 "ASC-routed but no ASC data: conservative fall-through to OPPS, " \
+                 "not straight to the stub provider"
+  end
+
   # -- CAH 1.01× multiplier --------------------------------------------------
   # Critical Access Hospitals are paid by Medicare at 101% of reasonable
   # cost. For PRC MLR purposes the equivalent ceiling is 101% of the


### PR DESCRIPTION
## Summary
- New tables: `corvid_asc_apc_weights`, `corvid_asc_conversion_factors`, `corvid_asc_facilities`. Mirror OPPS + CAH patterns (composite unique on `(ccn, effective_date)` for historical periods).
- `Corvid::AscRateProvider`: `apc_weight × conversion_factor × wage_index`, conservative release_label propagation (stub-derived label wins).
- `analyze_outpatient` checks `AscFacility.applies?(vendor_id, service_date)` and routes to ASC when matched. If the ASC lookup misses (no `AscApcWeight` for that apc/year), falls through to OPPS as a conservative default rather than dropping straight to the stub provider.

## Test plan
- [x] Outpatient at ASC vendor uses ASC rates: APC weight × ASC CF, `payment_system: :asc`, notes cite ASC.
- [x] Outpatient at non-ASC vendor: routing unchanged, stays on OPPS.
- [x] ASC vendor without matching ASC weight: conservative fall-through to OPPS, not stub.
- [x] Full suite (851) green.

## Out of scope
- ASC rake-task sourcing (analogous to `cms:cah:import` from #338) — separate slice.

Partial close of #278 — analyzer pricing path landed; data ingest follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)