### PR TITLE
Adopt Rails Omakase rubocop + add lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.2"
+          bundler-cache: true
+      - run: bundle exec rubocop
+
   test:
     runs-on: ubuntu-latest
     services:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/CyclomaticComplexity:
+  Max: 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 inherit_gem:
   rubocop-rails-omakase: rubocop.yml
 
+AllCops:
+  Exclude:
+    # Rails-generated; regenerated on every migration without Omakase spacing
+    - "**/db/schema.rb"
+
 Style/Documentation:
   Enabled: false
 

--- a/app/models/corvid/care_team.rb
+++ b/app/models/corvid/care_team.rb
@@ -70,10 +70,10 @@ module Corvid
         id: id&.to_s,
         status: status,
         name: name,
-        managingOrganization: facility_identifier.present? ? [{ reference: "Organization/#{facility_identifier}" }] : nil,
+        managingOrganization: facility_identifier.present? ? [ { reference: "Organization/#{facility_identifier}" } ] : nil,
         participant: care_team_members.active.map do |m|
           {
-            role: [{ text: m.role }],
+            role: [ { text: m.role } ],
             member: { reference: "Practitioner/#{m.practitioner_identifier}" }
           }
         end

--- a/app/models/corvid/committee_review.rb
+++ b/app/models/corvid/committee_review.rb
@@ -83,7 +83,7 @@ module Corvid
     end
 
     def summary
-      parts = ["Committee Review — #{committee_date}"]
+      parts = [ "Committee Review — #{committee_date}" ]
       parts << "Decision: #{decision_summary}"
       parts << "Attendees: #{attendees_count}" if attendees_count > 0
       parts << "Documents: #{documents_reviewed_count}" if documents_reviewed_count > 0

--- a/app/models/corvid/eligibility_checklist.rb
+++ b/app/models/corvid/eligibility_checklist.rb
@@ -29,7 +29,7 @@ module Corvid
       management_approved
     ].freeze
 
-    NON_APPROVAL_ITEMS = (ITEMS - [:management_approved]).freeze
+    NON_APPROVAL_ITEMS = (ITEMS - [ :management_approved ]).freeze
 
     # Item metadata: boolean field -> timestamp field, source/by field
     ITEM_FIELDS = {

--- a/app/models/corvid/fee_schedule_entry.rb
+++ b/app/models/corvid/fee_schedule_entry.rb
@@ -8,7 +8,7 @@ module Corvid
     validates :cpt_code, presence: true
     validates :locality, presence: true
     validates :effective_date, presence: true
-    validates :cpt_code, uniqueness: {scope: [:locality, :effective_date]}
+    validates :cpt_code, uniqueness: { scope: [ :locality, :effective_date ] }
 
     scope :current, -> { where(effective_date: ..Date.current).order(effective_date: :desc) }
     scope :for_code, ->(code) { where(cpt_code: code) }

--- a/app/models/corvid/payment.rb
+++ b/app/models/corvid/payment.rb
@@ -45,7 +45,7 @@ module Corvid
       end
 
       event :mark_failed do
-        transitions from: [:pending, :processing], to: :failed
+        transitions from: [ :pending, :processing ], to: :failed
       end
 
       event :mark_refunded do

--- a/app/rulesets/corvid/prc_eligibility_ruleset.rb
+++ b/app/rulesets/corvid/prc_eligibility_ruleset.rb
@@ -28,7 +28,7 @@ module Corvid
 
     CLINICAL_KEYWORDS = %w[chest pain cardiac surgery fracture injury urgent severe chronic failed treatment].freeze
 
-    VALID_COVERAGE_TYPES = ["IHS", "Medicare/IHS", "Private Insurance/IHS", "Medicaid/IHS"].freeze
+    VALID_COVERAGE_TYPES = [ "IHS", "Medicare/IHS", "Private Insurance/IHS", "Medicaid/IHS" ].freeze
 
     # Top-level eligibility: all checks must pass
     def is_eligible(is_tribally_enrolled, meets_residency, has_clinical_necessity, has_payor_coordination)

--- a/app/services/corvid/authorization_wizard.rb
+++ b/app/services/corvid/authorization_wizard.rb
@@ -299,7 +299,7 @@ module Corvid
 
       { success: true, message: message, referral: @prc_referral }
     rescue => e
-      { success: false, errors: [Corvid.sanitize_phi(e.message)] }
+      { success: false, errors: [ Corvid.sanitize_phi(e.message) ] }
     end
 
     # ----------------------------------------------------------------

--- a/app/services/corvid/chs_reporting_service.rb
+++ b/app/services/corvid/chs_reporting_service.rb
@@ -83,7 +83,7 @@ module Corvid
           report.each do |key, value|
             next if value.is_a?(Hash) || value.is_a?(Array)
 
-            csv << [key.to_s.titleize, value]
+            csv << [ key.to_s.titleize, value ]
           end
         end
       end

--- a/app/services/corvid/prior_authorization_api_service.rb
+++ b/app/services/corvid/prior_authorization_api_service.rb
@@ -112,8 +112,8 @@ module Corvid
           resourceType: "ClaimResponse",
           id: referral.referral_identifier,
           status: "active",
-          type: { coding: [{ system: "http://terminology.hl7.org/CodeSystem/claim-type",
-                             code: "professional" }] },
+          type: { coding: [ { system: "http://terminology.hl7.org/CodeSystem/claim-type",
+                             code: "professional" } ] },
           use: "preauthorization",
           patient: { reference: "Patient/#{referral.case.patient_identifier}" },
           created: referral.created_at.iso8601,
@@ -269,7 +269,7 @@ module Corvid
       end
 
       def additional_info_for(referral)
-        ["Additional clinical documentation requested"]
+        [ "Additional clinical documentation requested" ]
       end
     end
   end

--- a/app/services/corvid/prior_authorization_service.rb
+++ b/app/services/corvid/prior_authorization_service.rb
@@ -78,7 +78,7 @@ module Corvid
         within_window = days_since <= 3
         needs_retro = !within_window
 
-        messages = ["72-hour notification window"]
+        messages = [ "72-hour notification window" ]
         messages << "retroactive authorization required" if needs_retro
 
         AuthorizationResult.new(

--- a/corvid.gemspec
+++ b/corvid.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/corvid/version"
 Gem::Specification.new do |spec|
   spec.name        = "corvid"
   spec.version     = Corvid::VERSION
-  spec.authors     = ["Lakeraven"]
-  spec.email       = ["eng@lakeraven.com"]
+  spec.authors     = [ "Lakeraven" ]
+  spec.email       = [ "eng@lakeraven.com" ]
   spec.homepage    = "https://github.com/lakeraven/corvid"
   spec.summary     = "Case management engine for healthcare, social services, and benefit programs"
   spec.description = "EHR-agnostic Rails engine for managing service authorization workflows, " \

--- a/db/migrate/20260415000001_create_corvid_eligibility_checklists.rb
+++ b/db/migrate/20260415000001_create_corvid_eligibility_checklists.rb
@@ -46,7 +46,7 @@ class CreateCorvidEligibilityChecklists < ActiveRecord::Migration[8.1]
     end
 
     add_index :corvid_eligibility_checklists,
-              [:tenant_identifier, :facility_identifier],
+              [ :tenant_identifier, :facility_identifier ],
               name: "idx_corvid_elig_checklists_tenant_facility"
     add_index :corvid_eligibility_checklists,
               :prc_referral_id,

--- a/db/migrate/20260415000004_create_corvid_billing_tables.rb
+++ b/db/migrate/20260415000004_create_corvid_billing_tables.rb
@@ -20,8 +20,8 @@ class CreateCorvidBillingTables < ActiveRecord::Migration[8.1]
       t.string :error_message
       t.timestamps
     end
-    add_index :corvid_billing_transactions, [:tenant_identifier, :transaction_type]
-    add_index :corvid_billing_transactions, [:tenant_identifier, :reference_identifier]
+    add_index :corvid_billing_transactions, [ :tenant_identifier, :transaction_type ]
+    add_index :corvid_billing_transactions, [ :tenant_identifier, :reference_identifier ]
     add_check_constraint :corvid_billing_transactions,
       "transaction_type IN (#{TRANSACTION_TYPES.map { |s| "'#{s}'" }.join(',')})",
       name: "corvid_billing_tx_type_check"
@@ -57,8 +57,8 @@ class CreateCorvidBillingTables < ActiveRecord::Migration[8.1]
       t.string :provider_type
       t.timestamps
     end
-    add_index :corvid_claim_submissions, [:tenant_identifier, :status]
-    add_index :corvid_claim_submissions, [:tenant_identifier, :patient_identifier]
+    add_index :corvid_claim_submissions, [ :tenant_identifier, :status ]
+    add_index :corvid_claim_submissions, [ :tenant_identifier, :patient_identifier ]
     add_index :corvid_claim_submissions, :claim_identifier, unique: true
     add_check_constraint :corvid_claim_submissions,
       "status IN (#{CLAIM_STATUSES.map { |s| "'#{s}'" }.join(',')})",
@@ -76,8 +76,8 @@ class CreateCorvidBillingTables < ActiveRecord::Migration[8.1]
       t.string :claim_submission_identifier
       t.timestamps
     end
-    add_index :corvid_payments, [:tenant_identifier, :status]
-    add_index :corvid_payments, [:tenant_identifier, :patient_identifier]
+    add_index :corvid_payments, [ :tenant_identifier, :status ]
+    add_index :corvid_payments, [ :tenant_identifier, :patient_identifier ]
     add_index :corvid_payments, :payment_identifier, unique: true
     add_check_constraint :corvid_payments,
       "status IN (#{PAYMENT_STATUSES.map { |s| "'#{s}'" }.join(',')})",

--- a/db/migrate/20260424000001_create_corvid_case_programs.rb
+++ b/db/migrate/20260424000001_create_corvid_case_programs.rb
@@ -16,9 +16,9 @@ class CreateCorvidCasePrograms < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :corvid_case_programs, [:tenant_identifier, :facility_identifier], name: "idx_corvid_case_programs_tenant_facility"
-    add_index :corvid_case_programs, [:case_id, :program_code], unique: true, name: "idx_corvid_case_programs_case_code"
-    add_index :corvid_case_programs, [:tenant_identifier, :enrollment_status], name: "idx_corvid_case_programs_tenant_status"
+    add_index :corvid_case_programs, [ :tenant_identifier, :facility_identifier ], name: "idx_corvid_case_programs_tenant_facility"
+    add_index :corvid_case_programs, [ :case_id, :program_code ], unique: true, name: "idx_corvid_case_programs_case_code"
+    add_index :corvid_case_programs, [ :tenant_identifier, :enrollment_status ], name: "idx_corvid_case_programs_tenant_status"
     add_check_constraint :corvid_case_programs,
       "enrollment_status IN (#{ENROLLMENT_STATUSES.map { |s| "'#{s}'" }.join(',')})",
       name: "corvid_case_programs_enrollment_status_check"

--- a/db/migrate/20260503000001_create_corvid_repricing_tables.rb
+++ b/db/migrate/20260503000001_create_corvid_repricing_tables.rb
@@ -20,7 +20,7 @@ class CreateCorvidRepricingTables < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :corvid_fee_schedule_entries, [:cpt_code, :locality, :effective_date],
+    add_index :corvid_fee_schedule_entries, [ :cpt_code, :locality, :effective_date ],
       unique: true, name: "idx_corvid_fee_schedule_unique"
     add_index :corvid_fee_schedule_entries, :cpt_code
     add_index :corvid_fee_schedule_entries, :effective_date

--- a/features/step_definitions/billing_remaining_steps.rb
+++ b/features/step_definitions/billing_remaining_steps.rb
@@ -29,7 +29,7 @@ Given("no claim exists with Stedi ID {string}") do |stedi_id|
   Corvid.adapter.add_remittance("REM_ORPHAN_#{stedi_id}", {
     remittance_identifier: "REM_ORPHAN_#{stedi_id}",
     payer_name: "Test Payer", payment_date: Date.current, total_paid: 100.00,
-    line_items: [{ claim_identifier: stedi_id, paid_amount: 100.00 }]
+    line_items: [ { claim_identifier: stedi_id, paid_amount: 100.00 } ]
   })
 end
 
@@ -180,8 +180,8 @@ Given("a remittance includes denial for {string} with reason {string}") do |clai
   Corvid.adapter.add_remittance("REM_DENY_SPEC_#{claim_id}", {
     remittance_identifier: "REM_DENY_SPEC_#{claim_id}", payer_name: "Test Payer",
     payment_date: Date.current, total_paid: 0,
-    line_items: [{ claim_identifier: claim_id, paid_amount: 0,
-                   status: "denied", denial_reason: reason }]
+    line_items: [ { claim_identifier: claim_id, paid_amount: 0,
+                   status: "denied", denial_reason: reason } ]
   })
 end
 
@@ -200,18 +200,18 @@ Given("a remittance includes payment for {string}:") do |claim_id, table|
   # Parse adjustment like "CO-45:$100.00"
   adjustment_amount = adjustment_raw.split(":").last.to_s.gsub("$", "").to_f
   # Adjustment codes
-  codes = [adjustment_raw.split(":").first, denial_raw.split(":").first].compact.reject(&:empty?)
+  codes = [ adjustment_raw.split(":").first, denial_raw.split(":").first ].compact.reject(&:empty?)
 
   Corvid.adapter.add_remittance("REM_ADJ_SPEC_#{claim_id}", {
     remittance_identifier: "REM_ADJ_SPEC_#{claim_id}", payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: paid_amount,
-    line_items: [{
+    line_items: [ {
       claim_identifier: claim_id,
       paid_amount: paid_amount,
       adjustment_amount: adjustment_amount,
       adjustment_codes: codes
-    }]
+    } ]
   })
 end
 

--- a/features/step_definitions/billing_undefined_steps.rb
+++ b/features/step_definitions/billing_undefined_steps.rb
@@ -27,7 +27,7 @@ Given("there are paid claim submissions from multiple providers") do
 end
 
 Given("there are paid claim submissions across multiple quarters") do
-  [0, 3, 6, 9].each_with_index do |month_offset, i|
+  [ 0, 3, 6, 9 ].each_with_index do |month_offset, i|
     Corvid::ClaimSubmission.create!(
       tenant_identifier: @tenant, facility_identifier: @facility,
       patient_identifier: "pt_art6_q#{i}",
@@ -588,7 +588,7 @@ Given("a remittance exists with ID {string}") do |id|
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 250.00,
-    line_items: [{ claim_identifier: "CLM_X", paid_amount: 250.00 }]
+    line_items: [ { claim_identifier: "CLM_X", paid_amount: 250.00 } ]
   })
   @remittance_identifier = id
 end
@@ -628,7 +628,7 @@ Given("a remittance includes payment for {string}") do |claim_id|
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: 150.00,
-    line_items: [{ claim_identifier: claim_id, paid_amount: 150.00 }]
+    line_items: [ { claim_identifier: claim_id, paid_amount: 150.00 } ]
   })
 end
 
