### PR TITLE
NPI↔CCN crosswalk for CAH/ASC vendor matching (#353)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,12 @@ end
 Rake::TestTask.new(:test_models) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/models/**/*_test.rb", "test/services/**/*_test.rb", "test/rulesets/**/*_test.rb"]
+  t.test_files = FileList[
+    "test/models/**/*_test.rb",
+    "test/services/**/*_test.rb",
+    "test/rulesets/**/*_test.rb",
+    "test/lib/tasks/**/*_test.rb"
+  ]
   t.verbose = false
 end
 

--- a/app/models/corvid/asc_facility.rb
+++ b/app/models/corvid/asc_facility.rb
@@ -20,10 +20,14 @@ module Corvid
     validates :ccn, uniqueness: { scope: :effective_date }, allow_nil: true
     validates :npi, uniqueness: { scope: :effective_date }, allow_nil: true
 
+    # When the vendor is keyed by NPI but CMS only lists the facility
+    # by CCN, the NPI↔CCN crosswalk resolves the NPI to its CCN(s) in
+    # effect on the service date.
     def self.applies?(vendor_id:, on:)
       return false if vendor_id.blank? || on.nil?
 
-      where("ccn = :v OR npi = :v", v: vendor_id)
+      candidates = [ vendor_id ] + NpiCcnCrosswalk.ccns_for(npi: vendor_id, on: on)
+      where("ccn IN (:v) OR npi IN (:v)", v: candidates)
         .where("effective_date <= ?", on)
         .where("end_date IS NULL OR end_date >= ?", on)
         .exists?

--- a/app/models/corvid/cah_facility.rb
+++ b/app/models/corvid/cah_facility.rb
@@ -24,11 +24,15 @@ module Corvid
     validates :npi, uniqueness: { scope: :effective_date }, allow_nil: true
 
     # Returns true iff a CAH row matches the given vendor identifier
-    # (ccn or npi) and is in effect on the service date.
+    # (ccn or npi) and is in effect on the service date. When the vendor
+    # is keyed by NPI but CMS only lists the facility by CCN, the
+    # NPI↔CCN crosswalk resolves the NPI to its CCN(s) in effect on the
+    # service date.
     def self.applies?(vendor_id:, on:)
       return false if vendor_id.blank? || on.nil?
 
-      where("ccn = :v OR npi = :v", v: vendor_id)
+      candidates = [ vendor_id ] + NpiCcnCrosswalk.ccns_for(npi: vendor_id, on: on)
+      where("ccn IN (:v) OR npi IN (:v)", v: candidates)
         .where("effective_date <= ?", on)
         .where("end_date IS NULL OR end_date >= ?", on)
         .exists?

--- a/app/models/corvid/npi_ccn_crosswalk.rb
+++ b/app/models/corvid/npi_ccn_crosswalk.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Corvid
+  # NPI ↔ CCN crosswalk. CMS POS files (CAH, ASC registries) are keyed
+  # by CCN; tribal PRC exports may key vendor_id by either CCN or NPI
+  # depending on the EHR source. CahFacility#applies? and
+  # AscFacility#applies? consult this table to resolve an NPI-keyed
+  # vendor_id to the CCNs that NPI billed under on the service date.
+  #
+  # Sourced from CMS NPPES. Each row maps an NPI to a CCN for a
+  # specific time window; an NPI may map to multiple CCNs over time
+  # (organizational restructure, ownership change).
+  class NpiCcnCrosswalk < ::ActiveRecord::Base
+    self.table_name = "corvid_npi_ccn_crosswalks"
+
+    validates :npi, presence: true
+    validates :ccn, presence: true
+
+    # Returns the distinct CCNs an NPI was billing under on the given
+    # service date. Empty if the NPI has no crosswalk row in effect.
+    def self.ccns_for(npi:, on:)
+      return [] if npi.blank? || on.nil?
+
+      where(npi: npi)
+        .where("effective_date IS NULL OR effective_date <= ?", on)
+        .where("end_date IS NULL OR end_date >= ?", on)
+        .distinct
+        .pluck(:ccn)
+    end
+  end
+end

--- a/db/migrate/20260514000001_create_corvid_npi_ccn_crosswalks.rb
+++ b/db/migrate/20260514000001_create_corvid_npi_ccn_crosswalks.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# NPI ↔ CCN crosswalk table. The CMS Provider of Services (POS) files
+# we use for CAH and ASC facility registries don't carry NPI. Tribal
+# PRC exports may carry vendor_id as either CCN or NPI depending on
+# the EHR source. Without this crosswalk, CahFacility#applies? and
+# AscFacility#applies? silently miss every NPI-keyed vendor_id and
+# the CAH multiplier / ASC routing never fire.
+#
+# Sourced from CMS NPPES (National Plan and Provider Enumeration
+# System); each row maps an NPI to its CMS Other Provider Identifier
+# (the CCN) for a specific time window.
+class CreateCorvidNpiCcnCrosswalks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :corvid_npi_ccn_crosswalks do |t|
+      t.string :npi, null: false
+      t.string :ccn, null: false
+      t.date :effective_date
+      t.date :end_date
+      t.string :source_release
+      t.timestamps
+    end
+
+    # Composite unique on (npi, ccn, effective_date) lets the same
+    # NPI map to multiple CCNs over time (organizational restructure,
+    # ownership change) and lets the same (npi, ccn) tuple have
+    # multiple historical periods.
+    add_index :corvid_npi_ccn_crosswalks, [ :npi, :ccn, :effective_date ],
+              unique: true, name: "idx_corvid_npi_ccn_crosswalks_unique"
+
+    # Hot-path lookups in applies?: given an NPI vendor_id, return CCNs.
+    add_index :corvid_npi_ccn_crosswalks, :npi
+    add_index :corvid_npi_ccn_crosswalks, :ccn
+  end
+end

--- a/docs/cms_asc_data.md
+++ b/docs/cms_asc_data.md
@@ -52,7 +52,9 @@ ccn,npi,facility_name,effective_date,end_date
 04C0001111,,ADVANCED INTERVENTIONAL PAIN - TEXARKANA ASC,2022-10-28,
 ```
 
-- `npi` is blank (POS doesn't carry NPI; NPPES cross-walk = separate step)
+- `npi` is blank (POS doesn't carry NPI; resolved at lookup time via
+  the NPI ↔ CCN crosswalk — see
+  [cms_npi_crosswalk_data.md](cms_npi_crosswalk_data.md))
 - `effective_date` ← `orgnl_prtcptn_dt`
 - `end_date` blank for active, ISO date for terminated
 

--- a/docs/cms_cah_data.md
+++ b/docs/cms_cah_data.md
@@ -100,16 +100,9 @@ effective.
 Recommended cadence: refresh annually unless tribal customers report
 vendor mismatches.
 
-## NPI cross-walk (future)
+## NPI cross-walk
 
-POS file doesn't carry NPI. If PRC obligations arrive keyed by NPI
-rather than CCN, `CahFacility.applies?` won't match. Two paths:
-
-1. **Cross-walk via NPPES** — the National Plan and Provider
-   Enumeration System has a public CSV mapping NPI ↔ CCN. Adds a
-   second normalization step.
-2. **Customer-side conversion** — tribal IT translates NPI to CCN
-   before importing PRC obligations.
-
-For Yakama/Skokomish-shape customers we'll know which keying is in
-use after the first PRC export goes through the analyzer.
+POS file doesn't carry NPI. When PRC obligations arrive keyed by NPI,
+`CahFacility.applies?` resolves the NPI to its CCN(s) on the service
+date via `corvid_npi_ccn_crosswalks`. Source data and refresh recipe:
+see [cms_npi_crosswalk_data.md](cms_npi_crosswalk_data.md).

--- a/docs/cms_npi_crosswalk_data.md
+++ b/docs/cms_npi_crosswalk_data.md
@@ -1,0 +1,68 @@
+# NPI ↔ CCN Crosswalk Ingestion
+
+The CMS Provider of Services (POS) files that feed `corvid_cah_facilities`
+and `corvid_asc_facilities` are keyed by CCN only — they don't carry NPI.
+Tribal PRC exports may key vendor identifiers by either CCN or NPI
+depending on the EHR source. Without a crosswalk, `CahFacility.applies?`
+and `AscFacility.applies?` miss every NPI-keyed vendor, the 1.01× CAH
+multiplier never fires, and ASC routing falls back to OPPS rates.
+
+`corvid_npi_ccn_crosswalks` closes that gap. `applies?` consults it at
+lookup time: when `vendor_id` is an NPI, it resolves to the CCN(s) the
+NPI was billing under on the service date and matches those against the
+facility list.
+
+## Source
+
+The authoritative source is the **CMS National Plan and Provider
+Enumeration System (NPPES)** monthly file, published at
+download.cms.gov. ~10 GB CSV covering every NPI ever issued.
+
+Dataset page: https://download.cms.gov/nppes/NPI_Files.html
+
+We don't load the full file — only the rows whose CMS Other Provider
+Identifier (the CCN) already appears in one of the facility lists.
+
+## Canonical CSV shape
+
+```csv
+npi,ccn,effective_date,end_date
+1234567890,451301,2015-01-01,
+9876543210,451999,2020-01-01,2024-12-31
+```
+
+- `effective_date` / `end_date` come from the NPPES history for the
+  (NPI, CCN) tuple. Multiple historical periods per NPI are expected
+  for organizational restructure / ownership change cases.
+- `end_date` blank means the (NPI, CCN) tuple is still active.
+
+## Refresh recipe
+
+```bash
+# 1. Pull the monthly NPPES file (~10 GB)
+curl -sL "${NPPES_URL}" -o /tmp/nppes_$(date +%Y%m).zip
+
+# 2. Filter + normalize to canonical CSV against the CCNs we care about.
+#    (A standalone normalizer lives outside this engine — the corvid
+#    side just consumes the canonical CSV.)
+
+# 3. Upload to cms-fee-schedules-v1 release
+gh release upload cms-fee-schedules-v1 /tmp/npi_ccn_crosswalk_${LABEL}.csv \
+  --repo lakeraven/corvid --clobber
+
+# 4. Load
+bundle exec rails "cms:nppes:import_crosswalk[/tmp/npi_ccn_crosswalk_${LABEL}.csv,nppes_${LABEL}]"
+```
+
+Snapshot semantics: re-importing under the same `release_label` wipes
+that label's prior snapshot before insert. Other labels are untouched,
+so multiple historical NPPES snapshots can coexist.
+
+## Refresh cadence
+
+NPPES is published monthly. NPI ↔ CCN relationships change when a
+facility changes ownership or restructures. For PRC recovery work,
+the historical `effective_date` / `end_date` columns are what matter —
+a current snapshot prices historical claims correctly.
+
+Recommended cadence: refresh quarterly alongside the POS files.

--- a/lib/tasks/cms_nppes.rake
+++ b/lib/tasks/cms_nppes.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "csv"
+
+namespace :cms do
+  namespace :nppes do
+    desc "Import the NPI↔CCN crosswalk: rake cms:nppes:import_crosswalk[/path/to/crosswalk.csv,release_label]"
+    task :import_crosswalk, [ :path, :label ] => :environment do |_t, args|
+      abort "Usage: rake cms:nppes:import_crosswalk[/path/to/crosswalk.csv,release_label]" unless args[:path] && args[:label]
+      abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
+
+      label = args[:label]
+      now = Time.current
+      rows = []
+      CSV.foreach(args[:path], headers: true) do |csv_row|
+        npi = csv_row["npi"]&.strip
+        ccn = csv_row["ccn"]&.strip
+        next if npi.blank? || ccn.blank?
+
+        rows << {
+          npi: npi,
+          ccn: ccn,
+          effective_date: csv_row["effective_date"].presence,
+          end_date: csv_row["end_date"].presence,
+          source_release: label,
+          created_at: now,
+          updated_at: now
+        }
+      end
+
+      ActiveRecord::Base.transaction do
+        Corvid::NpiCcnCrosswalk.where(source_release: label).delete_all
+        rows.each_slice(1000) do |batch|
+          Corvid::NpiCcnCrosswalk.insert_all(batch)
+        end if rows.any?
+      end
+
+      puts "Imported #{rows.size} NPI↔CCN crosswalk rows (label=#{label}, replaced prior snapshot)"
+    end
+  end
+end

--- a/lib/tasks/cms_nppes.rake
+++ b/lib/tasks/cms_nppes.rake
@@ -1,41 +1,85 @@
 # frozen_string_literal: true
 
 require "csv"
+require "date"
 
 namespace :cms do
   namespace :nppes do
+    REQUIRED_HEADERS = %w[npi ccn effective_date end_date].freeze
+
     desc "Import the NPI↔CCN crosswalk: rake cms:nppes:import_crosswalk[/path/to/crosswalk.csv,release_label]"
     task :import_crosswalk, [ :path, :label ] => :environment do |_t, args|
       abort "Usage: rake cms:nppes:import_crosswalk[/path/to/crosswalk.csv,release_label]" unless args[:path] && args[:label]
       abort "File not found: #{args[:path]}" unless File.exist?(args[:path])
 
+      csv = CSV.read(args[:path], headers: true)
+      missing = REQUIRED_HEADERS - (csv.headers || []).map { |h| h&.strip }
+      abort "Missing required headers: #{missing.join(', ')}" if missing.any?
+
       label = args[:label]
       now = Time.current
       rows = []
-      CSV.foreach(args[:path], headers: true) do |csv_row|
+      rejects = []
+
+      csv.each_with_index do |csv_row, idx|
+        line = idx + 2 # +1 for header, +1 to 1-index
         npi = csv_row["npi"]&.strip
         ccn = csv_row["ccn"]&.strip
-        next if npi.blank? || ccn.blank?
+        next if npi.blank? && ccn.blank? && csv_row.to_h.values.all? { |v| v.to_s.strip.empty? }
+
+        if npi.blank? || ccn.blank?
+          rejects << { line: line, reason: "missing npi or ccn" }
+          next
+        end
+
+        begin
+          effective_date = parse_optional_date(csv_row["effective_date"])
+          end_date = parse_optional_date(csv_row["end_date"])
+        rescue ArgumentError => e
+          rejects << { line: line, reason: e.message }
+          next
+        end
 
         rows << {
           npi: npi,
           ccn: ccn,
-          effective_date: csv_row["effective_date"].presence,
-          end_date: csv_row["end_date"].presence,
+          effective_date: effective_date,
+          end_date: end_date,
           source_release: label,
           created_at: now,
           updated_at: now
         }
       end
 
+      if rows.empty?
+        msg = "No usable rows in #{args[:path]} (refusing to wipe snapshot for label=#{label})"
+        msg += "; #{rejects.size} row(s) rejected" if rejects.any?
+        abort msg
+      end
+
       ActiveRecord::Base.transaction do
         Corvid::NpiCcnCrosswalk.where(source_release: label).delete_all
         rows.each_slice(1000) do |batch|
           Corvid::NpiCcnCrosswalk.insert_all(batch)
-        end if rows.any?
+        end
       end
 
       puts "Imported #{rows.size} NPI↔CCN crosswalk rows (label=#{label}, replaced prior snapshot)"
+      if rejects.any?
+        puts "  skipped #{rejects.size} invalid row(s):"
+        rejects.each { |r| puts "    line #{r[:line]}: #{r[:reason]}" }
+      end
+    end
+
+    # Blank → nil (legitimate permissive bound). Garbage → raises so
+    # the row is rejected rather than silently coerced to nil (which
+    # would create an unbounded match window).
+    def parse_optional_date(raw)
+      stripped = raw.to_s.strip
+      return nil if stripped.empty?
+      Date.iso8601(stripped)
+    rescue ArgumentError
+      raise ArgumentError, "invalid date: #{raw.inspect}"
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_14_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,8 +29,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.datetime "updated_at", null: false
     t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
     t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
-    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying, 'medicare_b'::character varying, 'medicare_d'::character varying, 'medicaid'::character varying, 'va_benefits'::character varying, 'private_insurance'::character varying, 'workers_comp'::character varying, 'auto_insurance'::character varying, 'liability_coverage'::character varying, 'state_program'::character varying, 'tribal_program'::character varying, 'charity_care'::character varying]::text[])", name: "corvid_arc_resource_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying, 'checking'::character varying, 'enrolled'::character varying, 'not_enrolled'::character varying, 'denied'::character varying, 'exhausted'::character varying, 'pending_enrollment'::character varying]::text[])", name: "corvid_arc_status_check"
+    t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
   end
 
   create_table "corvid_api_call_logs", force: :cascade do |t|
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
     t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
     t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
-    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying, 'patient_access'::character varying, 'provider_access'::character varying, 'payer_to_payer'::character varying]::text[])", name: "corvid_api_call_logs_api_name_check"
+    t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
   end
 
   create_table "corvid_asc_conversion_factors", force: :cascade do |t|
@@ -99,9 +99,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
     t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
-    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying, 'outbound'::character varying]::text[])", name: "corvid_billing_tx_direction_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "corvid_billing_tx_status_check"
-    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying, 'claim'::character varying, 'claim_status'::character varying, 'remittance'::character varying, 'payment'::character varying]::text[])", name: "corvid_billing_tx_type_check"
+    t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
+    t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
   end
 
   create_table "corvid_cah_facilities", force: :cascade do |t|
@@ -140,7 +140,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying]::text[])", name: "corvid_care_teams_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
   end
 
   create_table "corvid_case_programs", force: :cascade do |t|
@@ -158,7 +158,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
     t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
-    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'pending'::character varying, 'terminated'::character varying]::text[])", name: "corvid_case_programs_enrollment_status_check"
+    t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
   end
 
   create_table "corvid_cases", force: :cascade do |t|
@@ -181,8 +181,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
     t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
     t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
-    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying, 'active_followup'::character varying, 'closure'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_lifecycle_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'closed'::character varying]::text[])", name: "corvid_cases_status_check"
+    t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
   end
 
   create_table "corvid_claim_submissions", force: :cascade do |t|
@@ -216,8 +216,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
     t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
-    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying, 'institutional'::character varying, 'dental'::character varying]::text[])", name: "corvid_claim_submissions_type_check"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'paid'::character varying, 'denied'::character varying, 'appealed'::character varying, 'error'::character varying]::text[])", name: "corvid_claim_submissions_status_check"
+    t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
 
   create_table "corvid_cms_fee_schedule_releases", force: :cascade do |t|
@@ -253,7 +253,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
     t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
     t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'modified'::character varying]::text[])", name: "corvid_committee_reviews_decision_check"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
   end
 
   create_table "corvid_determinations", force: :cascade do |t|
@@ -273,8 +273,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
     t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
     t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
-    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying, 'staff_review'::character varying, 'committee_review'::character varying]::text[])", name: "corvid_determinations_method_check"
-    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying, 'denied'::character varying, 'deferred'::character varying, 'pending_review'::character varying]::text[])", name: "corvid_determinations_outcome_check"
+    t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
+    t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
   end
 
   create_table "corvid_eligibility_checklists", force: :cascade do |t|
@@ -364,6 +364,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
   end
 
+  create_table "corvid_npi_ccn_crosswalks", force: :cascade do |t|
+    t.string "ccn", null: false
+    t.datetime "created_at", null: false
+    t.date "effective_date"
+    t.date "end_date"
+    t.string "npi", null: false
+    t.string "source_release"
+    t.datetime "updated_at", null: false
+    t.index ["ccn"], name: "index_corvid_npi_ccn_crosswalks_on_ccn"
+    t.index ["npi", "ccn", "effective_date"], name: "idx_corvid_npi_ccn_crosswalks_unique", unique: true
+    t.index ["npi"], name: "index_corvid_npi_ccn_crosswalks_on_npi"
+  end
+
   create_table "corvid_opps_apc_weights", force: :cascade do |t|
     t.string "apc_code", null: false
     t.integer "calendar_year", null: false
@@ -401,7 +414,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
     t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
     t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'processing'::character varying, 'succeeded'::character varying, 'failed'::character varying, 'refunded'::character varying]::text[])", name: "corvid_payments_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
   end
 
   create_table "corvid_prc_obligations", force: :cascade do |t|
@@ -494,7 +507,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
     t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
     t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'submitted'::character varying, 'eligibility_review'::character varying, 'management_approval'::character varying, 'alternate_resource_review'::character varying, 'priority_assignment'::character varying, 'committee_review'::character varying, 'exception_review'::character varying, 'authorized'::character varying, 'denied'::character varying, 'deferred'::character varying, 'cancelled'::character varying]::text[])", name: "corvid_prc_referrals_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
   create_table "corvid_tasks", force: :cascade do |t|
@@ -520,8 +533,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
     t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
     t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
     t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
-    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying, 'urgent'::character varying, 'asap'::character varying, 'stat'::character varying]::text[])", name: "corvid_tasks_priority_check"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'in_progress'::character varying, 'completed'::character varying, 'cancelled'::character varying, 'on_hold'::character varying]::text[])", name: "corvid_tasks_status_check"
+    t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
   end
 
   create_table "corvid_zip_localities", force: :cascade do |t|

--- a/test/lib/tasks/cms_nppes_rake_test.rb
+++ b/test/lib/tasks/cms_nppes_rake_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+
+# Asserts the NPPES crosswalk import behaves as a per-release snapshot:
+# a re-import of the same release_label replaces the prior snapshot so
+# that rows CMS dropped from the file don't linger in the DB.
+class CmsNppesRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["cms:nppes:import_crosswalk"].reenable
+    @tmpdir = Dir.mktmpdir
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  test "import_crosswalk loads canonical CSV rows tagged with the release label" do
+    path = File.join(@tmpdir, "crosswalk.csv")
+    File.write(path, <<~CSV)
+      npi,ccn,effective_date,end_date
+      1234567890,451301,2015-01-01,
+      9876543210,451999,2020-01-01,2024-12-31
+    CSV
+
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(path, "nppes_2026_q1")
+
+    rows = Corvid::NpiCcnCrosswalk.where(source_release: "nppes_2026_q1").order(:npi)
+    assert_equal 2, rows.count
+    assert_equal "451301", rows.find_by(npi: "1234567890").ccn
+    assert_equal Date.new(2024, 12, 31),
+                 rows.find_by(npi: "9876543210").end_date
+  end
+
+  test "import_crosswalk replaces the snapshot when re-run with the same release label" do
+    first = File.join(@tmpdir, "first.csv")
+    File.write(first, <<~CSV)
+      npi,ccn,effective_date,end_date
+      1234567890,451301,2015-01-01,
+      9876543210,451999,2020-01-01,
+    CSV
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(first, "nppes_2026_q1")
+    Rake::Task["cms:nppes:import_crosswalk"].reenable
+    assert_equal 2, Corvid::NpiCcnCrosswalk.where(source_release: "nppes_2026_q1").count
+
+    # CMS dropped 9876543210 and added a new row; re-importing under
+    # the same label must reflect the new snapshot exactly.
+    second = File.join(@tmpdir, "second.csv")
+    File.write(second, <<~CSV)
+      npi,ccn,effective_date,end_date
+      1234567890,451301,2015-01-01,
+      5555555555,452000,2024-01-01,
+    CSV
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(second, "nppes_2026_q1")
+
+    snapshot = Corvid::NpiCcnCrosswalk.where(source_release: "nppes_2026_q1")
+    assert_equal 2, snapshot.count
+    assert_nil snapshot.find_by(npi: "9876543210"),
+               "dropped NPI must not linger in DB after snapshot replacement"
+    refute_nil snapshot.find_by(npi: "5555555555")
+  end
+
+  test "import_crosswalk leaves other release-label snapshots untouched" do
+    older = File.join(@tmpdir, "older.csv")
+    File.write(older, "npi,ccn,effective_date,end_date\n1234567890,451301,2015-01-01,\n")
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(older, "nppes_2025_q4")
+    Rake::Task["cms:nppes:import_crosswalk"].reenable
+
+    newer = File.join(@tmpdir, "newer.csv")
+    File.write(newer, "npi,ccn,effective_date,end_date\n9876543210,451999,2020-01-01,\n")
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(newer, "nppes_2026_q1")
+
+    assert_equal 1, Corvid::NpiCcnCrosswalk.where(source_release: "nppes_2025_q4").count
+    assert_equal 1, Corvid::NpiCcnCrosswalk.where(source_release: "nppes_2026_q1").count
+  end
+
+  test "import_crosswalk aborts when given a missing file" do
+    assert_raises(SystemExit) do
+      Rake::Task["cms:nppes:import_crosswalk"].invoke("/no/such/file.csv", "label")
+    end
+  end
+end

--- a/test/lib/tasks/cms_nppes_rake_test.rb
+++ b/test/lib/tasks/cms_nppes_rake_test.rb
@@ -81,4 +81,72 @@ class CmsNppesRakeTest < ActiveSupport::TestCase
       Rake::Task["cms:nppes:import_crosswalk"].invoke("/no/such/file.csv", "label")
     end
   end
+
+  test "import_crosswalk rejects malformed date strings rather than silently coercing to nil" do
+    # A bad date string ActiveRecord can't parse would coerce to nil
+    # and create a row with unbounded effective_date / end_date — a
+    # silently-active crosswalk mapping. We reject the row instead.
+    path = File.join(@tmpdir, "bad_dates.csv")
+    File.write(path, <<~CSV)
+      npi,ccn,effective_date,end_date
+      1234567890,451301,not-a-date,
+      9876543210,451999,2020-01-01,definitely/not/a/date
+      5555555555,452000,2015-01-01,
+    CSV
+
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(path, "nppes_bad")
+
+    rows = Corvid::NpiCcnCrosswalk.where(source_release: "nppes_bad")
+    assert_equal 1, rows.count, "only the well-formed row should be inserted"
+    assert_equal "5555555555", rows.first.npi
+  end
+
+  test "import_crosswalk preserves blank effective_date / end_date as nil" do
+    # NPPES rows may legitimately omit a date — that's a permissive
+    # bound, not a malformed value, and must be distinguished from
+    # garbage input.
+    path = File.join(@tmpdir, "blank_dates.csv")
+    File.write(path, <<~CSV)
+      npi,ccn,effective_date,end_date
+      1234567890,451301,,
+    CSV
+
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(path, "nppes_blank")
+
+    row = Corvid::NpiCcnCrosswalk.find_by!(npi: "1234567890")
+    assert_nil row.effective_date
+    assert_nil row.end_date
+  end
+
+  test "import_crosswalk aborts on a file with missing required headers without wiping the prior snapshot" do
+    seed = File.join(@tmpdir, "seed.csv")
+    File.write(seed, "npi,ccn,effective_date,end_date\n1234567890,451301,2015-01-01,\n")
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(seed, "nppes_keep")
+    Rake::Task["cms:nppes:import_crosswalk"].reenable
+
+    bad = File.join(@tmpdir, "bad_headers.csv")
+    File.write(bad, "provider,facility\n1234567890,451301\n")
+    assert_raises(SystemExit) do
+      Rake::Task["cms:nppes:import_crosswalk"].invoke(bad, "nppes_keep")
+    end
+
+    assert_equal 1, Corvid::NpiCcnCrosswalk.where(source_release: "nppes_keep").count,
+                 "prior snapshot must survive a header-validation abort"
+  end
+
+  test "import_crosswalk aborts on a file that parses to zero usable rows without wiping the prior snapshot" do
+    seed = File.join(@tmpdir, "seed.csv")
+    File.write(seed, "npi,ccn,effective_date,end_date\n1234567890,451301,2015-01-01,\n")
+    Rake::Task["cms:nppes:import_crosswalk"].invoke(seed, "nppes_keep2")
+    Rake::Task["cms:nppes:import_crosswalk"].reenable
+
+    empty = File.join(@tmpdir, "empty_body.csv")
+    File.write(empty, "npi,ccn,effective_date,end_date\n,,,\n")
+    assert_raises(SystemExit) do
+      Rake::Task["cms:nppes:import_crosswalk"].invoke(empty, "nppes_keep2")
+    end
+
+    assert_equal 1, Corvid::NpiCcnCrosswalk.where(source_release: "nppes_keep2").count,
+                 "empty-body file must not silently wipe the prior snapshot"
+  end
 end

--- a/test/models/corvid/asc_facility_test.rb
+++ b/test/models/corvid/asc_facility_test.rb
@@ -42,4 +42,33 @@ class Corvid::AscFacilityTest < ActiveSupport::TestCase
     )
     refute dup.valid?
   end
+
+  test "applies? resolves an NPI vendor_id through the NPI↔CCN crosswalk to a CCN-keyed ASC row" do
+    # CMS iQIES POS file gives us the ASC row keyed by CCN only; the
+    # tribal PRC export may key vendor_id by NPI. Without the crosswalk,
+    # the claim would route to OppsRateProvider instead of AscRateProvider.
+    Corvid::AscFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1)
+    )
+
+    assert Corvid::AscFacility.applies?(vendor_id: "1234567890", on: Date.new(2024, 6, 1)),
+           "NPI vendor_id must match the CCN-keyed ASC row via crosswalk"
+  end
+
+  test "applies? does not match when crosswalk row is outside the service date window" do
+    Corvid::AscFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1), end_date: Date.new(2019, 12, 31)
+    )
+
+    refute Corvid::AscFacility.applies?(vendor_id: "1234567890", on: Date.new(2024, 6, 1)),
+           "NPI billed under a different CCN by 2024, must not match expired crosswalk"
+  end
 end

--- a/test/models/corvid/cah_facility_test.rb
+++ b/test/models/corvid/cah_facility_test.rb
@@ -64,4 +64,34 @@ class Corvid::CahFacilityTest < ActiveSupport::TestCase
     assert Corvid::CahFacility.applies?(vendor_id: "451301", on: Date.new(2022, 6, 1)),
            "within second historical period"
   end
+
+  test "applies? resolves an NPI vendor_id through the NPI↔CCN crosswalk to a CCN-keyed CAH row" do
+    # CMS POS feed gives us the CAH row keyed by CCN only; the tribal
+    # PRC export gives us vendor_id as the facility's NPI. Without the
+    # crosswalk, applies? would miss this match and the 1.01× CAH
+    # multiplier would never fire.
+    Corvid::CahFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1)
+    )
+
+    assert Corvid::CahFacility.applies?(vendor_id: "1234567890", on: Date.new(2024, 6, 1)),
+           "NPI vendor_id must match the CCN-keyed CAH row via crosswalk"
+  end
+
+  test "applies? does not match when crosswalk row is outside the service date window" do
+    Corvid::CahFacility.create!(
+      ccn: "451301", effective_date: Date.new(2015, 1, 1)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1), end_date: Date.new(2019, 12, 31)
+    )
+
+    refute Corvid::CahFacility.applies?(vendor_id: "1234567890", on: Date.new(2024, 6, 1)),
+           "NPI billed under a different CCN by 2024, must not match expired crosswalk"
+  end
 end

--- a/test/models/corvid/npi_ccn_crosswalk_test.rb
+++ b/test/models/corvid/npi_ccn_crosswalk_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::NpiCcnCrosswalkTest < ActiveSupport::TestCase
+  test "valid row requires both npi and ccn" do
+    row = Corvid::NpiCcnCrosswalk.new(npi: "1234567890", ccn: "451301")
+    assert row.valid?
+  end
+
+  test "ccns_for returns matching ccn for an active NPI on the service date" do
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1)
+    )
+    ccns = Corvid::NpiCcnCrosswalk.ccns_for(
+      npi: "1234567890", on: Date.new(2024, 6, 1)
+    )
+    assert_equal [ "451301" ], ccns
+  end
+
+  test "ccns_for returns empty when NPI has no crosswalk row" do
+    ccns = Corvid::NpiCcnCrosswalk.ccns_for(
+      npi: "9999999999", on: Date.new(2024, 6, 1)
+    )
+    assert_equal [], ccns
+  end
+
+  test "ccns_for returns multiple CCNs when an NPI maps to several over time" do
+    # Realistic case: organizational restructure — one NPI changes CCN.
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1), end_date: Date.new(2019, 12, 31)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451999",
+      effective_date: Date.new(2020, 1, 1)
+    )
+    on_2024 = Corvid::NpiCcnCrosswalk.ccns_for(npi: "1234567890", on: Date.new(2024, 6, 1))
+    assert_equal [ "451999" ], on_2024,
+                 "service date 2024 should match the post-2020 row only"
+
+    on_2018 = Corvid::NpiCcnCrosswalk.ccns_for(npi: "1234567890", on: Date.new(2018, 6, 1))
+    assert_equal [ "451301" ], on_2018,
+                 "service date 2018 should match the pre-2020 row only"
+  end
+
+  test "ccns_for returns empty when NPI is blank or service date is nil" do
+    Corvid::NpiCcnCrosswalk.create!(npi: "1234567890", ccn: "451301")
+    assert_equal [], Corvid::NpiCcnCrosswalk.ccns_for(npi: "", on: Date.current)
+    assert_equal [], Corvid::NpiCcnCrosswalk.ccns_for(npi: "1234567890", on: nil)
+  end
+
+  test "ccns_for de-duplicates when the same (npi, ccn) is listed across multiple historical periods" do
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2015, 1, 1), end_date: Date.new(2017, 12, 31)
+    )
+    Corvid::NpiCcnCrosswalk.create!(
+      npi: "1234567890", ccn: "451301",
+      effective_date: Date.new(2018, 1, 1)
+    )
+    ccns = Corvid::NpiCcnCrosswalk.ccns_for(npi: "1234567890", on: Date.new(2024, 6, 1))
+    assert_equal [ "451301" ], ccns
+  end
+end


### PR DESCRIPTION
## Summary
- New `corvid_npi_ccn_crosswalks` table (NPPES-sourced); `Corvid::NpiCcnCrosswalk.ccns_for(npi:, on:)` returns the distinct CCNs an NPI was billing under on the service date.
- `CahFacility.applies?` and `AscFacility.applies?` now resolve NPI vendor_ids through the crosswalk so the 1.01× CAH multiplier fires and ASC routing engages even when the PRC export keys vendor_id by NPI.
- `cms:nppes:import_crosswalk[path,label]` ingests the canonical CSV with per-release snapshot replacement.
- Rakefile now picks up `test/lib/tasks/**/*_test.rb` so rake-task tests run in CI (the existing `cms_ipps_rake_test.rb` was silently skipped previously).

Closes #353

## Test plan
- [x] `bundle exec rake test` — 931 runs, 2089 assertions, 0 failures
- [x] NpiCcnCrosswalk model: 6 tests covering active-window match, time-window filtering, multi-CCN history, de-duplication, and blank-input guards
- [x] CahFacility / AscFacility: new tests asserting NPI vendor_id matches a CCN-keyed facility row via crosswalk, and expired crosswalk windows don't match
- [x] cms:nppes:import_crosswalk: 4 tests covering load, snapshot replacement, label isolation, and missing-file abort

## Follow-ups (not in this PR)
- Standalone NPPES filter/normalizer (the ~10 GB monthly file → canonical CSV against our facility CCN set). Docs in `cms_npi_crosswalk_data.md` describe the recipe; the corvid engine consumes the canonical CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)