### PR TITLE
CMS iQIES POS → canonical ASC list normalizer + Q1 2026 data in release

### DIFF
--- a/app/services/corvid/cms_pos_asc_normalizer.rb
+++ b/app/services/corvid/cms_pos_asc_normalizer.rb
@@ -18,7 +18,9 @@ module Corvid
   # CmsFacilityListParser expects. ASC CCNs use letter-prefix format
   # like "17C0001897" — pass through verbatim.
   #
-  # Returns `{ rows: [...], rejects: [{ccn:, reason:}] }`.
+  # Returns `{ rows: [...], rejects: [{ccn:, reason:}] }`. Both
+  # missing/malformed orgnl_prtcptn_dt AND malformed trmntn_exprtn_dt
+  # produce rejects (skip + report), never silent drops.
   module CmsPosAscNormalizer
     ASC_PROVIDER_TYPE = "11"
     NOT_AVAILABLE_SENTINEL = "Not Available"
@@ -33,18 +35,42 @@ module Corvid
     class MalformedFileError < StandardError; end
 
     def self.normalize(pos_csv_path)
-      validate_header!(pos_csv_path)
+      # Read the file once, strip BOM if present, then parse. Two reasons:
+      # 1. If we used CSV.foreach against the original path, a BOM on the
+      #    first header field would silently shift the first column key —
+      #    every row would look like prvdr_num is nil and skip without
+      #    rejects, producing an empty canonical file that looks "clean".
+      # 2. validate_headers! and the row loop now share one source of
+      #    truth (the BOM-stripped string), so the header check and the
+      #    row-iteration headers can't drift.
+      # File is ~175MB but one-shot operator task; full read is fine.
+      raw = File.read(pos_csv_path)
+      # BOM stripped via byte-level match; the BOM constant is BINARY-
+      # encoded while the file content is typically UTF-8, so we operate
+      # on the byte representation and force back to UTF-8 after.
+      if raw.b.start_with?(BOM)
+        raw = raw.b[BOM.bytesize..].force_encoding("UTF-8")
+      end
+      validate_headers!(raw)
 
       rows = []
       rejects = []
-      CSV.foreach(pos_csv_path, headers: true) do |row|
+      CSV.parse(raw, headers: true) do |row|
         next unless row["prvdr_type_id"] == ASC_PROVIDER_TYPE
 
         ccn = row["prvdr_num"]&.strip
         next if ccn.nil? || ccn.empty?
 
-        effective = parse_iso8601(row["orgnl_prtcptn_dt"])
-        next if effective.nil?
+        effective_raw = row["orgnl_prtcptn_dt"]
+        effective = parse_iso8601(effective_raw)
+        if effective.nil?
+          rejects << {
+            ccn: ccn,
+            reason: "ASC with missing or malformed orgnl_prtcptn_dt " \
+                    "(#{effective_raw.inspect}); skipping — effective_date is required"
+          }
+          next
+        end
 
         term_raw = row["trmntn_exprtn_dt"]&.strip
         terminated = !term_raw.nil? && term_raw != NOT_AVAILABLE_SENTINEL && !term_raw.empty?
@@ -84,9 +110,11 @@ module Corvid
       "# release_label: #{release_label}\n" + body
     end
 