@@ -638,7 +638,7 @@ Given("a remittance includes payment for {string} with amount {string}") do |cla
     payer_name: "Test Payer",
     payment_date: Date.current,
     total_paid: amount.gsub("$", "").to_f,
-    line_items: [{ claim_identifier: claim_id, paid_amount: amount.gsub("$", "").to_f }]
+    line_items: [ { claim_identifier: claim_id, paid_amount: amount.gsub("$", "").to_f } ]
   })
 end
 

--- a/features/step_definitions/case_management_dashboard_steps.rb
+++ b/features/step_definitions/case_management_dashboard_steps.rb
@@ -80,7 +80,7 @@ end
 
 When("I view the case management dashboard") do
   @dashboard_metrics = Corvid::CaseDashboardService.metrics(
-    care_team_ids: [@care_team.id],
+    care_team_ids: [ @care_team.id ],
     provider_identifier: @provider_identifier
   )
 end
@@ -92,7 +92,7 @@ end
 
 When("the CaseDashboardService computes metrics") do
   @dashboard_metrics = Corvid::CaseDashboardService.metrics(
-    care_team_ids: [@care_team.id],
+    care_team_ids: [ @care_team.id ],
     provider_identifier: @provider_identifier
   )
 end
@@ -132,7 +132,7 @@ Then("the service should be read-only with no side effects") do
   # Dashboard metrics is a pure read — no records created/updated
   count_before = Corvid::Case.count
   Corvid::CaseDashboardService.metrics(
-    care_team_ids: [@care_team.id],
+    care_team_ids: [ @care_team.id ],
     provider_identifier: @provider_identifier
   )
   assert_equal count_before, Corvid::Case.count

--- a/features/step_definitions/claims_submission_steps.rb
+++ b/features/step_definitions/claims_submission_steps.rb
@@ -122,11 +122,11 @@ end
 
 When("Stedi reports the claim status changed to {string}") do |new_status|
   mapped = case new_status.downcase
-           when "accepted" then "accepted"
-           when "rejected" then "rejected"
-           when "paid" then "paid"
-           else new_status.downcase
-           end
+  when "accepted" then "accepted"
+  when "rejected" then "rejected"
+  when "paid" then "paid"
+  else new_status.downcase
+  end
   Corvid.adapter.add_claim(@claim_submission.claim_identifier, { status: mapped })
   @claim_submission.check_status!
 end

--- a/features/step_definitions/committee_review_steps.rb
+++ b/features/step_definitions/committee_review_steps.rb
@@ -94,7 +94,7 @@ When("I add {int} conditions to the committee review") do |count|
 end
 
 Given("committee reviews scheduled for tomorrow and next week and next month") do
