### PR TITLE
OPPS backfill CY 2007–CY 2026 + docs/cms_opps_data.md

### DIFF
--- a/app/services/corvid/cms_opps_addendum_a_normalizer.rb
+++ b/app/services/corvid/cms_opps_addendum_a_normalizer.rb
@@ -60,6 +60,11 @@ module Corvid
         weight_raw = row[cols[:weight]]&.strip
         next if apc.nil? || apc.empty?
         next if weight_raw.nil? || weight_raw.empty?
+        # CMS uses "." as a "not applicable" sentinel for rows that don't
+        # carry a national relative weight (contractor-priced, etc.).
+        # Distinct from corrupted numeric input like "12O.34" — sentinel
+        # rows skip cleanly; corruption still raises.
+        next if weight_raw == "."
         next unless WEIGHTED_STATUS_INDICATORS.include?(si)
 
         weight = parse_weight(weight_raw, apc: apc, line: line_number)

--- a/app/services/corvid/cms_opps_addendum_a_normalizer.rb
+++ b/app/services/corvid/cms_opps_addendum_a_normalizer.rb
@@ -94,12 +94,16 @@ module Corvid
     end
 
     def self.column_indexes(header_row)
-      normalized = header_row.map { |h| h.to_s.strip.downcase }
+      # Collapse internal whitespace too — quarterly variants sometimes
+      # ship `" Relative  Weight "` (double inner space) which would
+      # otherwise miss the `"Relative Weight"` lookup.
+      normalized = header_row.map { |h| h.to_s.strip.downcase.gsub(/\s+/, " ") }
       required = {
         apc: APC_HEADER, si: SI_HEADER, weight: WEIGHT_HEADER
       }
       required.transform_values do |label|
-        idx = normalized.index(label.downcase)
+        target = label.downcase.gsub(/\s+/, " ")
+        idx = normalized.index(target)
         raise MalformedFileError,
               "Addendum A header missing required column #{label.inspect}; " \
               "got: #{header_row.inspect}" if idx.nil?

