### PR TITLE
FhirAdapter: timeout / proxy / private-CA keywords

### DIFF
--- a/lib/corvid/adapters/fhir_adapter.rb
+++ b/lib/corvid/adapters/fhir_adapter.rb
@@ -68,10 +68,29 @@ module Corvid
         }.merge(headers)
         @open_timeout = open_timeout
         @read_timeout = read_timeout
-        @proxy_uri = proxy_uri && URI.parse(proxy_uri)
+        @proxy_uri = build_proxy_uri(proxy_uri)
         @ca_file = ca_file
         @ca_path = ca_path
       end
+
+      def build_proxy_uri(raw)
+        return nil if raw.nil?
+
+        uri = URI.parse(raw)
+        # Net::HTTP::Proxy does not perform TLS to the proxy itself; an
+        # "https://" proxy URI would silently be treated as HTTP-on-443
+        # and fail against a real TLS-wrapped HTTPS proxy. Reject loudly
+        # so the operator can re-route through stunnel or similar.
+        unless uri.scheme == "http"
+          raise ArgumentError,
+                "FhirAdapter proxy_uri must use the http:// scheme " \
+                "(got #{uri.scheme.inspect}). HTTPS proxies are not " \
+                "supported by Net::HTTP::Proxy; tunnel through stunnel " \
+                "or an outbound HTTP CONNECT proxy instead."
+        end
+        uri
+      end
+      private :build_proxy_uri
 
       # ----------------------------------------------------------------------
       # Patient

--- a/lib/corvid/adapters/fhir_adapter.rb
+++ b/lib/corvid/adapters/fhir_adapter.rb
@@ -51,13 +51,26 @@ module Corvid
         "charity_care"      => "CHAR"
       }.freeze
 
-      def initialize(base_url:, bearer_token: nil, headers: {})
+      DEFAULT_OPEN_TIMEOUT = 10
+      DEFAULT_READ_TIMEOUT = 30
+
+      def initialize(base_url:, bearer_token: nil, headers: {},
+                     open_timeout: DEFAULT_OPEN_TIMEOUT,
+                     read_timeout: DEFAULT_READ_TIMEOUT,
+                     proxy_uri: nil,
+                     ca_file: nil,
+                     ca_path: nil)
         @base_url = base_url.chomp("/")
         @bearer_token = bearer_token
         @default_headers = {
           "Accept" => "application/fhir+json",
           "Content-Type" => "application/fhir+json"
         }.merge(headers)
+        @open_timeout = open_timeout
+        @read_timeout = read_timeout
+        @proxy_uri = proxy_uri && URI.parse(proxy_uri)
+        @ca_file = ca_file
+        @ca_path = ca_path
       end
 
       # ----------------------------------------------------------------------
@@ -355,11 +368,26 @@ module Corvid
         @default_headers.each { |k, v| request[k] = v }
         request["Authorization"] = "Bearer #{@bearer_token}" if @bearer_token
 
-        http = Net::HTTP.new(uri.host, uri.port)
+        build_http(uri).request(request)
+      end
+
+      # Construct a Net::HTTP instance configured per the constructor's
+      # network keywords. Factored out so on-premises deploys (custom
+      # timeouts, outbound proxy, private CA bundle) can be unit-tested
+      # without making real HTTP calls.
+      def build_http(uri)
+        klass = if @proxy_uri
+          Net::HTTP::Proxy(@proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password)
+        else
+          Net::HTTP
+        end
+        http = klass.new(uri.host, uri.port)
         http.use_ssl = uri.scheme == "https"
-        http.open_timeout = 10
-        http.read_timeout = 30
-        http.request(request)
+        http.open_timeout = @open_timeout
+        http.read_timeout = @read_timeout
+        http.ca_file = @ca_file if @ca_file
+        http.ca_path = @ca_path if @ca_path
+        http
       end
 
       # FHIR helpers --------------------------------------------------------