-  [1.day.from_now, 5.days.from_now, 35.days.from_now].each_with_index do |date, i|
+  [ 1.day.from_now, 5.days.from_now, 35.days.from_now ].each_with_index do |date, i|
     Corvid::CommitteeReview.create!(
       prc_referral: @referral,
       committee_date: date.to_date,

--- a/features/step_definitions/determinations_audit_trail_steps.rb
+++ b/features/step_definitions/determinations_audit_trail_steps.rb
@@ -30,7 +30,7 @@ Given("the case has {int} determinations") do |count|
 end
 
 When("the system performs an automated eligibility check") do
-  @eligibility_result = { eligible: true, reasons: ["Valid enrollment", "In service area"] }
+  @eligibility_result = { eligible: true, reasons: [ "Valid enrollment", "In service area" ] }
 end
 
 When("the patient is found eligible") do
@@ -59,7 +59,7 @@ When("staff denies eligibility with reason {string}") do |reason|
     outcome: "denied",
     decision_method: "staff_review",
     determined_by_identifier: "pr_staff_001",
-    reasons: [reason]
+    reasons: [ reason ]
   )
 end
 
@@ -67,7 +67,7 @@ When("the referral is deferred pending Medicare enrollment") do
   @referral.record_determination!(
     outcome: "deferred",
     decision_method: "automated",
-    reasons: ["Medicare enrollment required"]
+    reasons: [ "Medicare enrollment required" ]
   )
 end
 

--- a/lib/corvid/adapters/fhir_adapter.rb
+++ b/lib/corvid/adapters/fhir_adapter.rb
@@ -341,10 +341,10 @@ module Corvid
       def execute_http(method, url, body = nil)
         uri = URI.parse(url)
         request = case method
-                  when :get  then Net::HTTP::Get.new(uri)
-                  when :post then Net::HTTP::Post.new(uri).tap { |r| r.body = body }
-                  when :put  then Net::HTTP::Put.new(uri).tap { |r| r.body = body }
-                  end
+        when :get  then Net::HTTP::Get.new(uri)
+        when :post then Net::HTTP::Post.new(uri).tap { |r| r.body = body }
+        when :put  then Net::HTTP::Put.new(uri).tap { |r| r.body = body }
+        end
         @default_headers.each { |k, v| request[k] = v }
         request["Authorization"] = "Bearer #{@bearer_token}" if @bearer_token
 

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -375,7 +375,7 @@ module Corvid
       end
 
       def search_payers(query)
-        [{ payer_identifier: "MOCK_PAYER", name: "Mock Payer matching '#{query}'" }]
+        [ { payer_identifier: "MOCK_PAYER", name: "Mock Payer matching '#{query}'" } ]
       end
 
       def process_payment(amount_cents:, patient_identifier:, description:)

--- a/lib/corvid/rules_engine.rb
+++ b/lib/corvid/rules_engine.rb
@@ -38,7 +38,7 @@ module Corvid
       end
 
       def all_facts
-        result = [self]
+        result = [ self ]
         reasons.each { |reason| result.concat(reason.all_facts) }
         result
       end

--- a/test/adapters/corvid/baseroll_adapter_test.rb
+++ b/test/adapters/corvid/baseroll_adapter_test.rb
@@ -33,7 +33,7 @@ module Corvid
       @adapter.stub_responses["/api/v1/people/1"] = {
         "member_status" => "enrolled",
         "membership_number" => "YN-12345",
-        "enrolled_tribe" => {"name" => "Test Tribe"},
+        "enrolled_tribe" => { "name" => "Test Tribe" },
         "born_on" => "1980-05-15"
       }
 
@@ -78,7 +78,7 @@ module Corvid
     test "verify_tribal_enrollment includes member_status" do
       @adapter.stub_responses["/api/v1/people/1"] = {
         "member_status" => "enrolled",
-        "enrolled_tribe" => {"name" => "Test Tribe"}
+        "enrolled_tribe" => { "name" => "Test Tribe" }
       }
 
       result = @adapter.verify_tribal_enrollment("1")
@@ -131,7 +131,7 @@ module Corvid
     test "verify_residency detects on-reservation address" do
       @adapter.stub_responses["/api/v1/people/1"] = {
         "addresses" => [
-          {"on_reservation" => true, "city" => "Toppenish", "service_area" => "Yakama Reservation"}
+          { "on_reservation" => true, "city" => "Toppenish", "service_area" => "Yakama Reservation" }
         ]
       }
 
@@ -145,7 +145,7 @@ module Corvid
     test "verify_residency returns false when off-reservation" do
       @adapter.stub_responses["/api/v1/people/1"] = {
         "addresses" => [
-          {"on_reservation" => false, "city" => "Seattle"}
+          { "on_reservation" => false, "city" => "Seattle" }
         ]
       }
 
@@ -201,7 +201,7 @@ module Corvid
       call_count = 0
       @adapter.define_singleton_method(:get) do |path, _params = {}|
         call_count += 1
-        {"member_status" => "enrolled", "enrolled_tribe" => {"name" => "T"}, "ssn_present" => true, "born_on" => "1980-01-01", "addresses" => []}
+        { "member_status" => "enrolled", "enrolled_tribe" => { "name" => "T" }, "ssn_present" => true, "born_on" => "1980-01-01", "addresses" => [] }
       end
 
       @adapter.verify_tribal_enrollment("1")

--- a/test/corvid/program_registry_test.rb
+++ b/test/corvid/program_registry_test.rb
@@ -102,7 +102,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
     Corvid::ProgramRegistry.register(
       "frozen_test",
       display_name: "Frozen Test",
-      milestones: [{ key: "x", description: "x", days_after_anchor: 0, required: true }]
+      milestones: [ { key: "x", description: "x", days_after_anchor: 0, required: true } ]
     )
     entry = Corvid::ProgramRegistry.find("frozen_test")
     assert entry.milestones.frozen?, "expected milestones array to be frozen"
@@ -143,7 +143,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
     Corvid::ProgramRegistry.register(
       "default_required",
       display_name: "Default Required",
-      milestones: [{ key: "x", description: "x", days_after_anchor: 0 }]
+      milestones: [ { key: "x", description: "x", days_after_anchor: 0 } ]
     )
     assert_equal false, Corvid::ProgramRegistry.find("default_required").milestones.first[:required]
   end
@@ -153,7 +153,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "missing_key",
         display_name: "Missing Key",
-        milestones: [{ description: "no key", days_after_anchor: 0 }]
+        milestones: [ { description: "no key", days_after_anchor: 0 } ]
       )
     end
   end
@@ -163,7 +163,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "missing_desc",
         display_name: "Missing Desc",
-        milestones: [{ key: "x", days_after_anchor: 0 }]
+        milestones: [ { key: "x", days_after_anchor: 0 } ]
       )
     end
   end
@@ -173,7 +173,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "missing_days",
         display_name: "Missing Days",
-        milestones: [{ key: "x", description: "x" }]
+        milestones: [ { key: "x", description: "x" } ]
       )
     end
   end
@@ -183,7 +183,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "bad_days",
         display_name: "Bad Days",
-        milestones: [{ key: "x", description: "x", days_after_anchor: "soon" }]
+        milestones: [ { key: "x", description: "x", days_after_anchor: "soon" } ]
       )
     end
   end
@@ -193,7 +193,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "bad_required",
         display_name: "Bad Required",
-        milestones: [{ key: "x", description: "x", days_after_anchor: 0, required: "true" }]
+        milestones: [ { key: "x", description: "x", days_after_anchor: 0, required: "true" } ]
       )
     end
   end
@@ -203,7 +203,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
       Corvid::ProgramRegistry.register(
         "bad_shape",
         display_name: "Bad Shape",
-        milestones: ["not a hash"]
+        milestones: [ "not a hash" ]
       )
     end
   end
@@ -212,7 +212,7 @@ class Corvid::ProgramRegistryTest < Minitest::Test
     Corvid::ProgramRegistry.register(
       "frozen_hashes",
       display_name: "Frozen Hashes",
-      milestones: [{ key: "x", description: "x", days_after_anchor: 0, required: true }]
+      milestones: [ { key: "x", description: "x", days_after_anchor: 0, required: true } ]
     )
     milestone = Corvid::ProgramRegistry.find("frozen_hashes").milestones.first
     assert milestone.frozen?, "expected milestone hash to be frozen"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -27,8 +27,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "response_data_token"
     t.string "status", default: "not_checked", null: false
     t.datetime "updated_at", null: false
-    t.index [ "prc_referral_id", "resource_type" ], name: "idx_corvid_arc_referral_type", unique: true
-    t.index [ "prc_referral_id" ], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
+    t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
+    t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
     t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
     t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
   end
