### PR TITLE
Extend verify_tribal_enrollment contract: tribe_code + confidence

### DIFF
--- a/lib/corvid/adapters/base.rb
+++ b/lib/corvid/adapters/base.rb
@@ -187,7 +187,17 @@ module Corvid
       # ----------------------------------------------------------------------
 
       # Returns { enrolled: bool, membership_number: str|nil,
-      #           tribe_name: str|nil, verified_at: datetime }
+      #           tribe_name: str|nil, tribe_code: str|nil,
+      #           member_status: str|nil, blood_quantum: hash|nil,
+      #           confidence: :verified|:stale|:unavailable,
+      #           verified_at: datetime }
+      #
+      # `tribe_code` lets eligibility services compare the enrollee's tribe
+      # against a facility's contracted tribe (preventing wrong-tribe false
+      # positives). `confidence` reflects how fresh the underlying data is —
+      # `:verified` is canonical; `:stale` means the source returned data
+      # but flagged it as out-of-date; `:unavailable` means the source could
+      # not be reached.
       def verify_tribal_enrollment(patient_identifier)
         raise NotImplementedError, "#{self.class}#verify_tribal_enrollment not implemented"
       end

--- a/lib/corvid/adapters/fhir_adapter.rb
+++ b/lib/corvid/adapters/fhir_adapter.rb
@@ -235,7 +235,14 @@ module Corvid
       # ----------------------------------------------------------------------
 
       def verify_tribal_enrollment(_patient_identifier)
-        { enrolled: false, membership_number: nil, tribe_name: nil, verified_at: Time.current }
+        {
+          enrolled: false,
+          membership_number: nil,
+          tribe_name: nil,
+          tribe_code: nil,
+          confidence: :unavailable,
+          verified_at: Time.current
+        }
       end
 
       def verify_identity_documents(_patient_identifier)

--- a/lib/corvid/adapters/mock_adapter.rb
+++ b/lib/corvid/adapters/mock_adapter.rb
@@ -308,14 +308,25 @@ module Corvid
 
       def verify_tribal_enrollment(patient_identifier)
         enrollment = @enrollments[patient_identifier.to_s]
-        return { enrolled: false, membership_number: nil, tribe_name: nil, verified_at: Time.current } unless enrollment
+        unless enrollment
+          return {
+            enrolled: false,
+            membership_number: nil,
+            tribe_name: nil,
+            tribe_code: nil,
+            confidence: :verified,
+            verified_at: Time.current
+          }
+        end
 
         {
           enrolled: enrollment[:enrolled],
           membership_number: enrollment[:membership_number],
           tribe_name: enrollment[:tribe_name],
+          tribe_code: enrollment[:tribe_code],
           blood_quantum: enrollment[:blood_quantum],
           member_status: enrollment[:member_status],
+          confidence: enrollment.fetch(:confidence, :verified),
           verified_at: Time.current
         }
       end

--- a/test/corvid/adapters/mock_adapter_test.rb
+++ b/test/corvid/adapters/mock_adapter_test.rb
@@ -121,6 +121,35 @@ class Corvid::Adapters::MockAdapterTest < Minitest::Test
     assert_nil @adapter.find_patient("pt_001")
   end
 
+  # -- verify_tribal_enrollment contract: tribe_code + confidence ------------
+
+  def test_verify_tribal_enrollment_returns_tribe_code_when_added_via_add_enrollment
+    @adapter.add_enrollment("pt_e1", enrolled: true, tribe_name: "Demo Tribe", tribe_code: "DEMO", member_status: "enrolled")
+    result = @adapter.verify_tribal_enrollment("pt_e1")
+    assert_equal "DEMO", result[:tribe_code]
+    assert_equal "Demo Tribe", result[:tribe_name]
+    assert result[:enrolled]
+  end
+
+  def test_verify_tribal_enrollment_defaults_confidence_to_verified
+    @adapter.add_enrollment("pt_e2", enrolled: true, tribe_name: "T", tribe_code: "T")
+    result = @adapter.verify_tribal_enrollment("pt_e2")
+    assert_equal :verified, result[:confidence]
+  end
+
+  def test_verify_tribal_enrollment_propagates_explicit_confidence_stale
+    @adapter.add_enrollment("pt_e3", enrolled: true, tribe_name: "T", tribe_code: "T", confidence: :stale)
+    result = @adapter.verify_tribal_enrollment("pt_e3")
+    assert_equal :stale, result[:confidence]
+  end
+
+  def test_verify_tribal_enrollment_unknown_patient_returns_not_enrolled_with_verified_confidence
+    result = @adapter.verify_tribal_enrollment("pt_unknown")
+    refute result[:enrolled]
+    assert_nil result[:tribe_code]
+    assert_equal :verified, result[:confidence]
+  end
+
   # -- ADR 0003: MockAdapter is not a security boundary ----------------------
 
   def test_mock_adapter_documents_it_is_not_a_security_boundary


### PR DESCRIPTION
## Summary
Adds two fields to the adapter's `verify_tribal_enrollment` return shape:

- **`tribe_code`** (string|nil) — the enrolled tribe's contract code. Lets eligibility services compare against a facility's contracted tribe (catches wrong-tribe false positives).
- **`confidence`** (`:verified` | `:stale` | `:unavailable`) — how fresh the source data is. Lets eligibility services choose to deny on `:unavailable` while still approving on `:stale` with a warning.

## Changes
- `lib/corvid/adapters/base.rb` — contract documentation
- `lib/corvid/adapters/mock_adapter.rb` — emits both fields; `add_enrollment` accepts `tribe_code` and `confidence`; defaults `:verified`
- `lib/corvid/adapters/fhir_adapter.rb` — not-implemented default returns `confidence: :unavailable`
- `test/corvid/adapters/mock_adapter_test.rb` — 4 new tests for the new contract

## Test plan
- [x] `bundle exec rake test` — 952 runs, 2129 assertions, 0 failures
- [x] `bundle exec rubocop` — clean

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)