### PR TITLE
Add BDD scenarios for tribal eligibility decision matrix

### DIFF
--- a/features/prc/tribal_eligibility.feature
+++ b/features/prc/tribal_eligibility.feature
@@ -1,0 +1,38 @@
+Feature: Tribal eligibility decision matrix (TribalEligibilityService)
+  As a PRC clerk
+  I want eligibility decisions to be structurally correct and audit-defensible
+  So that audit findings around enrollment documentation are addressed automatically
+
+  Background:
+    Given a tenant "tnt_test" with facility "fac_demo"
+    And facility "fac_demo" has contracted tribe code "DEMO"
+
+  Scenario: True positive — enrolled in contracted tribe, all checks pass
+    Given person "pt_tp" is enrolled in tribe "DEMO" with confidence verified
+    When I decide eligibility for person "pt_tp" at facility "fac_demo"
+    Then the decision should be eligible
+    And the reason codes should not include any hard-fail reason
+
+  Scenario: True negative — not enrolled
+    When I decide eligibility for person "pt_tn" at facility "fac_demo"
+    Then the decision should be ineligible
+    And the reason codes should include "not_enrolled"
+
+  Scenario: Would-be false positive — wrong-tribe enrollee is correctly denied
+    Given person "pt_wfp" is enrolled in tribe "OTHER" with confidence verified
+    When I decide eligibility for person "pt_wfp" at facility "fac_demo"
+    Then the decision should be ineligible
+    And the reason codes should include "not_enrolled_in_contracted_tribe"
+
+  Scenario: Would-be false negative — stale data is not a hard fail
+    Given person "pt_wfn" is enrolled in tribe "DEMO" with confidence stale
+    When I decide eligibility for person "pt_wfn" at facility "fac_demo"
+    Then the decision should be eligible
+    And the reason codes should include "enrollment_stale"
+    And the reason codes should not include any hard-fail reason
+
+  Scenario: Persistence — every decide writes a PrcEligibilityDecision row
+    Given person "pt_persist" is enrolled in tribe "DEMO" with confidence verified
+    When I decide eligibility for person "pt_persist" at facility "fac_demo"
+    Then exactly 1 PrcEligibilityDecision row should exist for person "pt_persist"
+    And that row should have the provider confidence "verified"

--- a/features/step_definitions/tribal_eligibility_steps.rb
+++ b/features/step_definitions/tribal_eligibility_steps.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Step definitions for tribal eligibility BDD scenarios.
+
+Facility = Struct.new(
+  :identifier,
+  :contracted_tribe_code,
+  :requires_on_reservation_flag,
+  :requires_ssn_on_file_flag,
+  keyword_init: true
+) do
+  def requires_on_reservation?
+    requires_on_reservation_flag
+  end
+
+  def requires_ssn_on_file?
+    requires_ssn_on_file_flag
+  end
+end unless defined?(Facility)
+
+Given("facility {string} has contracted tribe code {string}") do |facility_id, tribe_code|
+  @facility_objects ||= {}
+  @facility_objects[facility_id] = Facility.new(
+    identifier: facility_id,
+    contracted_tribe_code: tribe_code,
+    requires_on_reservation_flag: false,
+    requires_ssn_on_file_flag: false
+  )
+end
+
+Given("person {string} is enrolled in tribe {string} with confidence {word}") do |person_id, tribe_code, confidence|
+  Corvid.adapter.add_enrollment(person_id,
+                                enrolled: true,
+                                tribe_name: "#{tribe_code} Tribe",
+                                tribe_code: tribe_code,
+                                member_status: "enrolled",
+                                confidence: confidence.to_sym)
+end
+
+When("I decide eligibility for person {string} at facility {string}") do |person_id, facility_id|
+  facility = @facility_objects[facility_id]
+  @decision = Corvid::TribalEligibilityService.decide(
+    person_identifier: person_id,
+    facility: facility,
+    tenant_identifier: @tenant
+  )
+end
+
+Then("the decision should be eligible") do
+  assert @decision.eligible?, "expected eligible; got reasons: #{@decision.reason_codes.inspect}"
+end
+
+Then("the decision should be ineligible") do
+  refute @decision.eligible?, "expected ineligible; got reasons: #{@decision.reason_codes.inspect}"
+end
+
+Then("the reason codes should include {string}") do |code|
+  assert_includes @decision.reason_codes.map(&:to_s), code
+end
+
+Then("the reason codes should not include any hard-fail reason") do
+  intersection = @decision.reason_codes & Corvid::TribalEligibilityService::HARD_FAIL_REASONS
+  assert_empty intersection, "unexpected hard-fail reasons: #{intersection.inspect}"
+end
+
+Then("exactly {int} PrcEligibilityDecision row should exist for person {string}") do |count, person_id|
+  assert_equal count, Corvid::PrcEligibilityDecision.where(person_identifier: person_id).count
+end
+
+Then("that row should have the provider confidence {string}") do |confidence|
+  row = Corvid::PrcEligibilityDecision.order(decided_at: :desc).first
+  assert_equal confidence, row.provider_confidence
+end


### PR DESCRIPTION
## Summary
`features/prc/tribal_eligibility.feature` pins 5 outcomes against MockAdapter:

1. **True positive** — enrolled in contracted tribe, all checks pass
2. **True negative** — not enrolled (reason: `not_enrolled`)
3. **Would-be false positive** — wrong-tribe enrollee correctly denied (reason: `not_enrolled_in_contracted_tribe`)
4. **Would-be false negative** — stale data is NOT a hard fail; surfaces as `enrollment_stale` warning only
5. **Persistence** — every `decide` writes a `PrcEligibilityDecision` row with the provider's confidence label

Reuses the existing `Given a tenant ... with facility ...` step from `features/step_definitions/eligibility_checklist_steps.rb` so fixture wiring stays consistent.

## Test plan
- [x] `bundle exec cucumber features/prc/tribal_eligibility.feature` — 5 scenarios, 30 steps, 0 failures
- [x] `bundle exec cucumber --tags "not @wip"` — 374 scenarios (369 prior + 5 new), 0 failures
- [x] `bundle exec rake test` — 968 runs, 0 failures (unchanged)
- [x] `bundle exec rubocop` — clean

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)