@@ -43,9 +43,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "patient_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "tenant_identifier", "api_name", "called_at", "app_identifier" ], name: "idx_corvid_api_calls_tenant_api_time_app"
-    t.index [ "tenant_identifier", "api_name", "called_at", "patient_identifier" ], name: "idx_corvid_api_calls_tenant_api_time_patient"
-    t.index [ "tenant_identifier", "api_name", "endpoint", "called_at" ], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
+    t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
+    t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
+    t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
     t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
   end
 
@@ -57,7 +57,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index [ "calendar_year", "locality" ], name: "idx_corvid_asc_conversion_factors_cy_locality", unique: true
+    t.index ["calendar_year", "locality"], name: "idx_corvid_asc_conversion_factors_cy_locality", unique: true
   end
 
   create_table "corvid_asc_facilities", force: :cascade do |t|
@@ -69,8 +69,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index [ "ccn", "effective_date" ], name: "idx_corvid_asc_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
-    t.index [ "npi", "effective_date" ], name: "idx_corvid_asc_npi_effective", unique: true, where: "(npi IS NOT NULL)"
+    t.index ["ccn", "effective_date"], name: "idx_corvid_asc_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index ["npi", "effective_date"], name: "idx_corvid_asc_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_asc_hcpcs_rates", force: :cascade do |t|
@@ -81,7 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "payment_weight", precision: 10, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index [ "calendar_year", "hcpcs_code" ], name: "idx_corvid_asc_hcpcs_rates_cy_hcpcs", unique: true
+    t.index ["calendar_year", "hcpcs_code"], name: "idx_corvid_asc_hcpcs_rates_cy_hcpcs", unique: true
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -97,8 +97,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.string "transaction_type", null: false
     t.datetime "updated_at", null: false
-    t.index [ "tenant_identifier", "reference_identifier" ], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
-    t.index [ "tenant_identifier", "transaction_type" ], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
+    t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
+    t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
     t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
     t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
@@ -113,8 +113,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index [ "ccn", "effective_date" ], name: "idx_corvid_cah_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
-    t.index [ "npi", "effective_date" ], name: "idx_corvid_cah_npi_effective", unique: true, where: "(npi IS NOT NULL)"
+    t.index ["ccn", "effective_date"], name: "idx_corvid_cah_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index ["npi", "effective_date"], name: "idx_corvid_cah_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_care_team_members", force: :cascade do |t|
@@ -126,9 +126,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "role"
     t.date "start_date"
     t.datetime "updated_at", null: false
-    t.index [ "care_team_id", "practitioner_identifier" ], name: "idx_corvid_ctm_team_practitioner", unique: true
-    t.index [ "care_team_id" ], name: "index_corvid_care_team_members_on_care_team_id"
-    t.index [ "practitioner_identifier" ], name: "index_corvid_care_team_members_on_practitioner_identifier"
+    t.index ["care_team_id", "practitioner_identifier"], name: "idx_corvid_ctm_team_practitioner", unique: true
+    t.index ["care_team_id"], name: "index_corvid_care_team_members_on_care_team_id"
+    t.index ["practitioner_identifier"], name: "index_corvid_care_team_members_on_practitioner_identifier"
   end
 
   create_table "corvid_care_teams", force: :cascade do |t|
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "active", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
+    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
   end
 
@@ -154,10 +154,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "program_name", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "case_id", "program_code" ], name: "idx_corvid_case_programs_case_code", unique: true
-    t.index [ "case_id" ], name: "index_corvid_case_programs_on_case_id"
-    t.index [ "tenant_identifier", "enrollment_status" ], name: "idx_corvid_case_programs_tenant_status"
-    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_corvid_case_programs_tenant_facility"
+    t.index ["case_id", "program_code"], name: "idx_corvid_case_programs_case_code", unique: true
+    t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
+    t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
+    t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
     t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
   end
 
@@ -178,9 +178,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "active", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "care_team_id" ], name: "index_corvid_cases_on_care_team_id"
-    t.index [ "tenant_identifier", "facility_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
-    t.index [ "tenant_identifier", "status" ], name: "index_corvid_cases_on_tenant_identifier_and_status"
+    t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
+    t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
+    t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
     t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
   end
@@ -213,9 +213,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "submitted_at"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "claim_identifier" ], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
-    t.index [ "tenant_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
-    t.index [ "tenant_identifier", "status" ], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
+    t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
+    t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
+    t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
     t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
@@ -229,7 +229,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "source_checksum_sha256", null: false
     t.datetime "updated_at", null: false
     t.integer "year", null: false
-    t.index [ "year" ], name: "index_corvid_cms_fee_schedule_releases_on_year", unique: true
+    t.index ["year"], name: "index_corvid_cms_fee_schedule_releases_on_year", unique: true
   end
 
   create_table "corvid_committee_reviews", force: :cascade do |t|
@@ -250,9 +250,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "reviewer_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "committee_date" ], name: "index_corvid_committee_reviews_on_committee_date"
-    t.index [ "prc_referral_id" ], name: "index_corvid_committee_reviews_on_prc_referral_id"
-    t.index [ "tenant_identifier", "decision" ], name: "idx_on_tenant_identifier_decision_51d5d49df2"
+    t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
+    t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
+    t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
     t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
   end
 
@@ -269,10 +269,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "reasons_token"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "determinable_type", "determinable_id" ], name: "idx_on_determinable_type_determinable_id_6da50e3199"
-    t.index [ "determinable_type", "determinable_id" ], name: "index_corvid_determinations_on_determinable"
-    t.index [ "determined_at" ], name: "index_corvid_determinations_on_determined_at"
-    t.index [ "tenant_identifier", "outcome" ], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
+    t.index ["determinable_type", "determinable_id"], name: "idx_on_determinable_type_determinable_id_6da50e3199"
+    t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
+    t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
+    t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
     t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
     t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
   end
@@ -304,8 +304,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "residency_verified_at"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "prc_referral_id" ], name: "idx_corvid_elig_checklists_referral_unique", unique: true
-    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_corvid_elig_checklists_tenant_facility"
+    t.index ["prc_referral_id"], name: "idx_corvid_elig_checklists_referral_unique", unique: true
+    t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_elig_checklists_tenant_facility"
   end
 
   create_table "corvid_fee_schedule_entries", force: :cascade do |t|
@@ -323,9 +323,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "updated_at", null: false
     t.decimal "work_gpci", precision: 8, scale: 4
     t.decimal "work_rvu", precision: 8, scale: 4
-    t.index [ "cpt_code", "locality", "effective_date" ], name: "idx_corvid_fee_schedule_unique", unique: true
-    t.index [ "cpt_code" ], name: "index_corvid_fee_schedule_entries_on_cpt_code"
-    t.index [ "effective_date" ], name: "index_corvid_fee_schedule_entries_on_effective_date"
+    t.index ["cpt_code", "locality", "effective_date"], name: "idx_corvid_fee_schedule_unique", unique: true
+    t.index ["cpt_code"], name: "index_corvid_fee_schedule_entries_on_cpt_code"
+    t.index ["effective_date"], name: "index_corvid_fee_schedule_entries_on_effective_date"
   end
 
   create_table "corvid_fee_schedules", force: :cascade do |t|
@@ -339,8 +339,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.string "tiers_token"
     t.datetime "updated_at", null: false
-    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_4bbe5beaee"
-    t.index [ "tenant_identifier", "program" ], name: "index_corvid_fee_schedules_on_tenant_identifier_and_program"
+    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_4bbe5beaee"
+    t.index ["tenant_identifier", "program"], name: "index_corvid_fee_schedules_on_tenant_identifier_and_program"
   end
 
   create_table "corvid_ipps_drg_weights", force: :cascade do |t|
@@ -350,7 +350,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "relative_weight", precision: 8, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index [ "fiscal_year", "drg_code" ], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
+    t.index ["fiscal_year", "drg_code"], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
   end
 
   create_table "corvid_ipps_hospital_rates", force: :cascade do |t|
@@ -361,7 +361,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index [ "fiscal_year", "locality" ], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
+    t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
   end
 
   create_table "corvid_npi_ccn_crosswalks", force: :cascade do |t|
@@ -372,9 +372,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi", null: false
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index [ "ccn" ], name: "index_corvid_npi_ccn_crosswalks_on_ccn"
-    t.index [ "source_release", "npi", "ccn", "effective_date" ], name: "idx_corvid_npi_ccn_crosswalks_unique", unique: true
-    t.index [ "npi" ], name: "index_corvid_npi_ccn_crosswalks_on_npi"
+    t.index ["ccn"], name: "index_corvid_npi_ccn_crosswalks_on_ccn"
+    t.index ["source_release", "npi", "ccn", "effective_date"], name: "idx_corvid_npi_ccn_crosswalks_unique", unique: true
+    t.index ["npi"], name: "index_corvid_npi_ccn_crosswalks_on_npi"
   end
 
   create_table "corvid_opps_apc_weights", force: :cascade do |t|