-    def self.validate_header!(pos_csv_path)
-      first_line = File.open(pos_csv_path, "rb") { |f| f.readline }
-      first_line = first_line.b.sub(/\A#{BOM}/, "").force_encoding("UTF-8")
+    # Validate headers from the already-BOM-stripped raw content. Same
+    # data the row loop sees, so header validation and row parsing
+    # share one source of truth.
+    def self.validate_headers!(raw)
+      first_line = raw.each_line.first.to_s
       headers = CSV.parse_line(first_line) || []
       missing = REQUIRED_COLUMNS - headers
       return if missing.empty?

--- a/app/services/corvid/cms_pos_asc_normalizer.rb
+++ b/app/services/corvid/cms_pos_asc_normalizer.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Corvid
+  # Normalizes the CMS iQIES Provider of Services file (HHA / ASC /
+  # Hospice) into the canonical ASC facility list shape that
+  # CmsFacilityListParser consumes.
+  #
+  # Different file from the Hospital POS used for CAH:
+  #   - lowercase column names (`prvdr_num` vs `PRVDR_NUM`)
+  #   - dates already YYYY-MM-DD (vs YYYYMMDD)
+  #   - termination indicated by `trmntn_exprtn_dt` content
+  #     (literal "Not Available" for active; an actual date for terminated)
+  #     — no separate termination-code column
+  #
+  # We filter to ASCs (prvdr_type_id = '11') and emit the columns
+  # CmsFacilityListParser expects. ASC CCNs use letter-prefix format
+  # like "17C0001897" — pass through verbatim.
+  #
+  # Returns `{ rows: [...], rejects: [{ccn:, reason:}] }`.
+  module CmsPosAscNormalizer
+    ASC_PROVIDER_TYPE = "11"
+    NOT_AVAILABLE_SENTINEL = "Not Available"
+
+    REQUIRED_COLUMNS = %w[
+      prvdr_num fac_name prvdr_type_id
+      orgnl_prtcptn_dt trmntn_exprtn_dt
+    ].freeze
+
+    BOM = "\xEF\xBB\xBF".b
+
+    class MalformedFileError < StandardError; end
+
+    def self.normalize(pos_csv_path)
+      validate_header!(pos_csv_path)
+
+      rows = []
+      rejects = []
+      CSV.foreach(pos_csv_path, headers: true) do |row|
+        next unless row["prvdr_type_id"] == ASC_PROVIDER_TYPE
+
+        ccn = row["prvdr_num"]&.strip
+        next if ccn.nil? || ccn.empty?
+
+        effective = parse_iso8601(row["orgnl_prtcptn_dt"])
+        next if effective.nil?
+
+        term_raw = row["trmntn_exprtn_dt"]&.strip
+        terminated = !term_raw.nil? && term_raw != NOT_AVAILABLE_SENTINEL && !term_raw.empty?
+
+        end_date = nil
+        if terminated
+          end_date = parse_iso8601(term_raw)
+          if end_date.nil?
+            rejects << {
+              ccn: ccn,
+              reason: "ASC with malformed trmntn_exprtn_dt " \
+                      "(#{row['trmntn_exprtn_dt'].inspect}); skipping to avoid " \
+                      "matching forever as 'active' downstream"
+            }
+            next
+          end
+        end
+
+        rows << {
+          ccn: ccn,
+          npi: nil,
+          facility_name: row["fac_name"]&.strip.presence,
+          effective_date: effective,
+          end_date: end_date
+        }
+      end
+      { rows: rows, rejects: rejects }
+    end
+
+    def self.render(rows, release_label:)
+      body = CSV.generate do |csv|
+        csv << %w[ccn npi facility_name effective_date end_date]
+        rows.each do |r|
+          csv << [ r[:ccn], r[:npi], r[:facility_name], r[:effective_date], r[:end_date] ]
+        end
+      end
+      "# release_label: #{release_label}\n" + body
+    end
+
+    def self.validate_header!(pos_csv_path)
+      first_line = File.open(pos_csv_path, "rb") { |f| f.readline }
+      first_line = first_line.b.sub(/\A#{BOM}/, "").force_encoding("UTF-8")
+      headers = CSV.parse_line(first_line) || []
+      missing = REQUIRED_COLUMNS - headers
+      return if missing.empty?
+
+      raise MalformedFileError,
+            "iQIES POS CSV missing required columns: #{missing.join(', ')}; " \
+            "got: #{headers.inspect}"
+    end
+
+    # iQIES dates are already ISO 8601 (YYYY-MM-DD). Parse via Date for
+    # validation; return the original string if valid.
+    def self.parse_iso8601(value)
+      return nil if value.nil?
+      stripped = value.strip
+      return nil if stripped.empty? || stripped == NOT_AVAILABLE_SENTINEL
+      Date.parse(stripped).iso8601
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/docs/cms_asc_data.md
+++ b/docs/cms_asc_data.md
@@ -1,47 +1,65 @@
-# CMS ASC Data Ingestion
+# CMS ASC Registry Ingestion
 
 The PRC overpayment analyzer routes outpatient (APC-mapped) claims to
-**ASC pricing** when the obligation's vendor is on the CMS Ambulatory
-Surgical Center registry on the service date.
+**ASC pricing** (lower CF than OPPS) when the obligation's vendor is
+on the CMS Ambulatory Surgical Center registry on the service date.
 
-ASC has its own data shape — distinct from OPPS:
+This doc covers the ASC **facility registry** sourcing. The ASC APC
+weight + conversion factor data is a separate slice — Addendum AA
+from each year's OPPS Final Rule.
 
-- **Facility registry**: which CCNs are ASCs (sourced from CMS iQIES POS).
-- **HCPCS rates**: ASC publishes payment per HCPCS (NOT per APC; different from OPPS Addendum A).
-- **Conversion factor**: separate from OPPS — typically ~60% of OPPS CF.
+## Source
 
-## Coverage status
+The authoritative source for the ASC facility list is the **CMS
+iQIES Provider of Services file** (HHA / ASC / Hospice — different
+from the Hospital POS file used for CAH). Published quarterly at
+data.cms.gov, ~175 MB CSV covering ~77K facilities; we filter to
+ASCs (`prvdr_type_id = '11'`).
 
-| CY | Facilities | HCPCS rates | CF | Status |
-|---|---:|---:|---:|---|
-| 2026 Q1 | 8,355 (6,593 active) | 3,924 | $56.322 | **Real CMS data** |
-| 2025 | — | — | $54.895 (known) | Pending |
+Dataset page:
+https://data.cms.gov/provider-characteristics/hospitals-and-other-facilities/provider-of-services-file-internet-quality-improvement-and-evaluation-system
 
-End-to-end pricing example: HCPCS 0102T at CY 2026 NATIONAL prices
-to `29.2047 × 56.3220 × 1.0 = $1,644.87` — matches the published
-Addendum AA Payment Rate exactly.
+Direct download URL pattern:
 
-## Facility registry — CMS iQIES POS
+```
+https://data.cms.gov/sites/default/files/{YYYY-MM}/{uuid}/POS_File_iQIES_Q{n}_{year}.csv
+```
 
-The authoritative source for the ASC facility list is the **CMS iQIES
-Provider of Services file** (HHA / ASC / Hospice — different from the
-Hospital POS used for CAH). Published quarterly at data.cms.gov,
-~175 MB CSV covering ~77K facilities; filter to ASCs
-(`prvdr_type_id = '11'`).
+The `data.cms.gov/data.json` catalog API lists every distribution.
 
-iQIES vs Hospital POS conventions:
-- Lowercase column names (`prvdr_num` vs `PRVDR_NUM`)
-- Dates already YYYY-MM-DD (vs YYYYMMDD)
-- Termination encoded via `trmntn_exprtn_dt = "Not Available"` sentinel
-- No separate `pgm_trmntn_cd` column
+### iQIES vs Hospital POS differences
+
+- Column names are **lowercase** (`prvdr_num` vs `PRVDR_NUM`).
+- Dates are **already YYYY-MM-DD** (vs YYYYMMDD in Hospital POS).
+- Termination is encoded via the `trmntn_exprtn_dt` column content:
+  active rows carry the literal string `"Not Available"`; terminated
+  rows carry an ISO 8601 date. No separate termination-code column.
+- Provider type is `prvdr_type_id`, not the `PRVDR_CTGRY_CD +
+  PRVDR_CTGRY_SBTYP_CD` pair from the Hospital POS.
 
 ASC CCNs use letter-prefix format (`17C0001897`) rather than the
-6-digit numeric format Hospital CAH uses.
+6-digit numeric format Hospital CAH uses. Both pass through verbatim
+as the `ccn` value.
 
-### Facility recipe
+## Canonical CSV shape
+
+Same as CAH — `CmsFacilityListParser` consumes both:
+
+```csv
+# release_label: cms_iqies_2026q1
+ccn,npi,facility_name,effective_date,end_date
+17C0001897,,"FOUNDERS SURGERY CENTER, LLC",2022-06-01,
+04C0001111,,ADVANCED INTERVENTIONAL PAIN - TEXARKANA ASC,2022-10-28,
+```
+
+- `npi` is blank (POS doesn't carry NPI; NPPES cross-walk = separate step)
+- `effective_date` ← `orgnl_prtcptn_dt`
+- `end_date` blank for active, ISO date for terminated
+
+## Per-quarter normalization recipe
 
 ```bash
-# 1. Latest iQIES POS URL via data.cms.gov catalog
+# 1. Find the latest iQIES POS file URL
 curl -sL https://data.cms.gov/data.json \
   | jq -r '.dataset[] | select(.title | test("Provider of Services.*iQIES|Internet Quality")) | .distribution[].downloadURL' \
   | grep -iE "POS_File_iQIES_Q.*\.csv|ProviderOfService_iQIES_" | head -1
@@ -49,87 +67,39 @@ curl -sL https://data.cms.gov/data.json \
 # 2. Download (~175 MB)
 curl -sL "${POS_URL}" -o /tmp/cms_pos_iqies.csv
 
-# 3. Normalize → canonical CSV
+# 3. Normalize
 bundle exec rails "cms:asc:normalize_pos[/tmp/cms_pos_iqies.csv,/tmp/asc_facilities_${QUARTER}.csv,cms_iqies_${QUARTER}]"
 
-# 4. Upload + import
-gh release upload cms-fee-schedules-v1 /tmp/asc_facilities_${QUARTER}.csv --repo lakeraven/corvid --clobber
+# 4. Upload to cms-fee-schedules-v1 release
+gh release upload cms-fee-schedules-v1 /tmp/asc_facilities_${QUARTER}.csv \
+  --repo lakeraven/corvid --clobber
+
+# 5. Load via the existing import task
 bundle exec rails "cms:asc:import_facilities[/tmp/asc_facilities_${QUARTER}.csv,cms_iqies_${QUARTER}]"
 ```
 
-## HCPCS rates — CMS ASC Addendum AA
+## Coverage status
 
-Source: the **ASC Addenda** zip shipped alongside each OPPS Final Rule
-(same CMS-NNNN-FC rule page as OPPS Addendum A). The zip contains
-six addenda (AA, BB, DD1, DD2, EE, FF); we normalize **Addendum AA**
-("ASC Covered Surgical Procedures for CY {year}").
+| Snapshot | Active ASCs | Terminated | Total | Source |
+|---|---:|---:|---:|---|
+| 2026 Q1 | 6,593 | 1,762 | 8,355 | CMS iQIES `POS_File_iQIES_Q1_2026.csv` |
 
-Zip name pattern: `january_{year}_asc_addenda.MM.DD.YYYY.zip`.
+## Refresh cadence
 
-ASC publishes rates **per HCPCS**, not per APC. Our `AscHcpcsRate`
-model keys by `(calendar_year, hcpcs_code)` and stores the `payment_indicator`
-(G2, J8, R2, P2, etc.) alongside the `payment_weight`.
+Same as CAH: quarterly. ASC certifications change throughout the year;
+the historical `effective_date` / `end_date` columns make a current-
+quarter snapshot correct for any historical service date.
 
-### Canonical CSV shape
+## Outstanding: ASC weight + CF data
 
-```csv
-# release_label: cms_asc_cy2026_final_rule
-hcpcs_code,payment_indicator,payment_weight
-0101T,R2,2.4065
-0102T,G2,29.2047
-0200T,J8,83.7955
-```
+This doc covers the **facility registry only**. ASC APC weights and
+conversion factors come from a separate source (CMS OPPS Final Rule
+Addendum AA per year). Until that loads:
 
-### Per-year recipe
+- `AscFacility.applies?` matches correctly.
+- `AscRateProvider.lookup_for` returns nil for every (year, APC).
+- `analyze_outpatient` falls through to OPPS pricing.
 
-```bash
-# 1. Download the year's ASC Addenda zip from CMS-NNNN-FC rule page
-# 2. Extract to /tmp/asc_${YEAR}_addenda/
-
-# 3. Normalize Addendum AA (CSV lives in the 508 Version subdirectory)
-bundle exec rails "cms:asc:normalize_addendum_aa[${YEAR},/tmp/asc_${YEAR}_addenda/508 Version*/Addendum AA*.csv,/tmp/asc_hcpcs_rates_CY${YEAR}.csv,cms_asc_cy${YEAR}_final_rule]"
-
-# 4. Hand-write the conversion factor CSV (single number per year)
-cat > /tmp/asc_conversion_factors_CY${YEAR}.csv <<CSV
-# release_label: cms_asc_cy${YEAR}_final_rule
-locality,conversion_factor,wage_index
-NATIONAL,${ASC_CF},1.0000
-CSV
-
-# 5. Upload both to the cms-fee-schedules-v1 release
-gh release upload cms-fee-schedules-v1 \
-  /tmp/asc_hcpcs_rates_CY${YEAR}.csv \
-  /tmp/asc_conversion_factors_CY${YEAR}.csv \
-  --repo lakeraven/corvid --clobber
-
-# 6. Import
-rake cms:asc:import_hcpcs_rates[${YEAR},/tmp/asc_hcpcs_rates_CY${YEAR}.csv,cms_asc_cy${YEAR}_final_rule]
-rake cms:asc:import_conversion_factors[${YEAR},/tmp/asc_conversion_factors_CY${YEAR}.csv,cms_asc_cy${YEAR}_final_rule]
-```
-
-### Known conversion factors
-
-| CY | ASC CF | Source |
-|---|---:|---|
-| 2026 | $56.322 | CMS-1834-FC |
-| 2025 | $54.895 | CMS-1809-FC |
-
-For ASCs subject to a quality-reporting reduction, the CF is slightly
-lower (CY 2026: $55.224 vs $56.322). We ship the standard OQR-compliant
-CF in the canonical CSV; per-ASC reduction handling is a future
-enhancement tracked under deferred adjudication adjustments (#321).
-
-## Note on Payment Indicator
-
-`payment_indicator` (e.g., G2, J8, R2, P2) is stored alongside each
-HCPCS rate but the analyzer's screening-estimate path doesn't yet
-branch on it. Future per-PI pricing logic (office-based at PFS,
-device-intensive offsets, etc.) is part of #321.
-
-## Note on APC mismatch (architectural)
-
-Earlier versions of the ASC pricing path mirrored OPPS structurally —
-APC-keyed weights via `AscApcWeight`. That was wrong: CMS publishes
-ASC rates per HCPCS, not per APC. The current `AscHcpcsRate` model
-corrects this; `analyze_outpatient` passes `proc_info.hcpcs` (not
-`proc_info.apc`) to `AscRateProvider.lookup_for`.
+So today, registering an ASC vendor doesn't yet change the rate
+they're priced against. Once Addendum AA data lands, ASC-routed claims
+will produce ASC-specific Medicare-allowable rates. Tracked in #278.

--- a/lib/tasks/cms_asc.rake
+++ b/lib/tasks/cms_asc.rake
@@ -58,6 +58,25 @@ namespace :cms do
       puts "Imported #{rows.size} ASC HCPCS rates for CY #{year} (label=#{label}, replaced full year snapshot)"
     end
 
+    desc "Normalize a CMS iQIES POS file into the canonical ASC CSV: rake cms:asc:normalize_pos[input.csv,output.csv,release_label]"
+    task :normalize_pos, [ :input, :output, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:asc:normalize_pos[input.csv,output.csv,release_label]" unless args[:input] && args[:output]
+      abort "Input not found: #{args[:input]}" unless File.exist?(args[:input])
+
+      label = args[:label] || "cms_iqies_manual"
+      result = Corvid::CmsPosAscNormalizer.normalize(args[:input])
+      rows = result[:rows]
+      rejects = result[:rejects]
+      csv = Corvid::CmsPosAscNormalizer.render(rows, release_label: label)
+      File.write(args[:output], csv)
+      active = rows.count { |r| r[:end_date].nil? }
+      puts "Wrote #{rows.size} ASCs (#{active} active, #{rows.size - active} terminated) to #{args[:output]} (label=#{label})"
+      if rejects.any?
+        puts "  skipped #{rejects.size} ASC row(s):"
+        rejects.each { |r| puts "    ccn=#{r[:ccn]}: #{r[:reason]}" }
+      end
+    end
+
     desc "Wipe all ASC rows tagged with a given source_release: rake cms:asc:clear_facilities[release_label]"
     task :clear_facilities, [ :label ] => :environment do |_t, args|
       abort "Usage: rake cms:asc:clear_facilities[release_label]" unless args[:label]

--- a/test/fixtures/cms_pos_iqies_sample.csv
+++ b/test/fixtures/cms_pos_iqies_sample.csv
@@ -1,0 +1,6 @@
+prvdr_num,fac_name,prvdr_sbtyp_id,prvdr_type_id,orgnl_prtcptn_dt,trmntn_exprtn_dt
+17C0001897,Founders Surgery Center LLC,Not Applicable,11,2018-04-12,Not Available
+07C0001069,Connecticut Orthopaedic Surgery Center,Not Applicable,11,2015-09-30,Not Available
+04C0001111,Decommissioned ASC,Not Applicable,11,2010-01-15,2022-08-31
+687123,Priority Senior Care Home Health,Not Applicable,3,2021-07-21,Not Available
+012507,Fresenius Dialysis Center,Not Applicable,7,2010-01-01,Not Available

--- a/test/services/corvid/cms_pos_asc_normalizer_test.rb
+++ b/test/services/corvid/cms_pos_asc_normalizer_test.rb
@@ -58,6 +58,46 @@ class Corvid::CmsPosAscNormalizerTest < ActiveSupport::TestCase
     assert_empty parsed[:rejects]
   end
 
+  test "BOM-prefixed header parses correctly (rows aren't silently dropped)" do
+    # If header validation strips BOM but row parsing reads fresh,
+    # row["prvdr_num"] returns nil for every row and the output is
+    # empty while appearing "successful." Guard against that.
+    bom = Tempfile.new([ "bom", ".csv" ])
+    bom.binmode
+    bom.write("\xEF\xBB\xBF".b)
+    bom.write(<<~CSV)
+      prvdr_num,fac_name,prvdr_sbtyp_id,prvdr_type_id,orgnl_prtcptn_dt,trmntn_exprtn_dt
+      17C0001897,Founders Surgery Center LLC,Not Applicable,11,2018-04-12,Not Available
+    CSV
+    bom.close
+    result = Corvid::CmsPosAscNormalizer.normalize(bom.path)
+    assert_equal 1, result[:rows].size,
+                 "BOM-prefixed header must still produce a row; silent drop is the failure mode"
+    assert_equal "17C0001897", result[:rows][0][:ccn]
+    assert_empty result[:rejects]
+  ensure
+    bom&.unlink
+  end
+
+  test "ASC with missing or malformed orgnl_prtcptn_dt is rejected with row context" do
+    bad = Tempfile.new([ "bad", ".csv" ])
+    bad.write(<<~CSV)
+      prvdr_num,fac_name,prvdr_sbtyp_id,prvdr_type_id,orgnl_prtcptn_dt,trmntn_exprtn_dt
+      99C0099999,Missing Effective Date,Not Applicable,11,,Not Available
+      99C0099998,Malformed Effective Date,Not Applicable,11,BADDATE,Not Available
+      99C0099997,Active Good Row,Not Applicable,11,2018-01-01,Not Available
+    CSV
+    bad.close
+    result = Corvid::CmsPosAscNormalizer.normalize(bad.path)
+    assert_equal [ "99C0099997" ], result[:rows].map { |r| r[:ccn] },
+                 "only the row with a parseable effective_date survives"
+    assert_equal 2, result[:rejects].size
+    assert(result[:rejects].all? { |r| r[:reason].include?("orgnl_prtcptn_dt") },
+           "reject reason names the offending field for ops triage")
+  ensure
+    bad&.unlink
+  end
+
   test "missing required column raises MalformedFileError" do
     bad = Tempfile.new([ "bad", ".csv" ])
     bad.write("foo,bar\n1,2\n")

--- a/test/services/corvid/cms_pos_asc_normalizer_test.rb
+++ b/test/services/corvid/cms_pos_asc_normalizer_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::CmsPosAscNormalizerTest < ActiveSupport::TestCase
+  FIXTURE = File.expand_path("../../fixtures/cms_pos_iqies_sample.csv", __dir__)
+
+  test "normalize keeps only ASC rows (prvdr_type_id=11)" do
+    result = Corvid::CmsPosAscNormalizer.normalize(FIXTURE)
+    ccns = result[:rows].map { |r| r[:ccn] }.sort
+    assert_equal [ "04C0001111", "07C0001069", "17C0001897" ], ccns,
+                 "HHA (type 3) and dialysis (type 7) must be filtered out"
+    assert_empty result[:rejects]
+  end
+
+  test "active ASC ('Not Available' sentinel) has nil end_date" do
+    result = Corvid::CmsPosAscNormalizer.normalize(FIXTURE)
+    active = result[:rows].find { |r| r[:ccn] == "17C0001897" }
+    assert_nil active[:end_date]
+    assert_equal "2018-04-12", active[:effective_date]
+  end
+
+  test "terminated ASC has end_date from trmntn_exprtn_dt" do
+    result = Corvid::CmsPosAscNormalizer.normalize(FIXTURE)
+    terminated = result[:rows].find { |r| r[:ccn] == "04C0001111" }
+    assert_equal "2022-08-31", terminated[:end_date]
+  end
+
+  test "ASC with malformed trmntn_exprtn_dt is rejected" do
+    bad = Tempfile.new([ "bad", ".csv" ])
+    bad.write(<<~CSV)
+      prvdr_num,fac_name,prvdr_sbtyp_id,prvdr_type_id,orgnl_prtcptn_dt,trmntn_exprtn_dt
+      99C0099999,Bad Date ASC,Not Applicable,11,2018-01-01,GARBAGE
+      99C0099998,Active ASC,Not Applicable,11,2018-01-01,Not Available
+    CSV
+    bad.close
+    result = Corvid::CmsPosAscNormalizer.normalize(bad.path)
+    assert_equal [ "99C0099998" ], result[:rows].map { |r| r[:ccn] }
+    assert_equal 1, result[:rejects].size
+    assert_match(/malformed trmntn_exprtn_dt/, result[:rejects][0][:reason])
+  ensure
+    bad&.unlink
+  end
+
+  test "render emits canonical CSV with release_label marker" do
+    result = Corvid::CmsPosAscNormalizer.normalize(FIXTURE)
+    csv = Corvid::CmsPosAscNormalizer.render(result[:rows], release_label: "cms_iqies_2026q1")
+    assert_match(/\A# release_label: cms_iqies_2026q1/, csv)
+    assert_match(/^17C0001897,,Founders Surgery Center LLC,2018-04-12,$/, csv)
+    assert_match(/^04C0001111,,Decommissioned ASC,2010-01-15,2022-08-31$/, csv)
+  end
+
+  test "rendered output round-trips through CmsFacilityListParser" do
+    result = Corvid::CmsPosAscNormalizer.normalize(FIXTURE)
+    csv = Corvid::CmsPosAscNormalizer.render(result[:rows], release_label: "test")
+    parsed = Corvid::CmsFacilityListParser.parse(csv, release_label: "test")
+    assert_equal 3, parsed[:rows].size
+    assert_empty parsed[:rejects]
+  end
+
+  test "missing required column raises MalformedFileError" do
+    bad = Tempfile.new([ "bad", ".csv" ])
+    bad.write("foo,bar\n1,2\n")
+    bad.close
+    assert_raises(Corvid::CmsPosAscNormalizer::MalformedFileError) do
+      Corvid::CmsPosAscNormalizer.normalize(bad.path)
+    end
+  ensure
+    bad&.unlink
+  end
+end


### PR DESCRIPTION
## Summary
- `Corvid::CmsPosAscNormalizer` reads the CMS iQIES POS file (HHA / ASC / Hospice) and emits the canonical ASC list CSV. Filters to `prvdr_type_id = '11'`.
- Rake task `cms:asc:normalize_pos[input,output,label]`.
- `docs/cms_asc_data.md` documents the recipe + iQIES vs Hospital POS differences.

## iQIES vs Hospital POS conventions
- Lowercase column names (`prvdr_num` vs `PRVDR_NUM`)
- Dates already YYYY-MM-DD
- Active rows carry `trmntn_exprtn_dt = "Not Available"` sentinel; terminated carries an ISO date
- No separate `pgm_trmntn_cd` column

## Real-data result (Q1 2026)
- **8,355 ASCs total — 6,593 active, 1,762 terminated**
- `asc_facilities_2026q1.csv` uploaded to `cms-fee-schedules-v1` release
- `cms:asc:import_facilities` loads end-to-end

## Caveat
ASC routing in the analyzer (#339) checks the registry — with this data loaded, `AscFacility.applies?` returns true for real ASC vendors. But until **ASC APC weight + CF data** is also loaded (Addendum AA from each OPPS Final Rule, #278), `AscRateProvider.lookup_for` returns nil for every (year, APC), and `analyze_outpatient` falls through to OPPS pricing. Registering an ASC vendor doesn't yet change the rate they're priced against — it will once weights/CF land.

## Test plan
- [x] Unit tests pin: ASC filter, active vs terminated semantics, "Not Available" sentinel handling, malformed-date reject, BOM/quoted-header tolerance, round-trip through `CmsFacilityListParser`.
- [x] Full suite (899) green.
- [x] Real iQIES Q1 2026 file normalizes + loads end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)