### PR TITLE
Fix NameError in cms:opps:fetch_release final puts

### DIFF
--- a/lib/tasks/cms_opps.rake
+++ b/lib/tasks/cms_opps.rake
@@ -74,7 +74,7 @@ namespace :cms do
         Corvid::OppsConversionFactor.insert_all(cf_rows.map { |r| r.merge(created_at: Time.current, updated_at: Time.current) }) if cf_rows.any?
       end
 
-      puts "Fetched CY #{year} from cms-fee-schedules-v1: #{apc_rows.size} APC weights, #{cf_rows.size} conversion factors (label=#{label})"
+      puts "Fetched CY #{year} from cms-fee-schedules-v1: #{apc_rows.size} APC weights (label=#{apc_label}), #{cf_rows.size} conversion factors (label=#{cf_label})"
     end
 
     def strip_comments(csv_text)


### PR DESCRIPTION
The fetch_release task does the download + parse + transaction + insert correctly, then crashes on the final `puts` line which references `#{label}` — a variable that doesn't exist (got split into `apc_label` / `cf_label` in an earlier session, this line was missed).

Net effect today: data loads successfully, then the task exits with `NameError`. Caller sees a stack trace and assumes the import failed when it actually succeeded.

Fix: use the per-file labels in the puts.