### PR TITLE
CI: cache dummy app gems, cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,10 +39,19 @@ jobs:
           ruby-version: "4.0.2"
           bundler-cache: true
 
+      - name: Cache dummy app gems
+        uses: actions/cache@v4
+        with:
+          path: test/dummy/vendor/bundle
+          key: dummy-gems-${{ runner.os }}-ruby-4.0.2-${{ hashFiles('test/dummy/Gemfile.lock') }}
+          restore-keys: |
+            dummy-gems-${{ runner.os }}-ruby-4.0.2-
+
       - name: Install dummy app dependencies
         run: |
           cd test/dummy
-          bundle install
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4
 
       - name: Create and migrate test database
         run: |


### PR DESCRIPTION
## Summary
- Cache `test/dummy/vendor/bundle` keyed on `test/dummy/Gemfile.lock`. The dummy app has its own Gemfile that `ruby/setup-ruby`'s `bundler-cache` does not cover.
- Add concurrency group with `cancel-in-progress: true` so superseded CI runs are cancelled when a new commit lands on the same branch.

## Test plan
- [ ] First run on this branch establishes the dummy-gems cache (cold cache run; expect similar timing to main).
- [ ] Second push to this branch hits the cache (warm cache run; expect 15–30s savings).
- [ ] Compare against baseline runs on main (~1m33s).