--- a/docs/cms_opps_data.md
+++ b/docs/cms_opps_data.md
@@ -1,0 +1,201 @@
+# CMS OPPS Data Ingestion
+
+The PRC overpayment analyzer prices hospital outpatient obligations
+against real CMS OPPS (Outpatient Prospective Payment System) Final
+Rule rates loaded into `corvid_opps_apc_weights` and
+`corvid_opps_conversion_factors`. This doc covers where the source
+data comes from, how it's normalized into the canonical CSV shape,
+and how to ingest a year.
+
+## Coverage target
+
+CY 2008 through current year (matches the OPPS payment system's
+useful range for tribal PRC recovery — earlier years are pre-OPPS or
+have alternate rate systems).
+
+## Source
+
+CMS publishes annual **OPPS Final Rule** tables. The relevant artifact
+is **Addendum A — OPPS APCs for CY {year}**, distributed as part of
+the quarterly Web Addendum drops. The January Web Addendum carries
+the Final Rule values for that calendar year.
+
+URL pattern (current scheme, CY 2020+):
+
+```
+https://www.cms.gov/medicare/payment/prospective-payment-systems/hospital-outpatient/regulations-notices/cms-NNNN-fc
+```
+
+Where `cms-NNNN-fc` is the rule number for that year's Final Rule.
+Known rule numbers:
+
+| CY | Rule number |
+| --- | --- |
+| 2026 | CMS-1834-FC |
+| 2025 | CMS-1809-FC |
+| 2024 | CMS-1786-FC |
+| 2023 | CMS-1772-FC |
+| 2022 | CMS-1753-FC |
+| 2021 | CMS-1736-FC |
+| 2020 | CMS-1717-FC |
+
+Older years (CY 2008–2019) use the legacy URL scheme under
+`/Medicare/Medicare-Fee-for-Service-Payment/HospitalOutpatientPPS/`.
+
+CMS distributes the Addendum A as a `.zip` containing both an
+`.xlsx` and a `.csv` (in the `508 Version` subdirectory). The CSV
+is easier to parse and has the same content as the xlsx; we
+normalize from the CSV.
+
+## Canonical CSV shape
+
+Two files per year, named:
+
+```
+opps_apc_weights_CY{year}.csv
+opps_conversion_factors_CY{year}.csv
+```
+
+APC weights:
+
+```csv
+# release_label: cms_opps_cy2026_final_rule
+apc_code,relative_weight
+2616,194.3993
+2632,4.3354
+5071,25.4378
+...
+```
+
+Conversion factors (NATIONAL only in Phase 1; per-CBSA wage index
+is a Phase 2 add):
+
+```csv
+# release_label: cms_opps_cy2026_final_rule
+locality,conversion_factor,wage_index
+NATIONAL,91.4150,1.0000
+```
+
+The leading `#`-comment line is the `release_label` marker — read by
+`CmsOppsParser` and stripped before parsing.
+
+## Per-year normalization recipe
+
+```bash
+# 1. Find the year's Final Rule home page (rule number from table above)
+open "https://www.cms.gov/medicare/payment/prospective-payment-systems/hospital-outpatient/regulations-notices/cms-NNNN-fc"
+
+# 2. Download the "January YYYY Web Addendum A" zip from the rule's
+#    Downloads section (or click each Addendum A line). The zip
+#    contains both .xlsx and a 508 Version .csv.
+
+# 3. Extract to a local path
+unzip january_${YEAR}_web_addendum_a.MM.DD.YY.zip -d /tmp/opps_${YEAR}/
+
+# 4. Run the normalizer (corvid)
+bundle exec rails "cms:opps:normalize_addendum_a[${YEAR},/tmp/opps_${YEAR}/508 Version January ${YEAR} Web Addendum A/January ${YEAR} Web Addendum A.MM.DD.YY.csv,/tmp/opps_apc_weights_CY${YEAR}.csv,cms_opps_cy${YEAR}_final_rule]"
+
+# 5. Hand-write the conversion factor CSV (single line per year, NATIONAL only)
+cat > /tmp/opps_conversion_factors_CY${YEAR}.csv <<CSV
+# release_label: cms_opps_cy${YEAR}_final_rule
+locality,conversion_factor,wage_index
+NATIONAL,${OPPS_CF},1.0000
+CSV
+
+# 6. Upload both to the cms-fee-schedules-v1 release
+gh release upload cms-fee-schedules-v1 \
+  /tmp/opps_apc_weights_CY${YEAR}.csv \
+  /tmp/opps_conversion_factors_CY${YEAR}.csv \
+  --repo lakeraven/corvid --clobber
+
+# 7. Fetch + import in the host app
+rake cms:opps:fetch_release[${YEAR}]
+```
+
+## Known conversion factors
+
+The OPPS national conversion factor (full-update, OQR-compliant
+hospitals) is published in each year's Final Rule preamble:
+
+| CY | Conversion factor | Source |
+| --- | ---: | --- |
+| 2026 | $91.4150 | CMS-1834-FC |
+| 2025 | $89.1690 | CMS-1809-FC |
+| 2024 | $87.3820 | CMS-1786-FC |
+| 2023 | — | CMS-1772-FC (TBD) |
+| 2022 | — | CMS-1753-FC (TBD) |
+| 2021 | — | CMS-1736-FC (TBD) |
+| 2020 | — | CMS-1717-FC (TBD) |
+
+For hospitals subject to the 340B recoupment adjustment, the
+conversion factor is slightly lower (CY 2026: $90.97 vs $91.415). We
+ship the standard full-update CF in the canonical CSV. Per-hospital
+340B-recouped pricing is a future enhancement (covered by deferred
+adjudication-adjustments issue #321).
+
+## Layout drift across years
+
+CMS occasionally renames Addendum A columns. The normalizer resolves
+columns by header label (APC, SI, Relative Weight) rather than fixed
+position, so column-order shifts don't silently misread the weight.
+A missing required column raises `MalformedFileError`.
+
+Watch for in older years:
+
+- Pre-CY 2008: APC system existed but the relative-weight column
+  was sometimes named "Weight" rather than "Relative Weight". May
+  require normalizer adjustment.
+- ISO-8859-1 encoding throughout. The normalizer re-encodes to
+  UTF-8 on read; if a year ships UTF-8 directly we'd be unaffected.
+
+## Production ingest priority
+
+By dollar volume in tribal PRC obligations:
+
+1. CY 2026 — most recent claims; loaded today.
+2. CY 2025–CY 2023 — recent recoverable years.
+3. CY 2022–CY 2018 — older recoverable; statute of limitations varies.
+4. CY 2017–CY 2008 — long-tail; stub fallback acceptable.
+
+## Coverage status
+
+| CY | Status | release_label | CF |
+| --- | --- | --- | ---: |
+| 2026 | **Real CMS data** | `cms_opps_cy2026_final_rule` | $91.4150 |
+| 2025 | Stub fallback | — | $89.1690 (known) |
+| 2024 | Stub fallback | — | $87.3820 (known) |
+| 2023 | Stub fallback | — | TBD |
+| 2022 | Stub fallback | — | TBD |
+| 2021 | Stub fallback | — | TBD |
+| 2020 | Stub fallback | — | TBD |
+| 2019 | Stub fallback | — | TBD |
+| 2018 | Stub fallback | — | TBD |
+| 2017 | Stub fallback | — | TBD |
+| 2016 | Stub fallback | — | TBD |
+| 2015 | Stub fallback | — | TBD |
+| 2014 | Stub fallback | — | TBD |
+| 2013 | Stub fallback | — | TBD |
+| 2012 | Stub fallback | — | TBD |
+| 2011 | Stub fallback | — | TBD |
+| 2010 | Stub fallback | — | TBD |
+| 2009 | Stub fallback | — | TBD |
+| 2008 | Stub fallback | — | TBD |
+
+## Phase 2: per-CBSA wage index
+
+Phase 1 ships NATIONAL-only with `wage_index=1.0`. Real OPPS pricing
+applies a per-CBSA wage adjustment (the same wage-area data CMS uses
+for IPPS). Loading per-CBSA rows is a separate slice — adds geographic
+accuracy at the cost of a separate per-year sourcing step.
+
+For tribal PRC recovery in rural/non-metro areas, the wage adjustment
+is typically <5% — material but not game-changing. NATIONAL CF is
+"directionally correct" until Phase 2 lands.
+
+## ASC parity
+
+Ambulatory Surgical Centers use the same APC codes but a separate
+conversion factor (~60% of OPPS). When ASC backfill begins, the
+sourcing pattern mirrors this doc — Addendum AA (ASC payment rates)
+from each CMS-NNNN-FC. The same `Corvid::CmsOppsAddendumANormalizer`
+won't work directly; ASC has its own column layout. Tracked in #278.

--- a/docs/cms_opps_data.md
+++ b/docs/cms_opps_data.md
@@ -163,7 +163,7 @@ By dollar volume in tribal PRC obligations:
 | --- | --- | --- | ---: | ---: |
 | 2026 | **Real CMS data** | `cms_opps_cy2026_final_rule` | $91.4150 | 250 |
 | 2025 | **Real CMS data** | `cms_opps_cy2025_final_rule` | $89.1690 | 258 |
-| 2024 | Stub fallback | — | $87.3820 (known) | — |
+| 2024 | **Real CMS data** | `cms_opps_cy2024_final_rule` | $87.3820 | 257 |
 | 2023 | Stub fallback | — | TBD |
 | 2022 | Stub fallback | — | TBD |
 | 2021 | Stub fallback | — | TBD |

--- a/docs/cms_opps_data.md
+++ b/docs/cms_opps_data.md
@@ -159,11 +159,11 @@ By dollar volume in tribal PRC obligations:
 
 ## Coverage status
 
-| CY | Status | release_label | CF |
-| --- | --- | --- | ---: |
-| 2026 | **Real CMS data** | `cms_opps_cy2026_final_rule` | $91.4150 |
-| 2025 | Stub fallback | — | $89.1690 (known) |
-| 2024 | Stub fallback | — | $87.3820 (known) |
+| CY | Status | release_label | CF | APCs |
+| --- | --- | --- | ---: | ---: |
+| 2026 | **Real CMS data** | `cms_opps_cy2026_final_rule` | $91.4150 | 250 |
+| 2025 | **Real CMS data** | `cms_opps_cy2025_final_rule` | $89.1690 | 258 |
+| 2024 | Stub fallback | — | $87.3820 (known) | — |
 | 2023 | Stub fallback | — | TBD |
 | 2022 | Stub fallback | — | TBD |
 | 2021 | Stub fallback | — | TBD |

--- a/docs/cms_opps_data.md
+++ b/docs/cms_opps_data.md
@@ -159,27 +159,38 @@ By dollar volume in tribal PRC obligations:
 
 ## Coverage status
 
+**All 20 calendar years (CY 2007–CY 2026) on real CMS Final Rule data.**
+
 | CY | Status | release_label | CF | APCs |
 | --- | --- | --- | ---: | ---: |
-| 2026 | **Real CMS data** | `cms_opps_cy2026_final_rule` | $91.4150 | 250 |
-| 2025 | **Real CMS data** | `cms_opps_cy2025_final_rule` | $89.1690 | 258 |
-| 2024 | **Real CMS data** | `cms_opps_cy2024_final_rule` | $87.3820 | 257 |
-| 2023 | Stub fallback | — | TBD |
-| 2022 | Stub fallback | — | TBD |
-| 2021 | Stub fallback | — | TBD |
-| 2020 | Stub fallback | — | TBD |
-| 2019 | Stub fallback | — | TBD |
-| 2018 | Stub fallback | — | TBD |
-| 2017 | Stub fallback | — | TBD |
-| 2016 | Stub fallback | — | TBD |
-| 2015 | Stub fallback | — | TBD |
-| 2014 | Stub fallback | — | TBD |
-| 2013 | Stub fallback | — | TBD |
-| 2012 | Stub fallback | — | TBD |
-| 2011 | Stub fallback | — | TBD |
-| 2010 | Stub fallback | — | TBD |
-| 2009 | Stub fallback | — | TBD |
-| 2008 | Stub fallback | — | TBD |
+| 2026 | Real CMS data | `cms_opps_cy2026_final_rule` | $91.4150 | 250 |
+| 2025 | Real CMS data | `cms_opps_cy2025_final_rule` | $89.1690 | 258 |
+| 2024 | Real CMS data | `cms_opps_cy2024_final_rule` | $87.3820 | 257 |
+| 2023 | Real CMS data | `cms_opps_cy2023_final_rule` | $85.5850 | 258 |
+| 2022 | Real CMS data | `cms_opps_cy2022_final_rule` | $84.1770 | 248 |
+| 2021 | Real CMS data | `cms_opps_cy2021_final_rule` | $82.7970 | 228 |
+| 2020 | Real CMS data | `cms_opps_cy2020_final_rule` | $80.7930 | 241 |
+| 2019 | Real CMS data | `cms_opps_cy2019_final_rule` | $79.4900 | 224 |
+| 2018 | Real CMS data | `cms_opps_cy2018_final_rule` | $78.6360 | 225 |
+| 2017 | Real CMS data | `cms_opps_cy2017_final_rule` | $75.0010 | 225 |
+| 2016 | Real CMS data | `cms_opps_cy2016_final_rule` | $74.9090 | 250 |
+| 2015 | Real CMS data | `cms_opps_cy2015_final_rule` | $74.1440 | 358 |
+| 2014 | Real CMS data | `cms_opps_cy2014_final_rule` | $72.6720 | 381 |
+| 2013 | Real CMS data | `cms_opps_cy2013_final_rule` | $71.3130 | 387 |
+| 2012 | Real CMS data | `cms_opps_cy2012_final_rule` | $70.0160 | 385 |
+| 2011 | Real CMS data | `cms_opps_cy2011_final_rule` | $68.8760 | 384 |
+| 2010 | Real CMS data | `cms_opps_cy2010_final_rule` | $67.4060 | 381 |
+| 2009 | Real CMS data | `cms_opps_cy2009_final_rule` | $66.0590 | 365 |
+| 2008 | Real CMS data | `cms_opps_cy2008_final_rule` | $63.6940 | 330 |
+| 2007 | Real CMS data | `cms_opps_cy2007_final_rule` | $61.4680 | 368 |
+
+Notes on CFs:
+- All CFs are the full-update / OQR-compliant figure published in each year's Final Rule preamble.
+- CY 2010 had a mid-year change ($67.406 first half, $67.241 second half — payment-update legislation). Stored value is the first-half figure as the canonical annual snapshot; mid-year handling is a future enhancement.
+- 340B-recouped CF variant is not stored; covered by deferred adjudication-adjustments issue #321.
+
+Notes on APC counts:
+- Pre-CY 2016 (~330–387 weighted APCs) vs CY 2016+ (~225–258): CMS consolidated APCs in 2016 (the comprehensive-APC restructuring), dropping ~150 codes from the weighted list. Lower count is expected.
 
 ## Phase 2: per-CBSA wage index
 

--- a/test/services/corvid/cms_opps_addendum_a_normalizer_test.rb
+++ b/test/services/corvid/cms_opps_addendum_a_normalizer_test.rb
@@ -109,6 +109,26 @@ class Corvid::CmsOppsAddendumANormalizerTest < ActiveSupport::TestCase
     reordered&.unlink
   end
 
+  test "weight sentinel \".\" (CMS not-applicable) skips row, doesn't raise" do
+    # CMS published older years (CY 2009 in particular) with "." in the
+    # Relative Weight column for contractor-priced or otherwise-
+    # non-applicable rows. Treat as skip, not malformed.
+    sentinel = Tempfile.new([ "sent", ".csv" ])
+    sentinel.write(<<~CSV)
+      ,Addendum A,,,,,,,,
+      APC,Group Title,SI,Relative Weight,Payment Rate
+      5071,Level 1,J1,25.4378,$2324
+      5072,Non-applicable,J1,.,$.
+      5073,Level 2,J1,50.0,$4500
+    CSV
+    sentinel.close
+    rows = Corvid::CmsOppsAddendumANormalizer.normalize(sentinel.path)
+    assert_equal 2, rows.size, "sentinel '.' row dropped; only weighted rows kept"
+    assert_equal [ "5071", "5073" ], rows.map { |r| r[:apc_code] }
+  ensure
+    sentinel&.unlink
+  end
+
   test "header with extra internal whitespace still resolves (CY 2024 quirk)" do
     # CY 2024 quarterly Web Addendum A ships "Relative Weight" with a
     # double internal space and trailing/leading padding. Header match

--- a/test/services/corvid/cms_opps_addendum_a_normalizer_test.rb
+++ b/test/services/corvid/cms_opps_addendum_a_normalizer_test.rb
@@ -109,6 +109,24 @@ class Corvid::CmsOppsAddendumANormalizerTest < ActiveSupport::TestCase
     reordered&.unlink
   end
 
+  test "header with extra internal whitespace still resolves (CY 2024 quirk)" do
+    # CY 2024 quarterly Web Addendum A ships "Relative Weight" with a
+    # double internal space and trailing/leading padding. Header match
+    # must collapse whitespace runs, not just strip outer space.
+    quirky = Tempfile.new([ "quirky", ".csv" ])
+    quirky.write(<<~CSV)
+      ,Addendum A,,,,,,,,
+      APC ,Group Title,SI, Relative  Weight , Payment Rate
+      5071,Level 1 Excision,J1,25.4378,$2324
+    CSV
+    quirky.close
+    rows = Corvid::CmsOppsAddendumANormalizer.normalize(quirky.path)
+    assert_equal 1, rows.size
+    assert_in_delta 25.4378, rows[0][:relative_weight], 0.0001
+  ensure
+    quirky&.unlink
+  end
+
   test "header missing a required column raises with the offending name" do
     missing_col = Tempfile.new([ "miss", ".csv" ])
     missing_col.write(<<~CSV)


### PR DESCRIPTION
**All 20 calendar years (CY 2007–CY 2026) on real CMS OPPS Final Rule data.** Contiguous coverage; OPPS pricing now produces `:clear` confidence for any service date 2007 onward when the vendor isn't on the ASC registry.

## What landed

- `docs/cms_opps_data.md` — coverage tracking, source URLs, normalization recipe, per-year status table (mirrors `docs/cms_ipps_data.md`).
- 40 canonical CSVs uploaded to `cms-fee-schedules-v1` GitHub release (2 per year × 20 years):
  - `opps_apc_weights_CY{2007..2026}.csv`
  - `opps_conversion_factors_CY{2007..2026}.csv`
- Two normalizer robustness fixes surfaced and pinned with regression tests:
  - **`.` not-applicable sentinel** in Relative Weight column (CY 2009) — treat as skip, not malformed.
  - **Whitespace-run collapse** in header lookup (CY 2024 had `" Relative  Weight "`) — resilient to quarterly formatting drift.

## CFs by year

| CY | CF | APCs | CY | CF | APCs |
|---:|---:|---:|---:|---:|---:|
| 2026 | $91.4150 | 250 | 2016 | $74.9090 | 250 |
| 2025 | $89.1690 | 258 | 2015 | $74.1440 | 358 |
| 2024 | $87.3820 | 257 | 2014 | $72.6720 | 381 |
| 2023 | $85.5850 | 258 | 2013 | $71.3130 | 387 |
| 2022 | $84.1770 | 248 | 2012 | $70.0160 | 385 |
| 2021 | $82.7970 | 228 | 2011 | $68.8760 | 384 |
| 2020 | $80.7930 | 241 | 2010 | $67.4060 | 381 |
| 2019 | $79.4900 | 224 | 2009 | $66.0590 | 365 |
| 2018 | $78.6360 | 225 | 2008 | $63.6940 | 330 |
| 2017 | $75.0010 | 225 | 2007 | $61.4680 | 368 |

(APC count drop at CY 2016 reflects CMS's comprehensive-APC restructuring that year.)

## Loadable via

```
rake cms:opps:fetch_release[YEAR]  # any of 2007..2026
```

## Out of scope

- Per-CBSA wage index (Phase 2; ships NATIONAL-only here).
- Mid-year CF changes (CY 2010 had a Q2 update — first-half value stored as canonical annual snapshot).
- 340B-recouped CF variant — covered by deferred adjudication-adjustments issue #321.

## Test plan
- [x] Full suite (882) green.
- [x] All 20 years smoke-fetched via `cms:opps:fetch_release[YEAR]`; APC + CF counts match release content.
- [x] Two new regression tests pin the normalizer fixes from the backfill (`.` sentinel + whitespace-collapse).