@@ -384,7 +384,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "relative_weight", precision: 8, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index [ "calendar_year", "apc_code" ], name: "idx_corvid_opps_apc_weights_cy_apc", unique: true
+    t.index ["calendar_year", "apc_code"], name: "idx_corvid_opps_apc_weights_cy_apc", unique: true
   end
 
   create_table "corvid_opps_conversion_factors", force: :cascade do |t|
@@ -395,7 +395,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index [ "calendar_year", "locality" ], name: "idx_corvid_opps_conversion_factors_cy_locality", unique: true
+    t.index ["calendar_year", "locality"], name: "idx_corvid_opps_conversion_factors_cy_locality", unique: true
   end
 
   create_table "corvid_payments", force: :cascade do |t|
@@ -411,9 +411,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "pending", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "payment_identifier" ], name: "index_corvid_payments_on_payment_identifier", unique: true
-    t.index [ "tenant_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
-    t.index [ "tenant_identifier", "status" ], name: "index_corvid_payments_on_tenant_identifier_and_status"
+    t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
+    t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
+    t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
   end
 
@@ -436,10 +436,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.string "vendor_id"
-    t.index [ "tenant_identifier", "fiscal_year" ], name: "idx_on_tenant_identifier_fiscal_year_4256632613"
-    t.index [ "tenant_identifier", "obligation_id" ], name: "idx_corvid_prc_obligations_tenant_oblig", unique: true
-    t.index [ "tenant_identifier", "service_date" ], name: "idx_on_tenant_identifier_service_date_6d2dcaef53"
-    t.index [ "tenant_identifier", "vendor_id" ], name: "idx_on_tenant_identifier_vendor_id_08d803412f"
+    t.index ["tenant_identifier", "fiscal_year"], name: "idx_on_tenant_identifier_fiscal_year_4256632613"
+    t.index ["tenant_identifier", "obligation_id"], name: "idx_corvid_prc_obligations_tenant_oblig", unique: true
+    t.index ["tenant_identifier", "service_date"], name: "idx_on_tenant_identifier_service_date_6d2dcaef53"
+    t.index ["tenant_identifier", "vendor_id"], name: "idx_on_tenant_identifier_vendor_id_08d803412f"
   end
 
   create_table "corvid_prc_overpayment_analyses", force: :cascade do |t|
@@ -457,9 +457,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "recovery_confidence", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "prc_obligation_id", "analyzed_at" ], name: "idx_corvid_prc_overpay_oblig_time"
-    t.index [ "prc_obligation_id" ], name: "idx_corvid_prc_overpay_oblig"
-    t.index [ "tenant_identifier", "recovery_confidence" ], name: "idx_corvid_prc_overpay_confidence"
+    t.index ["prc_obligation_id", "analyzed_at"], name: "idx_corvid_prc_overpay_oblig_time"
+    t.index ["prc_obligation_id"], name: "idx_corvid_prc_overpay_oblig"
+    t.index ["tenant_identifier", "recovery_confidence"], name: "idx_corvid_prc_overpay_confidence"
   end
 
   create_table "corvid_prc_payments", force: :cascade do |t|
@@ -473,8 +473,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.string "vendor_name"
-    t.index [ "prc_obligation_id" ], name: "idx_corvid_prc_payments_oblig"
-    t.index [ "tenant_identifier", "payment_id" ], name: "idx_corvid_prc_payments_tenant_pmt", unique: true
+    t.index ["prc_obligation_id"], name: "idx_corvid_prc_payments_oblig"
+    t.index ["tenant_identifier", "payment_id"], name: "idx_corvid_prc_payments_tenant_pmt", unique: true
   end
 
   create_table "corvid_prc_referrals", force: :cascade do |t|
@@ -504,9 +504,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "draft", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "case_id" ], name: "index_corvid_prc_referrals_on_case_id"
-    t.index [ "tenant_identifier", "facility_identifier", "referral_identifier" ], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
-    t.index [ "tenant_identifier", "status" ], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
+    t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
+    t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
+    t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
@@ -528,11 +528,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "taskable_type", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index [ "taskable_type", "taskable_id", "milestone_key" ], name: "idx_corvid_tasks_taskable_milestone", unique: true, where: "(milestone_key IS NOT NULL)"
-    t.index [ "taskable_type", "taskable_id" ], name: "index_corvid_tasks_on_taskable"
-    t.index [ "tenant_identifier", "assignee_identifier" ], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
-    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
-    t.index [ "tenant_identifier", "status" ], name: "index_corvid_tasks_on_tenant_identifier_and_status"
+    t.index ["taskable_type", "taskable_id", "milestone_key"], name: "idx_corvid_tasks_taskable_milestone", unique: true, where: "(milestone_key IS NOT NULL)"
+    t.index ["taskable_type", "taskable_id"], name: "index_corvid_tasks_on_taskable"
+    t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
+    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
+    t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
     t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
   end
@@ -544,8 +544,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "state"
     t.datetime "updated_at", null: false
     t.string "zip_code", null: false
-    t.index [ "locality" ], name: "index_corvid_zip_localities_on_locality"
-    t.index [ "zip_code" ], name: "index_corvid_zip_localities_on_zip_code", unique: true
+    t.index ["locality"], name: "index_corvid_zip_localities_on_locality"
+    t.index ["zip_code"], name: "index_corvid_zip_localities_on_zip_code", unique: true
   end
 
   add_foreign_key "corvid_alternate_resource_checks", "corvid_prc_referrals", column: "prc_referral_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -27,8 +27,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "response_data_token"
     t.string "status", default: "not_checked", null: false
     t.datetime "updated_at", null: false
-    t.index ["prc_referral_id", "resource_type"], name: "idx_corvid_arc_referral_type", unique: true
-    t.index ["prc_referral_id"], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
+    t.index [ "prc_referral_id", "resource_type" ], name: "idx_corvid_arc_referral_type", unique: true
+    t.index [ "prc_referral_id" ], name: "index_corvid_alternate_resource_checks_on_prc_referral_id"
     t.check_constraint "resource_type::text = ANY (ARRAY['medicare_a'::character varying::text, 'medicare_b'::character varying::text, 'medicare_d'::character varying::text, 'medicaid'::character varying::text, 'va_benefits'::character varying::text, 'private_insurance'::character varying::text, 'workers_comp'::character varying::text, 'auto_insurance'::character varying::text, 'liability_coverage'::character varying::text, 'state_program'::character varying::text, 'tribal_program'::character varying::text, 'charity_care'::character varying::text])", name: "corvid_arc_resource_type_check"
     t.check_constraint "status::text = ANY (ARRAY['not_checked'::character varying::text, 'checking'::character varying::text, 'enrolled'::character varying::text, 'not_enrolled'::character varying::text, 'denied'::character varying::text, 'exhausted'::character varying::text, 'pending_enrollment'::character varying::text])", name: "corvid_arc_status_check"
   end
@@ -43,9 +43,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "patient_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["tenant_identifier", "api_name", "called_at", "app_identifier"], name: "idx_corvid_api_calls_tenant_api_time_app"
-    t.index ["tenant_identifier", "api_name", "called_at", "patient_identifier"], name: "idx_corvid_api_calls_tenant_api_time_patient"
-    t.index ["tenant_identifier", "api_name", "endpoint", "called_at"], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
+    t.index [ "tenant_identifier", "api_name", "called_at", "app_identifier" ], name: "idx_corvid_api_calls_tenant_api_time_app"
+    t.index [ "tenant_identifier", "api_name", "called_at", "patient_identifier" ], name: "idx_corvid_api_calls_tenant_api_time_patient"
+    t.index [ "tenant_identifier", "api_name", "endpoint", "called_at" ], name: "idx_corvid_api_calls_tenant_api_endpoint_time"
     t.check_constraint "api_name::text = ANY (ARRAY['pas'::character varying::text, 'patient_access'::character varying::text, 'provider_access'::character varying::text, 'payer_to_payer'::character varying::text])", name: "corvid_api_call_logs_api_name_check"
   end
 
@@ -57,7 +57,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index ["calendar_year", "locality"], name: "idx_corvid_asc_conversion_factors_cy_locality", unique: true
+    t.index [ "calendar_year", "locality" ], name: "idx_corvid_asc_conversion_factors_cy_locality", unique: true
   end
 
   create_table "corvid_asc_facilities", force: :cascade do |t|
@@ -69,8 +69,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn", "effective_date"], name: "idx_corvid_asc_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
-    t.index ["npi", "effective_date"], name: "idx_corvid_asc_npi_effective", unique: true, where: "(npi IS NOT NULL)"
+    t.index [ "ccn", "effective_date" ], name: "idx_corvid_asc_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index [ "npi", "effective_date" ], name: "idx_corvid_asc_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_asc_hcpcs_rates", force: :cascade do |t|
@@ -81,7 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "payment_weight", precision: 10, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index ["calendar_year", "hcpcs_code"], name: "idx_corvid_asc_hcpcs_rates_cy_hcpcs", unique: true
+    t.index [ "calendar_year", "hcpcs_code" ], name: "idx_corvid_asc_hcpcs_rates_cy_hcpcs", unique: true
   end
 
   create_table "corvid_billing_transactions", force: :cascade do |t|