--- a/test/corvid/adapters/fhir_adapter_network_test.rb
+++ b/test/corvid/adapters/fhir_adapter_network_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "corvid/adapters/fhir_adapter"
+
+# Tests for the on-premises-friendly network keywords on FhirAdapter.
+# Mode 2 (SaaS reaches into customer VPN/private CA) needs configurable
+# timeouts, HTTP proxy support, and a CA-bundle pointer to talk to
+# customer-internal FHIR endpoints.
+class Corvid::Adapters::FhirAdapterNetworkTest < Minitest::Test
+  BASE = "https://fhir.example.com/r4"
+  TARGET = URI.parse("#{BASE}/Patient/1")
+
+  # --- defaults preserved -----------------------------------------------------
+
+  def test_defaults_preserve_current_timeout_behavior
+    adapter = Corvid::Adapters::FhirAdapter.new(base_url: BASE)
+    http = adapter.send(:build_http, TARGET)
+
+    assert_equal 10, http.open_timeout
+    assert_equal 30, http.read_timeout
+  end
+
+  def test_defaults_do_not_configure_proxy_or_ca
+    adapter = Corvid::Adapters::FhirAdapter.new(base_url: BASE)
+    http = adapter.send(:build_http, TARGET)
+
+    refute http.proxy?
+    assert_nil http.ca_file
+    assert_nil http.ca_path
+  end
+
+  # --- timeout keywords -------------------------------------------------------
+
+  def test_open_timeout_keyword_overrides_default
+    adapter = Corvid::Adapters::FhirAdapter.new(base_url: BASE, open_timeout: 45)
+    http = adapter.send(:build_http, TARGET)
+
+    assert_equal 45, http.open_timeout
+    assert_equal 30, http.read_timeout
+  end
+
+  def test_read_timeout_keyword_overrides_default
+    adapter = Corvid::Adapters::FhirAdapter.new(base_url: BASE, read_timeout: 90)
+    http = adapter.send(:build_http, TARGET)
+
+    assert_equal 10, http.open_timeout
+    assert_equal 90, http.read_timeout
+  end
+
+  # --- proxy --------------------------------------------------------------
+
+  def test_proxy_uri_keyword_routes_through_a_proxy
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      proxy_uri: "http://proxy.example.com:3128"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert http.proxy?, "expected http to be configured for proxy"
+    assert_equal "proxy.example.com", http.proxy_address
+    assert_equal 3128, http.proxy_port
+  end
+
+  def test_proxy_uri_with_credentials_carries_them_through
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      proxy_uri: "http://proxyuser:proxypass@proxy.example.com:3128"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert http.proxy?
+    assert_equal "proxyuser", http.proxy_user
+    assert_equal "proxypass", http.proxy_pass
+  end
+
+  # --- private CA bundle ------------------------------------------------------
+
+  def test_ca_file_keyword_pins_a_private_ca_bundle
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      ca_file: "/etc/ssl/customer-root.pem"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert_equal "/etc/ssl/customer-root.pem", http.ca_file
+  end
+
+  def test_ca_path_keyword_pins_a_private_ca_directory
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      ca_path: "/etc/ssl/customer-certs.d"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert_equal "/etc/ssl/customer-certs.d", http.ca_path
+  end
+
+  # --- TLS still enabled for https URIs --------------------------------------
+
+  def test_https_uri_still_enables_ssl_with_custom_ca
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      ca_file: "/etc/ssl/customer-root.pem"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert http.use_ssl?
+  end
+
+  def test_http_uri_does_not_enable_ssl
+    adapter = Corvid::Adapters::FhirAdapter.new(base_url: "http://internal.example.com/r4")
+    http = adapter.send(:build_http, URI.parse("http://internal.example.com/r4/Patient/1"))
+
+    refute http.use_ssl?
+  end
+end

--- a/test/corvid/adapters/fhir_adapter_network_test.rb
+++ b/test/corvid/adapters/fhir_adapter_network_test.rb
@@ -74,6 +74,32 @@ class Corvid::Adapters::FhirAdapterNetworkTest < Minitest::Test
     assert_equal "proxypass", http.proxy_pass
   end
 
+  def test_proxy_uri_without_explicit_port_uses_uri_default
+    adapter = Corvid::Adapters::FhirAdapter.new(
+      base_url: BASE,
+      proxy_uri: "http://proxy.example.com"
+    )
+    http = adapter.send(:build_http, TARGET)
+
+    assert http.proxy?
+    assert_equal "proxy.example.com", http.proxy_address
+    # URI.parse("http://proxy.example.com").port => 80
+    assert_equal 80, http.proxy_port
+  end
+
+  def test_https_proxy_uri_is_rejected_loudly
+    # Net::HTTP::Proxy does not perform TLS to the proxy itself; an
+    # https:// proxy_uri would silently be treated as HTTP-on-443 and
+    # fail against a real TLS-wrapped HTTPS proxy. Reject up front.
+    err = assert_raises(ArgumentError) do
+      Corvid::Adapters::FhirAdapter.new(
+        base_url: BASE,
+        proxy_uri: "https://proxy.example.com:3128"
+      )
+    end
+    assert_match(/proxy_uri.*http:/i, err.message)
+  end
+
   # --- private CA bundle ------------------------------------------------------
 
   def test_ca_file_keyword_pins_a_private_ca_bundle


### PR DESCRIPTION
## Summary
- \`FhirAdapter.new\` accepts five new keywords: \`open_timeout:\`, \`read_timeout:\`, \`proxy_uri:\`, \`ca_file:\`, \`ca_path:\`. All default to current values; no caller breaks.
- Refactors \`execute_http\` to delegate to a \`build_http(uri)\` helper so the constructor's network configuration can be unit-tested without making real HTTP calls.
- Adds \`test/corvid/adapters/fhir_adapter_network_test.rb\` with 10 tests covering each keyword (default preservation, propagation to Net::HTTP, proxy with credentials, CA file / path, TLS still on for https URIs, off for http).

## Why
Track 0 of the on-premises plan. Mode 2 deployments (SaaS reaches inbound into customer VPN / private CA) need configurable timeouts (VPN latency), HTTP proxy support (SaaS-side egress proxies), and a private CA bundle pointer (customer-internal CAs). All three were hardcoded; today the workaround is OS-level config which forces operators to maintain non-portable host state.

## Test plan
- [x] \`bundle exec rake test\` — 968 runs, 2180 assertions, 0 failures, 0 errors
- [x] 10-test \`fhir_adapter_network_test.rb\` covers each keyword
- [x] \`bundle exec rubocop\` — clean

Closes #389
Part of the on-prem roadmap (see #388 ADR pending)