### PR TITLE
Lock in calendar-year semantics: Sep 30 and Oct 1 in same CY match

### DIFF
--- a/test/services/corvid/asc_rate_provider_test.rb
+++ b/test/services/corvid/asc_rate_provider_test.rb
@@ -86,6 +86,24 @@ class Corvid::AscRateProviderTest < ActiveSupport::TestCase
     assert_in_delta 1_800.0, jan_1,  0.01, "Jan 1, 2027 should price against CY 2027 rows"
   end
 
+  test "rate_for keeps Sep 30 and Oct 1 in the same calendar year (not fiscal)" do
+    sep_30 = Corvid::AscRateProvider.rate_for(
+      hcpcs_code: "0102T",
+      locality: "NATIONAL",
+      date: Date.new(2026, 9, 30)
+    )
+    oct_1 = Corvid::AscRateProvider.rate_for(
+      hcpcs_code: "0102T",
+      locality: "NATIONAL",
+      date: Date.new(2026, 10, 1)
+    )
+
+    refute_nil sep_30
+    refute_nil oct_1
+    assert_in_delta sep_30, oct_1, 0.001,
+                    "Sep 30 and Oct 1 in same CY should hit identical CY 2026 rows"
+  end
+
   test "rate_for falls back to NATIONAL locality when locality-specific row is missing" do
     rate = Corvid::AscRateProvider.rate_for(
       hcpcs_code: "0102T",


### PR DESCRIPTION
## Summary
- PR #360's boundary test was renamed `Jan 1, not Oct 1` but didn't actually exercise an Oct 1 date.
- Add a same-CY-on-both-sides assertion: a Sep 30 and an Oct 1 date in CY 2026 should produce identical rates (both hit the same CY 2026 rows). A regression that introduces fiscal-year logic would fail loudly.

## Test plan
- [x] `bundle exec rake test_models TEST=test/services/corvid/asc_rate_provider_test.rb` — 12 runs, 18 assertions, 0 failures, 0 errors

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)