@@ -97,8 +97,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.string "transaction_type", null: false
     t.datetime "updated_at", null: false
-    t.index ["tenant_identifier", "reference_identifier"], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
-    t.index ["tenant_identifier", "transaction_type"], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
+    t.index [ "tenant_identifier", "reference_identifier" ], name: "idx_on_tenant_identifier_reference_identifier_6214d6a05c"
+    t.index [ "tenant_identifier", "transaction_type" ], name: "idx_on_tenant_identifier_transaction_type_c3e90efcf5"
     t.check_constraint "direction::text = ANY (ARRAY['inbound'::character varying::text, 'outbound'::character varying::text])", name: "corvid_billing_tx_direction_check"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "corvid_billing_tx_status_check"
     t.check_constraint "transaction_type::text = ANY (ARRAY['eligibility'::character varying::text, 'claim'::character varying::text, 'claim_status'::character varying::text, 'remittance'::character varying::text, 'payment'::character varying::text])", name: "corvid_billing_tx_type_check"
@@ -113,8 +113,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi"
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn", "effective_date"], name: "idx_corvid_cah_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
-    t.index ["npi", "effective_date"], name: "idx_corvid_cah_npi_effective", unique: true, where: "(npi IS NOT NULL)"
+    t.index [ "ccn", "effective_date" ], name: "idx_corvid_cah_ccn_effective", unique: true, where: "(ccn IS NOT NULL)"
+    t.index [ "npi", "effective_date" ], name: "idx_corvid_cah_npi_effective", unique: true, where: "(npi IS NOT NULL)"
   end
 
   create_table "corvid_care_team_members", force: :cascade do |t|
@@ -126,9 +126,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "role"
     t.date "start_date"
     t.datetime "updated_at", null: false
-    t.index ["care_team_id", "practitioner_identifier"], name: "idx_corvid_ctm_team_practitioner", unique: true
-    t.index ["care_team_id"], name: "index_corvid_care_team_members_on_care_team_id"
-    t.index ["practitioner_identifier"], name: "index_corvid_care_team_members_on_practitioner_identifier"
+    t.index [ "care_team_id", "practitioner_identifier" ], name: "idx_corvid_ctm_team_practitioner", unique: true
+    t.index [ "care_team_id" ], name: "index_corvid_care_team_members_on_care_team_id"
+    t.index [ "practitioner_identifier" ], name: "index_corvid_care_team_members_on_practitioner_identifier"
   end
 
   create_table "corvid_care_teams", force: :cascade do |t|
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "active", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
+    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_6f25172ef7"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text])", name: "corvid_care_teams_status_check"
   end
 
@@ -154,10 +154,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "program_name", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["case_id", "program_code"], name: "idx_corvid_case_programs_case_code", unique: true
-    t.index ["case_id"], name: "index_corvid_case_programs_on_case_id"
-    t.index ["tenant_identifier", "enrollment_status"], name: "idx_corvid_case_programs_tenant_status"
-    t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_case_programs_tenant_facility"
+    t.index [ "case_id", "program_code" ], name: "idx_corvid_case_programs_case_code", unique: true
+    t.index [ "case_id" ], name: "index_corvid_case_programs_on_case_id"
+    t.index [ "tenant_identifier", "enrollment_status" ], name: "idx_corvid_case_programs_tenant_status"
+    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_corvid_case_programs_tenant_facility"
     t.check_constraint "enrollment_status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'pending'::character varying::text, 'terminated'::character varying::text])", name: "corvid_case_programs_enrollment_status_check"
   end
 
@@ -178,9 +178,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "active", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["care_team_id"], name: "index_corvid_cases_on_care_team_id"
-    t.index ["tenant_identifier", "facility_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
-    t.index ["tenant_identifier", "status"], name: "index_corvid_cases_on_tenant_identifier_and_status"
+    t.index [ "care_team_id" ], name: "index_corvid_cases_on_care_team_id"
+    t.index [ "tenant_identifier", "facility_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_patien_a3dd76b8ca"
+    t.index [ "tenant_identifier", "status" ], name: "index_corvid_cases_on_tenant_identifier_and_status"
     t.check_constraint "lifecycle_status::text = ANY (ARRAY['intake'::character varying::text, 'active_followup'::character varying::text, 'closure'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_lifecycle_check"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'closed'::character varying::text])", name: "corvid_cases_status_check"
   end
@@ -213,9 +213,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "submitted_at"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["claim_identifier"], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
-    t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
-    t.index ["tenant_identifier", "status"], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
+    t.index [ "claim_identifier" ], name: "index_corvid_claim_submissions_on_claim_identifier", unique: true
+    t.index [ "tenant_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_patient_identifier_0a950bd516"
+    t.index [ "tenant_identifier", "status" ], name: "index_corvid_claim_submissions_on_tenant_identifier_and_status"
     t.check_constraint "claim_type::text = ANY (ARRAY['professional'::character varying::text, 'institutional'::character varying::text, 'dental'::character varying::text])", name: "corvid_claim_submissions_type_check"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'paid'::character varying::text, 'denied'::character varying::text, 'appealed'::character varying::text, 'error'::character varying::text])", name: "corvid_claim_submissions_status_check"
   end
@@ -229,7 +229,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "source_checksum_sha256", null: false
     t.datetime "updated_at", null: false
     t.integer "year", null: false
-    t.index ["year"], name: "index_corvid_cms_fee_schedule_releases_on_year", unique: true
+    t.index [ "year" ], name: "index_corvid_cms_fee_schedule_releases_on_year", unique: true
   end
 
   create_table "corvid_committee_reviews", force: :cascade do |t|
@@ -250,9 +250,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "reviewer_identifier"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["committee_date"], name: "index_corvid_committee_reviews_on_committee_date"
-    t.index ["prc_referral_id"], name: "index_corvid_committee_reviews_on_prc_referral_id"
-    t.index ["tenant_identifier", "decision"], name: "idx_on_tenant_identifier_decision_51d5d49df2"
+    t.index [ "committee_date" ], name: "index_corvid_committee_reviews_on_committee_date"
+    t.index [ "prc_referral_id" ], name: "index_corvid_committee_reviews_on_prc_referral_id"
+    t.index [ "tenant_identifier", "decision" ], name: "idx_on_tenant_identifier_decision_51d5d49df2"
     t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'modified'::character varying::text])", name: "corvid_committee_reviews_decision_check"
   end
 
@@ -269,10 +269,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "reasons_token"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["determinable_type", "determinable_id"], name: "idx_on_determinable_type_determinable_id_6da50e3199"
-    t.index ["determinable_type", "determinable_id"], name: "index_corvid_determinations_on_determinable"
-    t.index ["determined_at"], name: "index_corvid_determinations_on_determined_at"
-    t.index ["tenant_identifier", "outcome"], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
+    t.index [ "determinable_type", "determinable_id" ], name: "idx_on_determinable_type_determinable_id_6da50e3199"
+    t.index [ "determinable_type", "determinable_id" ], name: "index_corvid_determinations_on_determinable"
+    t.index [ "determined_at" ], name: "index_corvid_determinations_on_determined_at"
+    t.index [ "tenant_identifier", "outcome" ], name: "index_corvid_determinations_on_tenant_identifier_and_outcome"
     t.check_constraint "decision_method::text = ANY (ARRAY['automated'::character varying::text, 'staff_review'::character varying::text, 'committee_review'::character varying::text])", name: "corvid_determinations_method_check"
     t.check_constraint "outcome::text = ANY (ARRAY['approved'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'pending_review'::character varying::text])", name: "corvid_determinations_outcome_check"
   end
@@ -304,8 +304,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "residency_verified_at"
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["prc_referral_id"], name: "idx_corvid_elig_checklists_referral_unique", unique: true
-    t.index ["tenant_identifier", "facility_identifier"], name: "idx_corvid_elig_checklists_tenant_facility"
+    t.index [ "prc_referral_id" ], name: "idx_corvid_elig_checklists_referral_unique", unique: true
+    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_corvid_elig_checklists_tenant_facility"
   end
 
   create_table "corvid_fee_schedule_entries", force: :cascade do |t|
@@ -323,9 +323,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.datetime "updated_at", null: false
     t.decimal "work_gpci", precision: 8, scale: 4
     t.decimal "work_rvu", precision: 8, scale: 4
-    t.index ["cpt_code", "locality", "effective_date"], name: "idx_corvid_fee_schedule_unique", unique: true
-    t.index ["cpt_code"], name: "index_corvid_fee_schedule_entries_on_cpt_code"
-    t.index ["effective_date"], name: "index_corvid_fee_schedule_entries_on_effective_date"
+    t.index [ "cpt_code", "locality", "effective_date" ], name: "idx_corvid_fee_schedule_unique", unique: true
+    t.index [ "cpt_code" ], name: "index_corvid_fee_schedule_entries_on_cpt_code"
+    t.index [ "effective_date" ], name: "index_corvid_fee_schedule_entries_on_effective_date"
   end
 
   create_table "corvid_fee_schedules", force: :cascade do |t|
