### PR TITLE
Add headless JSON API for tribal eligibility decisions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ Rake::TestTask.new(:test_models) do |t|
   t.test_files = FileList[
     "test/models/**/*_test.rb",
     "test/services/**/*_test.rb",
+    "test/controllers/**/*_test.rb",
     "test/rulesets/**/*_test.rb",
     "test/lib/tasks/**/*_test.rb"
   ]

--- a/app/controllers/corvid/api/v1/base_controller.rb
+++ b/app/controllers/corvid/api/v1/base_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Corvid
+  module Api
+    module V1
+      # Base class for corvid's headless JSON API. Subclasses inherit
+      # tenant-context resolution + standard error rendering so each
+      # endpoint stays focused on its own action.
+      class BaseController < ActionController::API
+        before_action :set_tenant_context
+
+        rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+        rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable
+        rescue_from Corvid::MissingTenantContextError, with: :render_missing_tenant
+
+        private
+
+        # Tenant comes in via header. The host application is responsible
+        # for setting `X-Tenant-Identifier` (the deployment knows where
+        # tenant identity comes from — JWT claim, subdomain, etc. — and
+        # forwards it here).
+        def set_tenant_context
+          identifier = request.headers["X-Tenant-Identifier"].to_s
+          if identifier.empty?
+            render json: { error: "missing X-Tenant-Identifier header" }, status: :bad_request
+            return false
+          end
+          Corvid::TenantContext.current_tenant_identifier = identifier
+        end
+
+        def render_not_found(exception)
+          render json: { error: exception.message }, status: :not_found
+        end
+
+        def render_unprocessable(exception)
+          render json: { error: exception.message, details: exception.record&.errors&.full_messages }, status: :unprocessable_entity
+        end
+
+        def render_missing_tenant(exception)
+          render json: { error: exception.message }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/corvid/api/v1/decisions_controller.rb
+++ b/app/controllers/corvid/api/v1/decisions_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Corvid
+  module Api
+    module V1
+      # GET /corvid/api/v1/decisions
+      # GET /corvid/api/v1/decisions/:id
+      #
+      # List + detail for PrcEligibilityDecision rows. List supports
+      # query params:
+      #   - facility_identifier
+      #   - person_identifier
+      #   - eligible (true|false)
+      #   - decided_after (ISO date)
+      #   - decided_before (ISO date)
+      class DecisionsController < BaseController
+        def index
+          scope = Corvid::PrcEligibilityDecision.recent
+          scope = scope.where(facility_identifier: params[:facility_identifier]) if params[:facility_identifier].present?
+          scope = scope.for_person(params[:person_identifier]) if params[:person_identifier].present?
+          if params[:eligible].present?
+            scope = ActiveModel::Type::Boolean.new.cast(params[:eligible]) ? scope.eligible : scope.ineligible
+          end
+          scope = scope.where("decided_at >= ?", Date.parse(params[:decided_after])) if params[:decided_after].present?
+          scope = scope.where("decided_at <= ?", Date.parse(params[:decided_before])) if params[:decided_before].present?
+
+          render json: scope.limit(100).map { |d| decision_summary(d) }
+        end
+
+        def show
+          decision = Corvid::PrcEligibilityDecision.find(params[:id])
+          render json: decision_full(decision)
+        end
+
+        private
+
+        def decision_summary(d)
+          {
+            id: d.id,
+            person_identifier: d.person_identifier,
+            facility_identifier: d.facility_identifier,
+            decided_at: d.decided_at.iso8601,
+            eligible: d.eligible,
+            reason_codes: d.reason_codes,
+            provider_confidence: d.provider_confidence
+          }
+        end
+
+        def decision_full(d)
+          decision_summary(d).merge(
+            decided_by_identifier: d.decided_by_identifier,
+            as_of_date: d.as_of_date.iso8601,
+            provider_source: d.provider_source,
+            verification_snapshot_hash: d.verification_snapshot_hash
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/corvid/api/v1/eligibility_controller.rb
+++ b/app/controllers/corvid/api/v1/eligibility_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Corvid
+  module Api
+    module V1
+      # POST /corvid/api/v1/eligibility/check
+      #
+      # Body shape:
+      #   {
+      #     "person_identifier": "pt_001",
+      #     "facility": {
+      #       "identifier": "fac_demo",
+      #       "contracted_tribe_code": "DEMO",
+      #       "requires_on_reservation": true,
+      #       "requires_ssn_on_file": true
+      #     },
+      #     "as_of_date": "2026-05-16",          # optional, defaults to today
+      #     "decided_by_identifier": "user_42"   # optional, host's actor id
+      #   }
+      class EligibilityController < BaseController
+        Facility = Struct.new(
+          :identifier,
+          :contracted_tribe_code,
+          :requires_on_reservation_flag,
+          :requires_ssn_on_file_flag,
+          keyword_init: true
+        ) do
+          def requires_on_reservation?
+            requires_on_reservation_flag
+          end
+
+          def requires_ssn_on_file?
+            requires_ssn_on_file_flag
+          end
+        end
+
+        def check
+          facility_hash = check_params[:facility].to_h.symbolize_keys
+          facility = Facility.new(
+            identifier: facility_hash[:identifier],
+            contracted_tribe_code: facility_hash[:contracted_tribe_code],
+            requires_on_reservation_flag: facility_hash[:requires_on_reservation],
+            requires_ssn_on_file_flag: facility_hash[:requires_ssn_on_file]
+          )
+
+          decision = Corvid::TribalEligibilityService.decide(
+            person_identifier: check_params[:person_identifier],
+            facility: facility,
+            as_of_date: check_params[:as_of_date].presence ? Date.parse(check_params[:as_of_date]) : Date.current,
+            decided_by_identifier: check_params[:decided_by_identifier]
+          )
+
+          render json: decision_response(decision)
+        end
+
+        private
+
+        def check_params
+          params.permit(
+            :person_identifier,
+            :as_of_date,
+            :decided_by_identifier,
+            facility: [ :identifier, :contracted_tribe_code, :requires_on_reservation, :requires_ssn_on_file ]
+          )
+        end
+
+        def decision_response(decision)
+          {
+            decision_id: decision.decision_id,
+            eligible: decision.eligible,
+            reason_codes: decision.reason_codes.map(&:to_s),
+            provider_source: decision.provider_source,
+            provider_confidence: decision.provider_confidence
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Corvid::Engine.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      post "eligibility/check", to: "eligibility#check"
+      resources :decisions, only: [ :index, :show ]
+    end
+  end
+end

--- a/test/controllers/corvid/api/v1/decisions_controller_test.rb
+++ b/test/controllers/corvid/api/v1/decisions_controller_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::Api::V1::DecisionsControllerTest < ActionDispatch::IntegrationTest
+  TENANT = "tenant_test"
+
+  setup do
+    Corvid::TenantContext.reset!
+    Corvid::PrcEligibilityDecision.unscoped.delete_all
+    Corvid::TenantContext.current_tenant_identifier = TENANT
+
+    @d1 = Corvid::PrcEligibilityDecision.create!(
+      tenant_identifier: TENANT,
+      person_identifier: "pt_a",
+      facility_identifier: "fac_demo",
+      decided_at: 2.hours.ago,
+      as_of_date: Date.current,
+      eligible: true,
+      reason_codes: []
+    )
+    @d2 = Corvid::PrcEligibilityDecision.create!(
+      tenant_identifier: TENANT,
+      person_identifier: "pt_b",
+      facility_identifier: "fac_demo",
+      decided_at: 1.hour.ago,
+      as_of_date: Date.current,
+      eligible: false,
+      reason_codes: [ "not_enrolled" ]
+    )
+  end
+
+  teardown do
+    Corvid::TenantContext.reset!
+  end
+
+  def headers
+    { "X-Tenant-Identifier" => TENANT }
+  end
+
+  test "index returns recent decisions" do
+    get "/corvid/api/v1/decisions", headers: headers
+    assert_response :success
+    rows = JSON.parse(response.body)
+    assert_equal 2, rows.size
+    assert_equal @d2.id, rows.first["id"], "ordered recent-first"
+  end
+
+  test "index filters by eligible=false" do
+    get "/corvid/api/v1/decisions", params: { eligible: "false" }, headers: headers
+    assert_response :success
+    rows = JSON.parse(response.body)
+    assert_equal 1, rows.size
+    refute rows.first["eligible"]
+  end
+
+  test "index filters by person_identifier" do
+    get "/corvid/api/v1/decisions", params: { person_identifier: "pt_a" }, headers: headers
+    assert_response :success
+    rows = JSON.parse(response.body)
+    assert_equal 1, rows.size
+    assert_equal "pt_a", rows.first["person_identifier"]
+  end
+
+  test "show returns the full decision detail" do
+    get "/corvid/api/v1/decisions/#{@d1.id}", headers: headers
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @d1.id, body["id"]
+    assert body.key?("verification_snapshot_hash"), "detail includes provenance"
+    assert body.key?("decided_by_identifier")
+  end
+
+  test "show returns 404 for unknown id" do
+    get "/corvid/api/v1/decisions/999999999", headers: headers
+    assert_response :not_found
+  end
+
+  test "missing tenant header returns 400" do
+    get "/corvid/api/v1/decisions", headers: {}
+    assert_response :bad_request
+  end
+end

--- a/test/controllers/corvid/api/v1/eligibility_controller_test.rb
+++ b/test/controllers/corvid/api/v1/eligibility_controller_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Corvid::Api::V1::EligibilityControllerTest < ActionDispatch::IntegrationTest
+  TENANT = "tenant_test"
+
+  setup do
+    Corvid::TenantContext.reset!
+    Corvid.configure { |c| c.adapter = Corvid::Adapters::MockAdapter.new }
+    Corvid::PrcEligibilityDecision.unscoped.delete_all
+    Corvid::TenantContext.current_tenant_identifier = TENANT
+  end
+
+  teardown do
+    Corvid::TenantContext.reset!
+  end
+
+  def headers
+    { "X-Tenant-Identifier" => TENANT, "Content-Type" => "application/json" }
+  end
+
+  def check_body(person_id, **overrides)
+    {
+      person_identifier: person_id,
+      facility: {
+        identifier: "fac_demo",
+        contracted_tribe_code: "DEMO",
+        requires_on_reservation: false,
+        requires_ssn_on_file: false
+      }
+    }.merge(overrides).to_json
+  end
+
+  test "check returns eligible for enrolled-in-contracted-tribe person" do
+    Corvid.adapter.add_enrollment("pt_tp",
+                                  enrolled: true, tribe_name: "Demo Tribe",
+                                  tribe_code: "DEMO", member_status: "enrolled",
+                                  confidence: :verified)
+
+    post "/corvid/api/v1/eligibility/check", params: check_body("pt_tp"), headers: headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["eligible"]
+    refute_nil body["decision_id"]
+  end
+
+  test "check returns ineligible for not-enrolled person with structured reason" do
+    post "/corvid/api/v1/eligibility/check", params: check_body("pt_tn"), headers: headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    refute body["eligible"]
+    assert_includes body["reason_codes"], "not_enrolled"
+  end
+
+  test "check returns ineligible for wrong-tribe enrollee with not_enrolled_in_contracted_tribe" do
+    Corvid.adapter.add_enrollment("pt_wfp",
+                                  enrolled: true, tribe_name: "Other Tribe",
+                                  tribe_code: "OTHER", member_status: "enrolled",
+                                  confidence: :verified)
+
+    post "/corvid/api/v1/eligibility/check", params: check_body("pt_wfp"), headers: headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    refute body["eligible"]
+    assert_includes body["reason_codes"], "not_enrolled_in_contracted_tribe"
+  end
+
+  test "check requires X-Tenant-Identifier header" do
+    post "/corvid/api/v1/eligibility/check",
+         params: check_body("pt_tp"),
+         headers: { "Content-Type" => "application/json" }
+
+    assert_response :bad_request
+  end
+end


### PR DESCRIPTION
## Summary
Engine's first controllers. Three endpoints under `/corvid/api/v1`:
- `POST eligibility/check` — runs the eligibility flow, returns the decision + persisted audit-row id
- `GET decisions` — recent decisions list with filters (`facility_identifier`, `person_identifier`, `eligible`, `decided_after`, `decided_before`)
- `GET decisions/:id` — full audit detail including `verification_snapshot_hash` and `decided_by_identifier`

## Tenant context
Comes in via `X-Tenant-Identifier` header — host apps are responsible for setting it (deployment knows where tenant identity comes from: JWT claim, subdomain, etc.). Missing header → 400.

## Test plan
- [x] Controller tests cover happy path + filters + missing-header + 404
- [x] `bundle exec rake test` — 968 runs, 2180 assertions, 0 failures (now includes `test/controllers/`)
- [x] `bundle exec rubocop` — clean

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)