@@ -339,8 +339,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.string "tiers_token"
     t.datetime "updated_at", null: false
-    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_4bbe5beaee"
-    t.index ["tenant_identifier", "program"], name: "index_corvid_fee_schedules_on_tenant_identifier_and_program"
+    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_4bbe5beaee"
+    t.index [ "tenant_identifier", "program" ], name: "index_corvid_fee_schedules_on_tenant_identifier_and_program"
   end
 
   create_table "corvid_ipps_drg_weights", force: :cascade do |t|
@@ -350,7 +350,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "relative_weight", precision: 8, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index ["fiscal_year", "drg_code"], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
+    t.index [ "fiscal_year", "drg_code" ], name: "idx_corvid_ipps_drg_weights_fy_drg", unique: true
   end
 
   create_table "corvid_ipps_hospital_rates", force: :cascade do |t|
@@ -361,7 +361,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index ["fiscal_year", "locality"], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
+    t.index [ "fiscal_year", "locality" ], name: "idx_corvid_ipps_hospital_rates_fy_locality", unique: true
   end
 
   create_table "corvid_npi_ccn_crosswalks", force: :cascade do |t|
@@ -372,9 +372,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "npi", null: false
     t.string "source_release"
     t.datetime "updated_at", null: false
-    t.index ["ccn"], name: "index_corvid_npi_ccn_crosswalks_on_ccn"
-    t.index ["source_release", "npi", "ccn", "effective_date"], name: "idx_corvid_npi_ccn_crosswalks_unique", unique: true
-    t.index ["npi"], name: "index_corvid_npi_ccn_crosswalks_on_npi"
+    t.index [ "ccn" ], name: "index_corvid_npi_ccn_crosswalks_on_ccn"
+    t.index [ "source_release", "npi", "ccn", "effective_date" ], name: "idx_corvid_npi_ccn_crosswalks_unique", unique: true
+    t.index [ "npi" ], name: "index_corvid_npi_ccn_crosswalks_on_npi"
   end
 
   create_table "corvid_opps_apc_weights", force: :cascade do |t|
@@ -384,7 +384,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.decimal "relative_weight", precision: 8, scale: 4, null: false
     t.string "release_label"
     t.datetime "updated_at", null: false
-    t.index ["calendar_year", "apc_code"], name: "idx_corvid_opps_apc_weights_cy_apc", unique: true
+    t.index [ "calendar_year", "apc_code" ], name: "idx_corvid_opps_apc_weights_cy_apc", unique: true
   end
 
   create_table "corvid_opps_conversion_factors", force: :cascade do |t|
@@ -395,7 +395,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "release_label"
     t.datetime "updated_at", null: false
     t.decimal "wage_index", precision: 8, scale: 4, default: "1.0", null: false
-    t.index ["calendar_year", "locality"], name: "idx_corvid_opps_conversion_factors_cy_locality", unique: true
+    t.index [ "calendar_year", "locality" ], name: "idx_corvid_opps_conversion_factors_cy_locality", unique: true
   end
 
   create_table "corvid_payments", force: :cascade do |t|
@@ -411,9 +411,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "pending", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["payment_identifier"], name: "index_corvid_payments_on_payment_identifier", unique: true
-    t.index ["tenant_identifier", "patient_identifier"], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
-    t.index ["tenant_identifier", "status"], name: "index_corvid_payments_on_tenant_identifier_and_status"
+    t.index [ "payment_identifier" ], name: "index_corvid_payments_on_payment_identifier", unique: true
+    t.index [ "tenant_identifier", "patient_identifier" ], name: "idx_on_tenant_identifier_patient_identifier_238e33c764"
+    t.index [ "tenant_identifier", "status" ], name: "index_corvid_payments_on_tenant_identifier_and_status"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'processing'::character varying::text, 'succeeded'::character varying::text, 'failed'::character varying::text, 'refunded'::character varying::text])", name: "corvid_payments_status_check"
   end
 
@@ -436,10 +436,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.string "vendor_id"
-    t.index ["tenant_identifier", "fiscal_year"], name: "idx_on_tenant_identifier_fiscal_year_4256632613"
-    t.index ["tenant_identifier", "obligation_id"], name: "idx_corvid_prc_obligations_tenant_oblig", unique: true
-    t.index ["tenant_identifier", "service_date"], name: "idx_on_tenant_identifier_service_date_6d2dcaef53"
-    t.index ["tenant_identifier", "vendor_id"], name: "idx_on_tenant_identifier_vendor_id_08d803412f"
+    t.index [ "tenant_identifier", "fiscal_year" ], name: "idx_on_tenant_identifier_fiscal_year_4256632613"
+    t.index [ "tenant_identifier", "obligation_id" ], name: "idx_corvid_prc_obligations_tenant_oblig", unique: true
+    t.index [ "tenant_identifier", "service_date" ], name: "idx_on_tenant_identifier_service_date_6d2dcaef53"
+    t.index [ "tenant_identifier", "vendor_id" ], name: "idx_on_tenant_identifier_vendor_id_08d803412f"
   end
 
   create_table "corvid_prc_overpayment_analyses", force: :cascade do |t|
@@ -457,9 +457,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "recovery_confidence", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["prc_obligation_id", "analyzed_at"], name: "idx_corvid_prc_overpay_oblig_time"
-    t.index ["prc_obligation_id"], name: "idx_corvid_prc_overpay_oblig"
-    t.index ["tenant_identifier", "recovery_confidence"], name: "idx_corvid_prc_overpay_confidence"
+    t.index [ "prc_obligation_id", "analyzed_at" ], name: "idx_corvid_prc_overpay_oblig_time"
+    t.index [ "prc_obligation_id" ], name: "idx_corvid_prc_overpay_oblig"
+    t.index [ "tenant_identifier", "recovery_confidence" ], name: "idx_corvid_prc_overpay_confidence"
   end
 
   create_table "corvid_prc_payments", force: :cascade do |t|
@@ -473,8 +473,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
     t.string "vendor_name"
-    t.index ["prc_obligation_id"], name: "idx_corvid_prc_payments_oblig"
-    t.index ["tenant_identifier", "payment_id"], name: "idx_corvid_prc_payments_tenant_pmt", unique: true
+    t.index [ "prc_obligation_id" ], name: "idx_corvid_prc_payments_oblig"
+    t.index [ "tenant_identifier", "payment_id" ], name: "idx_corvid_prc_payments_tenant_pmt", unique: true
   end
 
   create_table "corvid_prc_referrals", force: :cascade do |t|
@@ -504,9 +504,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "status", default: "draft", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["case_id"], name: "index_corvid_prc_referrals_on_case_id"
-    t.index ["tenant_identifier", "facility_identifier", "referral_identifier"], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
-    t.index ["tenant_identifier", "status"], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
+    t.index [ "case_id" ], name: "index_corvid_prc_referrals_on_case_id"
+    t.index [ "tenant_identifier", "facility_identifier", "referral_identifier" ], name: "idx_corvid_prc_referrals_tenant_referral", unique: true
+    t.index [ "tenant_identifier", "status" ], name: "index_corvid_prc_referrals_on_tenant_identifier_and_status"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'submitted'::character varying::text, 'eligibility_review'::character varying::text, 'management_approval'::character varying::text, 'alternate_resource_review'::character varying::text, 'priority_assignment'::character varying::text, 'committee_review'::character varying::text, 'exception_review'::character varying::text, 'authorized'::character varying::text, 'denied'::character varying::text, 'deferred'::character varying::text, 'cancelled'::character varying::text])", name: "corvid_prc_referrals_status_check"
   end
 
@@ -528,11 +528,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "taskable_type", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
-    t.index ["taskable_type", "taskable_id", "milestone_key"], name: "idx_corvid_tasks_taskable_milestone", unique: true, where: "(milestone_key IS NOT NULL)"
-    t.index ["taskable_type", "taskable_id"], name: "index_corvid_tasks_on_taskable"
-    t.index ["tenant_identifier", "assignee_identifier"], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
-    t.index ["tenant_identifier", "facility_identifier"], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
-    t.index ["tenant_identifier", "status"], name: "index_corvid_tasks_on_tenant_identifier_and_status"
+    t.index [ "taskable_type", "taskable_id", "milestone_key" ], name: "idx_corvid_tasks_taskable_milestone", unique: true, where: "(milestone_key IS NOT NULL)"
+    t.index [ "taskable_type", "taskable_id" ], name: "index_corvid_tasks_on_taskable"
+    t.index [ "tenant_identifier", "assignee_identifier" ], name: "idx_on_tenant_identifier_assignee_identifier_35adb7cf72"
+    t.index [ "tenant_identifier", "facility_identifier" ], name: "idx_on_tenant_identifier_facility_identifier_aa1e96cb7e"
+    t.index [ "tenant_identifier", "status" ], name: "index_corvid_tasks_on_tenant_identifier_and_status"
     t.check_constraint "priority::text = ANY (ARRAY['routine'::character varying::text, 'urgent'::character varying::text, 'asap'::character varying::text, 'stat'::character varying::text])", name: "corvid_tasks_priority_check"
     t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text, 'on_hold'::character varying::text])", name: "corvid_tasks_status_check"
   end
@@ -544,8 +544,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000002) do
     t.string "state"
     t.datetime "updated_at", null: false
     t.string "zip_code", null: false
-    t.index ["locality"], name: "index_corvid_zip_localities_on_locality"
-    t.index ["zip_code"], name: "index_corvid_zip_localities_on_zip_code", unique: true
+    t.index [ "locality" ], name: "index_corvid_zip_localities_on_locality"
+    t.index [ "zip_code" ], name: "index_corvid_zip_localities_on_zip_code", unique: true
   end
 
   add_foreign_key "corvid_alternate_resource_checks", "corvid_prc_referrals", column: "prc_referral_id"

--- a/test/models/corvid/committee_review_test.rb
+++ b/test/models/corvid/committee_review_test.rb
@@ -175,7 +175,7 @@ class Corvid::CommitteeReviewTest < ActiveSupport::TestCase
       r3 = create_review(committee_date: 2.days.ago)
 
       ordered = Corvid::CommitteeReview.chronological.to_a
-      assert_equal [r1, r3, r2], ordered
+      assert_equal [ r1, r3, r2 ], ordered
     end
   end
 

--- a/test/models/corvid/determination_test.rb
+++ b/test/models/corvid/determination_test.rb
@@ -119,7 +119,7 @@ class Corvid::DeterminationTest < ActiveSupport::TestCase
       d3 = Corvid::Determination.create!(determinable: referral, decision_method: "automated", outcome: "approved", created_at: Time.current)
 
       ordered = Corvid::Determination.chronological
-      assert_equal [d1, d2, d3], ordered.to_a
+      assert_equal [ d1, d2, d3 ], ordered.to_a
     end
   end
 

--- a/test/models/corvid/fee_schedule_test.rb
+++ b/test/models/corvid/fee_schedule_test.rb
@@ -98,7 +98,7 @@ class Corvid::FeeScheduleTest < ActiveSupport::TestCase
       create_schedule(name: "General", program: "general")
 
       results = Corvid::FeeSchedule.for_program("immunization")
-      assert_equal [immun], results.to_a
+      assert_equal [ immun ], results.to_a
     end
   end
 

--- a/test/rulesets/corvid/prc_eligibility_ruleset_test.rb
+++ b/test/rulesets/corvid/prc_eligibility_ruleset_test.rb
@@ -67,8 +67,8 @@ class Corvid::PrcEligibilityRulesetTest < ActiveSupport::TestCase
   # === CLINICAL JUSTIFICATION ===
 
   test "has_clinical_justification passes with clinical keywords" do
-    ["chest pain", "cardiac evaluation", "surgery consultation", "fracture treatment",
-     "severe headache", "chronic condition", "failed treatment"].each do |reason|
+    [ "chest pain", "cardiac evaluation", "surgery consultation", "fracture treatment",
+     "severe headache", "chronic condition", "failed treatment" ].each do |reason|
       engine = Corvid::RulesEngine.new(Corvid::PrcEligibilityRuleset.new)
       engine.set_facts(reason_for_referral: reason)
       assert engine.evaluate(:has_clinical_justification).value, "Expected '#{reason}' to pass"

--- a/test/services/corvid/case_dashboard_service_test.rb
+++ b/test/services/corvid/case_dashboard_service_test.rb
@@ -23,7 +23,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       Corvid::Case.create!(patient_identifier: "pt_1", care_team: team, facility_identifier: "fac_test")
       Corvid::Case.create!(patient_identifier: "pt_2", care_team: team, facility_identifier: "fac_test", status: :closed)
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
       assert_equal 1, result[:active_cases_count]
     end
   end
@@ -37,7 +37,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       Corvid::Task.create!(taskable: kase, assignee_identifier: provider, description: "IP task", status: :in_progress)
       Corvid::Task.create!(taskable: kase, assignee_identifier: provider, description: "Done task", status: :completed)
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
 
       assert result.key?(:task_counts)
       assert_equal 1, result[:task_counts][:pending]
@@ -55,7 +55,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       Corvid::Task.create!(taskable: kase, assignee_identifier: provider, description: "In progress", status: :in_progress)
       Corvid::Task.create!(taskable: kase, assignee_identifier: provider, description: "Done", status: :completed)
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
       assert_equal 2, result[:my_incomplete_tasks_count]
     end
   end
@@ -71,7 +71,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
         ref.save!(validate: false)
       end
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
 
       assert result.key?(:referral_pipeline)
       assert_equal 1, result[:referral_pipeline]["draft"]
@@ -83,7 +83,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
   test "metrics includes generated_at timestamp" do
     with_tenant(TENANT) do
       team, provider = setup_team_and_provider
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
 
       assert result.key?(:generated_at)
       assert_kind_of Time, result[:generated_at]
@@ -95,7 +95,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       team, provider = setup_team_and_provider
       Corvid::Case.create!(patient_identifier: "pt_age", care_team: team, facility_identifier: "fac_test")
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
 
       assert result.key?(:avg_case_age_days)
       assert result[:avg_case_age_days] >= 0
@@ -110,7 +110,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       Corvid::Case.create!(patient_identifier: "pt_ro", care_team: team, facility_identifier: "fac_test")
 
       count_before = { cases: Corvid::Case.count, tasks: Corvid::Task.count }
-      Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
 
       assert_equal count_before[:cases], Corvid::Case.count
       assert_equal count_before[:tasks], Corvid::Task.count
@@ -122,7 +122,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
   test "metrics handles empty care team" do
     with_tenant(TENANT) do
       team = Corvid::CareTeam.create!(name: "Empty Team", facility_identifier: "fac_test")
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: "pr_999")
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: "pr_999")
 
       assert_equal 0, result[:active_cases_count]
       assert_equal 0, result[:my_incomplete_tasks_count]
@@ -140,7 +140,7 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
       other_case = Corvid::Case.create!(patient_identifier: "pt_other", care_team: other_team, facility_identifier: "fac_test")
       Corvid::Task.create!(taskable: other_case, assignee_identifier: provider, description: "Unrelated task", status: :pending)
 
-      result = Corvid::CaseDashboardService.metrics(care_team_ids: [team.id], provider_identifier: provider)
+      result = Corvid::CaseDashboardService.metrics(care_team_ids: [ team.id ], provider_identifier: provider)
       assert_equal 2, result[:my_incomplete_tasks_count]
     end
   end
@@ -151,6 +151,6 @@ class Corvid::CaseDashboardServiceTest < ActiveSupport::TestCase
     provider = "pr_dash_101"
     team = Corvid::CareTeam.create!(name: "Test Team", facility_identifier: "fac_test")
     Corvid::CareTeamMember.create!(care_team: team, practitioner_identifier: provider, role: "provider")
-    [team, provider]
+    [ team, provider ]
   end
 end

--- a/test/services/corvid/cms_fee_schedule_parser_test.rb
+++ b/test/services/corvid/cms_fee_schedule_parser_test.rb
@@ -218,7 +218,7 @@ class Corvid::CmsFeeScheduleParserTest < ActiveSupport::TestCase
     with_tempfile(csv) do |path|
       yielded = []
       Corvid::CmsFeeScheduleParser.parse_rvus(path) do |cpt, work, pe, mp|
-        yielded << [cpt, work, pe, mp]
+        yielded << [ cpt, work, pe, mp ]
       end
 
       assert_equal 1, yielded.size, "expected only 99213 (A0021 has zero work + pe)"
@@ -230,7 +230,7 @@ class Corvid::CmsFeeScheduleParserTest < ActiveSupport::TestCase
   private
 
   def with_tempfile(content)
-    f = Tempfile.new(["cms_test", ".csv"])
+    f = Tempfile.new([ "cms_test", ".csv" ])
     f.write(content)
     f.close
     yield f.path


### PR DESCRIPTION
## Summary
- Add `.rubocop.yml` inheriting from `rubocop-rails-omakase` (same shape as the lakeraven-ehr engine)
- Autocorrect 161 existing offenses across 33 files via `bundle exec rubocop -A` (array/bracket spacing in test fixtures, no logic changes)
- Add a `lint` job to `.github/workflows/ci.yml` so style drift fails CI on PRs

## Test plan
- [x] `bundle exec rake test` — 949 runs, 2122 assertions, 0 failures
- [x] `bundle exec cucumber --tags "not @wip"` — 369 scenarios, 2421 steps, all passed
- [x] `bundle exec rubocop` — 271 files inspected, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)